### PR TITLE
Make like_util work independent of 'use_new_styles' 

### DIFF
--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -28,6 +28,9 @@ class InstaPy:
     #self.display.start()
     chrome_options = Options()
     chrome_options.add_argument('--dns-prefetch-disable')
+    chrome_options.add_argument('--no-sandbox')
+    chrome_options.add_argument('--lang=en-US')
+    chrome_options.add_experimental_option('prefs', {'intl.accept_languages': 'en-US'})
     self.browser = webdriver.Chrome('./assets/chromedriver', chrome_options=chrome_options)
     self.browser.implicitly_wait(25)
 

--- a/instapy/like_util.py
+++ b/instapy/like_util.py
@@ -48,9 +48,8 @@ def check_link(browser, link, dont_like, ignore_if_contains, username):
 
   sleep(2)
 
-  user_div = browser.find_element_by_xpath("//article/div[2]/div[1]/ul[1]/li[1]")
-  user_name = user_div.find_element_by_tag_name('a').text
-  image_text = user_div.find_element_by_tag_name('span').text
+  user_name = browser.execute_script("return window._sharedData.entry_data.PostPage[0].media.owner.username")
+  image_text = browser.execute_script("return window._sharedData.entry_data.PostPage[0].media.caption")
 
   print('Image from: ' + user_name)
   print('Link: ' + link)
@@ -68,8 +67,8 @@ def check_link(browser, link, dont_like, ignore_if_contains, username):
 
 def like_image(browser):
   """Likes the browser opened image"""
-  like_elem = browser.find_elements_by_xpath("//span[contains(@class, 'coreSpriteLikeHeartOpen')]")
-  liked_elem = browser.find_elements_by_xpath("//span[contains(@class, 'coreSpriteLikeHeartFull')]")
+  like_elem = browser.find_elements_by_xpath("//a[@role = 'button']/span[text()='Like']")
+  liked_elem = browser.find_elements_by_xpath("//a[@role = 'button']/span[text()='Unlike']")
 
   if len(like_elem) == 1:
     like_elem[0].click()
@@ -88,8 +87,7 @@ def get_tags(browser, url):
   browser.get(url)
   sleep(1)
 
-  user_div = browser.find_element_by_xpath("//article/div[2]/div[1]/ul[1]/li[1]")
-  image_text = user_div.find_element_by_tag_name('span').text
+  image_text = browser.execute_script("return window._sharedData.entry_data.PostPage[0].media.caption")
 
   tags = findall(r'#\w*', image_text)
   return tags


### PR DESCRIPTION
With the #33 I realized that there’s a JS variable that contains all
data that we need and that the UI of Instagram Web differs from users
(use_new_styles flag).

Changed the XPATH/DOM references for JS functions to retrieve the data,
independent of ‘use_new_styles’.

Also made a change on InstaPy.py that forces the Chrome to run with the
“en-US” location to avoid the Locale/Language problem with the like
button and the comment placeholder.