### PR TITLE
Fix like when the "Get the App" bar is visible

### DIFF
--- a/instapy/like_util.py
+++ b/instapy/like_util.py
@@ -82,7 +82,7 @@ def like_image(browser):
   liked_elem = browser.find_elements_by_xpath("//a[@role = 'button']/span[text()='Unlike']")
 
   if len(like_elem) == 1:
-    like_elem[0].click()
+    browser.execute_script("document.getElementsByClassName('" + like_elem[0].get_attribute("class") + "')[0].click()")
     print('--> Image Liked!')
     sleep(2)
     return True


### PR DESCRIPTION
Instead of calling Selenium method Click, get the Class of the Like
Button and do a Click() with Javascript.

If there’s an element above the Like Button, Selenium doesn’t hit it
and throw an error, JS don’t.