### PR TITLE
comment_util fixes

### DIFF
--- a/instapy/comment_util.py
+++ b/instapy/comment_util.py
@@ -16,20 +16,28 @@ def comment_image(browser, comments):
   rand_comment = emoji.emojize(rand_comment, use_aliases=True)
 
 
-  try:
-    #Explicitly will wait up to 10 seconds to find the element but may return sooner
-    comment_input = WebDriverWait(browser,10).until(EC.presence_of_element_located((By.XPATH,'//input[@placeholder = "Add a comment…"]')))
 
-    browser.execute_script("arguments[0].value = '" + rand_comment + " ';", comment_input);
+  comment_input = browser.find_elements_by_xpath('//textarea[@placeholder = "Add a comment…"]')
+  if len(comment_input) > 0:
+    browser.execute_script("arguments[0].value = '" + rand_comment + " ';", comment_input[0]);
     #An extra space is added here and then deleted. This forces the input box to update the reactJS core
-    comment_input.send_keys("\b")
-    comment_input.submit()
-
+    comment_input[0].send_keys("\b")
+    comment_input[0].submit()
+  else:
+    comment_input = browser.find_elements_by_xpath('//input[@placeholder = "Add a comment…"]')
+    if len(comment_input) > 0:
+      browser.execute_script("arguments[0].value = '" + rand_comment + " ';", comment_input[0]);
+      #An extra space is added here and then deleted. This forces the input box to update the reactJS core
+      comment_input[0].send_keys("\b")
+      comment_input[0].submit()
+    else:
+      print(u'--> Warning: Comment Action Likely Failed: Comment Element not found')
     # print(u'--> Commented: {}'.format(rand_comment))
-    print("--> Commented: " + rand_comment.encode('utf-8'))
-    sleep(2)
-  except TimeoutException:
-    print("--> Warning: Comment box could not be found within an acceptable ammount of time, skipping comment")
+  #print("--> Commented: " + rand_comment.encode('utf-8'))
+  print("--> Commented: {}".format(rand_comment.encode('utf-8')))
+  sleep(2)
+
+
 
 
   return 1

--- a/instapy/comment_util.py
+++ b/instapy/comment_util.py
@@ -18,26 +18,20 @@ def comment_image(browser, comments):
 
 
   comment_input = browser.find_elements_by_xpath('//textarea[@placeholder = "Add a comment…"]')
+  if len(comment_input) < 0:
+    comment_input = browser.find_elements_by_xpath('//input[@placeholder = "Add a comment…"]')
+
   if len(comment_input) > 0:
     browser.execute_script("arguments[0].value = '" + rand_comment + " ';", comment_input[0]);
     #An extra space is added here and then deleted. This forces the input box to update the reactJS core
     comment_input[0].send_keys("\b")
     comment_input[0].submit()
   else:
-    comment_input = browser.find_elements_by_xpath('//input[@placeholder = "Add a comment…"]')
-    if len(comment_input) > 0:
-      browser.execute_script("arguments[0].value = '" + rand_comment + " ';", comment_input[0]);
-      #An extra space is added here and then deleted. This forces the input box to update the reactJS core
-      comment_input[0].send_keys("\b")
-      comment_input[0].submit()
-    else:
       print(u'--> Warning: Comment Action Likely Failed: Comment Element not found')
     # print(u'--> Commented: {}'.format(rand_comment))
   #print("--> Commented: " + rand_comment.encode('utf-8'))
   print("--> Commented: {}".format(rand_comment.encode('utf-8')))
   sleep(2)
-
-
 
 
   return 1

--- a/instapy/comment_util.py
+++ b/instapy/comment_util.py
@@ -18,7 +18,7 @@ def comment_image(browser, comments):
 
 
   comment_input = browser.find_elements_by_xpath('//textarea[@placeholder = "Add a comment…"]')
-  if len(comment_input) < 0:
+  if len(comment_input) <= 0:
     comment_input = browser.find_elements_by_xpath('//input[@placeholder = "Add a comment…"]')
 
   if len(comment_input) > 0:
@@ -27,7 +27,7 @@ def comment_image(browser, comments):
     comment_input[0].send_keys("\b")
     comment_input[0].submit()
   else:
-      print(u'--> Warning: Comment Action Likely Failed: Comment Element not found')
+    print(u'--> Warning: Comment Action Likely Failed: Comment Element not found')
     # print(u'--> Commented: {}'.format(rand_comment))
   #print("--> Commented: " + rand_comment.encode('utf-8'))
   print("--> Commented: {}".format(rand_comment.encode('utf-8')))

--- a/instapy/comment_util.py
+++ b/instapy/comment_util.py
@@ -1,6 +1,10 @@
 # -*- coding: utf-8 -*-
 """Module which handles the commenting features"""
 from random import choice
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
 
 from .time_util import sleep
 import emoji
@@ -11,15 +15,21 @@ def comment_image(browser, comments):
   rand_comment = emoji.demojize(rand_comment)
   rand_comment = emoji.emojize(rand_comment, use_aliases=True)
 
-  comment_input = browser.find_elements_by_xpath\
-    ('//input[@placeholder = "Add a comment…"]')
+  
+  try:
+    #Explicitly will wait up to 10 seconds to find the element but may return sooner
+    comment_input = WebDriverWait(browser,10).until(EC.presence_of_element_located((By.XPATH,'//input[@placeholder = "Add a comment…"]')))
 
-  browser.execute_script("arguments[0].value = '" + rand_comment + " ';", comment_input[0]);
-  #An extra space is added here and then deleted. This forces the input box to update the reactJS core
-  comment_input[0].send_keys("\b")
-  comment_input[0].submit()
+    browser.execute_script("arguments[0].value = '" + rand_comment + " ';", comment_input);
+    #An extra space is added here and then deleted. This forces the input box to update the reactJS core
+    comment_input.send_keys("\b")
+    comment_input.submit()
 
-  # print(u'--> Commented: {}'.format(rand_comment))
-  print("--> Commented: " + rand_comment.encode('utf-8'))
-  sleep(2)
+    # print(u'--> Commented: {}'.format(rand_comment))
+    print("--> Commented: " + rand_comment.encode('utf-8'))
+    sleep(2)
+  except TimeoutError:
+    print("--> Warning: Comment box could not be found within an acceptable ammount of time, skipping comment")
+
+
   return 1

--- a/instapy/comment_util.py
+++ b/instapy/comment_util.py
@@ -15,7 +15,7 @@ def comment_image(browser, comments):
   rand_comment = emoji.demojize(rand_comment)
   rand_comment = emoji.emojize(rand_comment, use_aliases=True)
 
-  
+
   try:
     #Explicitly will wait up to 10 seconds to find the element but may return sooner
     comment_input = WebDriverWait(browser,10).until(EC.presence_of_element_located((By.XPATH,'//input[@placeholder = "Add a comment…"]')))
@@ -28,7 +28,7 @@ def comment_image(browser, comments):
     # print(u'--> Commented: {}'.format(rand_comment))
     print("--> Commented: " + rand_comment.encode('utf-8'))
     sleep(2)
-  except TimeoutError:
+  except TimeoutException:
     print("--> Warning: Comment box could not be found within an acceptable ammount of time, skipping comment")
 
 


### PR DESCRIPTION
Added an explicit wait on the comment_input element. If the element isn't found within 10 seconds then warn the user and continue without commenting. 

This may return sooner. It's just capped at 10 seconds to find the element. Hopefully this addresses some of the issues we've been having.