### PR TITLE
Fixed an encoding issue when writing log

### DIFF
--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -124,7 +124,7 @@ class InstaPy:
                 if followers is not None:
                     self.logger.info("  {} followers".format(followers))
                 self.logger.info(u'Link: {}'.format(link))
-                self.logger.info(u'Description: {}'.format(image_text))
+                self.logger.info(u'Description: {}'.format(image_text.encode('utf-8')))
 
                 # If image isn't good, go to the next one
                 if not good:


### PR DESCRIPTION
When client encoding not support some unicode characters, raises the error.
sample error:
UnicodeEncodeError: 'gbk' codec can't encode character '\U0001f6b2' in position
251: illegal multibyte sequence