### PR TITLE
fix unfollow errors

### DIFF
--- a/instapy/unfollow_util.py
+++ b/instapy/unfollow_util.py
@@ -49,7 +49,7 @@ def unfollow(browser, username, amount, dont_include, onlyInstapyFollowed, autom
 
     # find dialog box
 
-    dialog = browser.find_element_by_xpath('/html/body/div[3]/div/div[2]/div/div[2]')
+    dialog = browser.find_element_by_xpath('/html/body/div[4]/div/div[2]/div/div[2]/div/div[2]')
 
     # scroll down the page
     scroll_bottom(browser, dialog, allfollowing)

--- a/instapy/util.py
+++ b/instapy/util.py
@@ -21,7 +21,7 @@ def delete_line_from_file(filepath, lineToDelete):
 
 def scroll_bottom(browser, element, range_int):
     # put a limit to the scrolling
-    if range_int > 50: range_int = 1
+    if range_int > 50: range_int = 50
 
     for i in range(int(range_int / 2)):
         browser.execute_script("arguments[0].scrollTop = arguments[0].scrollHeight", element)


### PR DESCRIPTION
This pull request fixes two problems with the unfollow feature

1. the path of the dialog box changes
2. the script did not unfollow if the first users were not in the pool because it didn't scroll

This closes #456 and closes #453