### PR TITLE
Fixed like, comment and follow references

### DIFF
--- a/instapy/comment_util.py
+++ b/instapy/comment_util.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Module which handles the commenting features"""
 from random import choice
 from time import sleep

--- a/instapy/like_util.py
+++ b/instapy/like_util.py
@@ -48,7 +48,7 @@ def check_link(browser, link, dont_like, ignore_if_contains, username):
 
   sleep(2)
 
-  user_div = browser.find_element_by_class_name('_nk46a')
+  user_div = browser.find_element_by_xpath("//article/div[2]/div[1]/ul[1]/li[1]")
   user_name = user_div.find_element_by_tag_name('a').text
   image_text = user_div.find_element_by_tag_name('span').text
 
@@ -68,10 +68,7 @@ def check_link(browser, link, dont_like, ignore_if_contains, username):
 
 def like_image(browser):
   """Likes the browser opened image"""
-  a_elems = browser.find_elements_by_xpath('//a[@role = "button"]')
-
-  #handle videos
-  link_elem = a_elems[0] if len(a_elems) < 2 else a_elems[len(a_elems) - 1]
+  link_elem = browser.find_element_by_xpath('//article/div[2]/section[1]/a[1]/span[1]')
 
   span_elem_text = link_elem.text
 
@@ -90,7 +87,7 @@ def get_tags(browser, url):
   browser.get(url)
   sleep(1)
 
-  user_div = browser.find_element_by_class_name('_nk46a')
+  user_div = browser.find_element_by_xpath("//article/div[2]/div[1]/ul[1]/li[1]")
   image_text = user_div.find_element_by_tag_name('span').text
 
   tags = findall(r'#\w*', image_text)

--- a/instapy/unfollow_util.py
+++ b/instapy/unfollow_util.py
@@ -33,7 +33,7 @@ def unfollow(browser, username, amount, dont_include):
 
 def follow_user(browser, user_name, follow_restrict):
   """Follows the user of the currently opened image"""
-  follow_button = browser.find_elements_by_tag_name('button')[0]
+  follow_button = browser.find_element_by_xpath("//article/header/span/button")
   sleep(2)
 
   if follow_button.text == 'Follow':


### PR DESCRIPTION
Instagram changes the class of elements for some users/locations.

I’ve changed the like, follow and comment references for XPATH, instead
of Class.

Also added coding header on comment_util for avoiding errors when user
comment contains special characters/accents.