### PR TITLE
Only get number of followers if actually needs to.

### DIFF
--- a/instapy/like_util.py
+++ b/instapy/like_util.py
@@ -65,24 +65,24 @@ def check_link(browser, link, dont_like, ignore_if_contains, username, like_by_f
   if image_text is None:
     image_text = "No description"
 
-  """Find the number of followes the user has"""
-  userlink = 'https://www.instagram.com/' + user_name
-  browser.get(userlink)
-  sleep(1)
-  num_followers = browser.execute_script("return window._sharedData.entry_data.ProfilePage[0].user.followed_by.count")
-  browser.get(link)
-  sleep(1)
-
-
   print('Image from: ' + user_name)
   print('Link: ' + link)
   print('Description: ' + image_text)
-  print('Number of Followers: ', num_followers)
 
-  if like_by_followers_upper_limit and num_followers > like_by_followers_upper_limit:
-    return True, user_name, 'Number of followers exceeds limit'
-  if like_by_followers_lower_limit and num_followers < like_by_followers_lower_limit:
-    return True, user_name, 'Number of followers does not reach limit'
+  """Find the number of followes the user has"""
+  if like_by_followers_upper_limit or like_by_followers_lower_limit:
+    userlink = 'https://www.instagram.com/' + user_name
+    browser.get(userlink)
+    sleep(1)
+    num_followers = browser.execute_script("return window._sharedData.entry_data.ProfilePage[0].user.followed_by.count")
+    browser.get(link)
+    sleep(1)
+    print('Number of Followers: ' + num_followers)
+
+    if like_by_followers_upper_limit and num_followers > like_by_followers_upper_limit:
+      return True, user_name, 'Number of followers exceeds limit'
+    if like_by_followers_lower_limit and num_followers < like_by_followers_lower_limit:
+      return True, user_name, 'Number of followers does not reach minimum'
 
   if any((word in image_text for word in ignore_if_contains)):
       return False, user_name, 'None'


### PR DESCRIPTION
Avoid going to the image poster profile page and back to the image if we are not filtering the likes by number of followers.

This is not about the logged in user (the one running the script). This is about the owner of the picture being liked.