### PR TITLE
Like different pictures of a user's profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ session.like_by_tags(['#cat'], amount=15, media='Video')
 session.like_from_image(url='www.instagram.com/image', amount=15, media='Video')
 
 #Likes 10 random pictures of user's profiles
-session.like_by_users(['natgeo', 'geo'], amount=10, random=True)
+session.like_by_user(['natgeo', 'geo'], amount=10, random=True)
 
 session.end()
 ```

--- a/README.md
+++ b/README.md
@@ -108,6 +108,9 @@ session.like_from_image(url='www.instagram.com/image', amount=50, media='Photo')
 session.like_by_tags(['#cat'], amount=15, media='Video')
 session.like_from_image(url='www.instagram.com/image', amount=15, media='Video')
 
+#Likes 10 random pictures of user's profiles
+session.like_by_users(['natgeo', 'geo'], amount=10, random=True)
+
 session.end()
 ```
 
@@ -156,8 +159,18 @@ session.follow_by_list(accs, times=1)
 # The usernames can be either a list or a string
 # The amount is for each account, in this case 30 users will be followed
 # If random is false it will pick in a top-down fashion
- 
+
 session.follow_user_followers(['friend1', 'friend2', 'friend3'], amount=10, random=False)
+```
+
+
+```python
+# For every user of the 20 randomly selected, move to their profile
+# and randomly choose 10 pictures to be liked.
+# Take into account the other set options like the comment rate
+# and the filtering for inappropriate words or users
+session.set_user_interact(amount=10, random=True)
+session.follow_user_followers(['friend1', 'friend2', 'friend3'], amount=20, random=False, interact=True)
 ```
 
 ### Follow users that someone else is following
@@ -167,8 +180,18 @@ session.follow_user_followers(['friend1', 'friend2', 'friend3'], amount=10, rand
 # The usernames can be either a list or a string
 # The amount is for each account, in this case 30 users will be followed
 # If random is false it will pick in a top-down fashion
- 
+
 session.follow_user_following(['friend1', 'friend2', 'friend3'], amount=10, random=False)
+```
+
+
+```python
+# For every user of the 20 randomly selected, move to their profile
+# and randomly choose 10 pictures to be liked.
+# Take into account the other set options like the comment rate
+# and the filtering for inappropriate words or users
+session.set_user_interact(amount=10, random=True)
+session.follow_user_following(['friend1', 'friend2', 'friend3'], amount=20, random=False, interact=True)
 ```
 
 ### Unfollowing
@@ -406,7 +429,7 @@ docker-compose up -d --build
 
 That's all! At this step, you are already successfully running your personal bot!
 
-### 3. See what your bot can do right now 
+### 3. See what your bot can do right now
 
 Run your VNC viewer, and type address and port `localhost:5900`. The password is `secret`.
 
@@ -431,7 +454,7 @@ Use it to help us with development and test instapy! `docker-dev.yml` file.
 docker-compose -f docker-dev.yml up -d
 ```
 
-After striking this command, you can access your bot by VNC on the adress  `localhost:5901`, the password is `secret`. 
+After striking this command, you can access your bot by VNC on the adress  `localhost:5901`, the password is `secret`.
 
 But there is more! There is a fully accessible bash console with all code mounted at the path `/code`. When you hack some files they are dynamically updated inside your container.
 

--- a/examples/example.py
+++ b/examples/example.py
@@ -71,9 +71,27 @@ session.like_by_tags(['#test'], amount=10, media='Video')
 # The amount is for each account, in this case 30 users will be followed
 # If random is false it will pick in a top-down fashion
 session.follow_user_followers(['friend1', 'friend2', 'friend3'], amount=10, random=False)
+
+# For every user of the 20 randomly selected, move to their profile
+# and randomly choose 10 pictures to be liked.
+# Take into account the other set options like the comment rate
+# and the filtering for inappropriate words or users
+session.set_user_interact(amount=10, random=True)
+session.follow_user_followers(['friend1', 'friend2', 'friend3'], amount=20, random=False, interact=True)
+
+
+
 # follows the people that a given user is following
 # Same rules as the function above
 session.follow_user_following('friend2', amount=10, random=True)
+
+# For every user of the 20 randomly selected, move to their profile
+# and randomly choose 10 pictures to be liked.
+# Take into account the other set options like the comment rate
+# and the filtering for inappropriate words or users
+session.set_user_interact(amount=10, random=True)
+session.follow_user_following(['friend1', 'friend2', 'friend3'], amount=20, random=False, interact=True)
+
 
 session.unfollow_users(
     amount=10)  # unfollows 10 of the accounts your following -> instagram will only unfollow 10 before you'll be 'blocked

--- a/examples/example.py
+++ b/examples/example.py
@@ -66,6 +66,9 @@ session.like_from_image(url='www.instagram.com/image', amount=100)
 # media filtering works here as well
 session.like_by_tags(['#test'], amount=10, media='Video')
 
+# Likes 10 random posts from friend1
+session.like_by_user(["friend1"], amount=10, random=True)
+
 # follows the followers of a given user
 # The usernames can be either a list or a string
 # The amount is for each account, in this case 30 users will be followed

--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -36,7 +36,7 @@ from .like_util import get_posts_by_user
 class InstaPy:
     """Class to be instantiated to use the script"""
 
-    def like_by_user(self, user_names, amount=10, is_random=False, media=None):
+    def like_by_user(self, user_names, amount=10, random = False, media=None):
         if self.aborting:
             return self
         liked_img = 0
@@ -44,6 +44,8 @@ class InstaPy:
         inap_img = 0
         commented = 0
         followed = 0
+
+        is_random=False
 
         user_names = user_names or []
 
@@ -53,8 +55,10 @@ class InstaPy:
             self.logFile.write('User_name [{}/[]]'.format(index + 1, len(user_names)))
             self.logFile.write('--> {}\n'.format(user_name.encode('utf-8')))
 
+            _amount = amount
+
             try:
-                raw_links = get_posts_by_user(self.browser, user_name, amount, is_random)
+                raw_links = get_posts_by_user(self.browser, user_name, _amount, random)
             except NoSuchElementException:
                 print('Too few images, aborting')
                 self.logFile.write('Too few images, aborting\n')
@@ -64,19 +68,29 @@ class InstaPy:
 
             picked_lnks = []
             if is_random:
-                samples = sample(range(0, len(raw_links)), amount)
+                samples = sample(range(0, len(raw_links)), _amount)
 
                 for x in samples:
                     picked_lnks.append(raw_links[x])
             else:
                 picked_lnks = raw_links
 
+            if _amount > len(picked_lnks):
+                _amount = len(picked_lnks)
 
             for i, link in enumerate(picked_lnks):
-                print('[{}/{}]'.format(i + 1, len(picked_lnks)))
-                self.logFile.write('[{}/{}]'.format(i + 1, len(picked_lnks)))
+                print('[{}/{}]'.format(i + 1, _amount))
+                self.logFile.write('[{}/{}]'.format(i + 1, _amount))
                 self.logFile.write(link)
-
+                if random:
+                    sh_pick = randint(0,10)
+                    if sh_pick < 6:
+                        print('--> Image not liked: Randomly Skipped.')
+                        _amount += 1
+                        continue
+                if i >= _amount:
+                    print('-->  Finished')
+                    break
                 try:
                     inappropriate, user_name, is_video, reason = \
                         check_link(self.browser, link, self.dont_like, self.ignore_if_contains, self.ignore_users,
@@ -185,6 +199,9 @@ class InstaPy:
         self.comments = ['Cool!', 'Nice!', 'Looks good!']
         self.photo_comments = []
         self.video_comments = []
+        self.user_interact = False
+        self.user_interact_amount = 10
+        self.user_interact_random = False
 
         self.followed = 0
         self.follow_restrict = load_follow_restriction()
@@ -211,6 +228,12 @@ class InstaPy:
 
         if selenium_local_session:
             self.set_selenium_local_session()
+
+    def set_user_interact(self, amount=10, random=True):
+        self.user_interact = True
+        self.user_interact_random = random
+        self.user_interact_amount = amount
+        return self
 
     def set_selenium_local_session(self):
         """Starts local session for a selenium server. Default case scenario."""
@@ -674,13 +697,17 @@ class InstaPy:
 
         return self
 
-    def follow_user_followers(self, usernames, amount=10, random=False):
+    def follow_user_followers(self, usernames, amount=10, random=False, interact=False):
         unfollowNumber = 0
         if not isinstance(usernames, list):
             usernames = [usernames]
         try:
             for user in usernames:
-                unfollowNumber += follow_given_user_followers(self.browser, user, amount, self.dont_include, self.username, self.follow_restrict, random)
+                flwdList = follow_given_user_followers(self.browser, user, amount, self.dont_include, self.username, self.follow_restrict, random)
+                if self.user_interact and interact:
+                    self.like_by_user(flwdList, self.user_interact_amount, self.user_interact_random)
+
+                unfollowNumber += len(flwdList)
             print("--> Total people followed : {} ".format(unfollowNumber))
 
         except (TypeError, RuntimeWarning) as err:
@@ -698,13 +725,19 @@ class InstaPy:
 
         return self
 
-    def follow_user_following(self, usernames, amount=10, random=False):
+    def follow_user_following(self, usernames, amount=10, random=False, interact=False):
         unfollowNumber = 0
         if not isinstance(usernames, list):
             usernames = [usernames]
+
+
         try:
             for user in usernames:
-                unfollowNumber += follow_given_user_following(self.browser, user, amount, self.dont_include, self.username, self.follow_restrict, random)
+                flwdList = follow_given_user_following(self.browser, user, amount, self.dont_include, self.username, self.follow_restrict, random)
+                if self.user_interact and interact:
+                    self.like_by_user(flwdList, self.user_interact_amount, self.user_interact_random)
+
+                unfollowNumber += len(flwdList)
             print("--> Total people followed : {} ".format(unfollowNumber))
 
         except (TypeError, RuntimeWarning) as err:

--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from os import environ
 
 from random import randint
+from random import sample
 from pyvirtualdisplay import Display
 from selenium import webdriver
 from selenium.common.exceptions import NoSuchElementException
@@ -29,10 +30,137 @@ from .unfollow_util import load_follow_restriction
 from .unfollow_util import dump_follow_restriction
 from .unfollow_util import set_automated_followed_pool
 from .feed_util import get_like_on_feed
+from .like_util import get_posts_by_user
 
 
 class InstaPy:
     """Class to be instantiated to use the script"""
+
+    def like_by_user(self, user_names, amount=10, is_random=False, media=None):
+        if self.aborting:
+            return self
+        liked_img = 0
+        already_liked = 0
+        inap_img = 0
+        commented = 0
+        followed = 0
+
+        user_names = user_names or []
+
+        for index, user_name in enumerate(user_names):
+            print('User_name [{}/{}]'.format(index + 1, len(user_names)))
+            print('--> {}'.format(user_name.encode('utf-8')))
+            self.logFile.write('User_name [{}/[]]'.format(index + 1, len(user_names)))
+            self.logFile.write('--> {}\n'.format(user_name.encode('utf-8')))
+
+            try:
+                raw_links = get_posts_by_user(self.browser, user_name, amount, is_random)
+            except NoSuchElementException:
+                print('Too few images, aborting')
+                self.logFile.write('Too few images, aborting\n')
+
+                self.aborting = True
+                return self
+
+            picked_lnks = []
+            if is_random:
+                samples = sample(range(0, len(raw_links)), amount)
+
+                for x in samples:
+                    picked_lnks.append(raw_links[x])
+            else:
+                picked_lnks = raw_links
+
+
+            for i, link in enumerate(picked_lnks):
+                print('[{}/{}]'.format(i + 1, len(picked_lnks)))
+                self.logFile.write('[{}/{}]'.format(i + 1, len(picked_lnks)))
+                self.logFile.write(link)
+
+                try:
+                    inappropriate, user_name, is_video, reason = \
+                        check_link(self.browser, link, self.dont_like, self.ignore_if_contains, self.ignore_users,
+                                   self.username, self.like_by_followers_upper_limit,
+                                   self.like_by_followers_lower_limit)
+
+                    if not inappropriate:
+                        liked = like_image(self.browser)
+
+                        if liked:
+                            liked_img += 1
+                            checked_img = True
+                            temp_comments = []
+                            commenting = randint(0, 100) <= self.comment_percentage
+                            following = randint(0, 100) <= self.follow_percentage
+
+                            if self.use_clarifai and (following or commenting):
+                                try:
+                                    checked_img, temp_comments = \
+                                        check_image(self.browser, self.clarifai_id,
+                                                    self.clarifai_secret,
+                                                    self.clarifai_img_tags,
+                                                    self.clarifai_full_match)
+                                except Exception as err:
+                                    print('Image check error: {}'.format(err))
+                                    self.logFile.write('Image check error: {}\n'.format(err))
+
+                            if self.do_comment and user_name not in self.dont_include \
+                                    and checked_img and commenting:
+                                if temp_comments:
+                                    # Use clarifai related comments only!
+                                    comments = temp_comments
+                                elif is_video:
+                                    comments = self.comments + self.video_comments
+                                else:
+                                    comments = self.comments + self.photo_comments
+                                commented += comment_image(self.browser, comments)
+                            else:
+                                print('--> Not commented')
+                                sleep(1)
+
+                            if self.do_follow and user_name not in self.dont_include \
+                                    and checked_img and following \
+                                    and self.follow_restrict.get(user_name, 0) < self.follow_times:
+                                followed += follow_user(self.browser, self.follow_restrict, self.username, user_name)
+                            else:
+                                print('--> Not following')
+                                sleep(1)
+                        else:
+                            already_liked += 1
+                            if is_random:
+
+                                repickedNum = -1
+                                while repickedNum == -1 or raw_links[repickedNum] not in picked_lnks:
+                                    repickedNum = randint(0, len(raw_links)-1)
+                                    print("PICKED - > " + str(repickedNum) + " -__- " + str(len(raw_links)))
+                                picked_lnks.append(raw_links[repickedNum])
+                                print("--------------> REPICKING -> " + str(raw_links[repickedNum]))
+                    else:
+                        print('--> Image not liked: {}'.format(reason))
+                        inap_img += 1
+                except NoSuchElementException as err:
+                    print('Invalid Page: {}'.format(err))
+                    self.logFile.write('Invalid Page: {}\n'.format(err))
+
+                print('')
+                self.logFile.write('\n')
+
+        print('Liked: {}'.format(liked_img))
+        print('Already Liked: {}'.format(already_liked))
+        print('Inappropriate: {}'.format(inap_img))
+        print('Commented: {}'.format(commented))
+        print('Followed: {}'.format(followed))
+
+        self.logFile.write('Liked: {}\n'.format(liked_img))
+        self.logFile.write('Already Liked: {}\n'.format(already_liked))
+        self.logFile.write('Inappropriate: {}\n'.format(inap_img))
+        self.logFile.write('Commented: {}\n'.format(commented))
+        self.logFile.write('Followed: {}\n'.format(followed))
+
+        self.followed += followed
+
+        return self
+
 
     def __init__(self, username=None, password=None, nogui=False, selenium_local_session=True, use_firefox=False, page_delay=25):
         if nogui:

--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -36,146 +36,6 @@ from .like_util import get_posts_by_user
 class InstaPy:
     """Class to be instantiated to use the script"""
 
-    def like_by_user(self, user_names, amount=10, random = False, media=None):
-        if self.aborting:
-            return self
-        liked_img = 0
-        already_liked = 0
-        inap_img = 0
-        commented = 0
-        followed = 0
-
-        is_random=False
-
-        user_names = user_names or []
-
-        for index, user_name in enumerate(user_names):
-            print('User_name [{}/{}]'.format(index + 1, len(user_names)))
-            print('--> {}'.format(user_name.encode('utf-8')))
-            self.logFile.write('User_name [{}/[]]'.format(index + 1, len(user_names)))
-            self.logFile.write('--> {}\n'.format(user_name.encode('utf-8')))
-
-            _amount = amount
-
-            try:
-                raw_links = get_posts_by_user(self.browser, user_name, _amount, random)
-            except NoSuchElementException:
-                print('Too few images, aborting')
-                self.logFile.write('Too few images, aborting\n')
-
-                self.aborting = True
-                return self
-
-            picked_lnks = []
-            if is_random:
-                samples = sample(range(0, len(raw_links)), _amount)
-
-                for x in samples:
-                    picked_lnks.append(raw_links[x])
-            else:
-                picked_lnks = raw_links
-
-            if _amount > len(picked_lnks):
-                _amount = len(picked_lnks)
-
-            for i, link in enumerate(picked_lnks):
-                print('[{}/{}]'.format(i + 1, _amount))
-                self.logFile.write('[{}/{}]'.format(i + 1, _amount))
-                self.logFile.write(link)
-                if random:
-                    sh_pick = randint(0,10)
-                    if sh_pick < 6:
-                        print('--> Image not liked: Randomly Skipped.')
-                        _amount += 1
-                        continue
-                if i >= _amount:
-                    print('-->  Finished')
-                    break
-                try:
-                    inappropriate, user_name, is_video, reason = \
-                        check_link(self.browser, link, self.dont_like, self.ignore_if_contains, self.ignore_users,
-                                   self.username, self.like_by_followers_upper_limit,
-                                   self.like_by_followers_lower_limit)
-
-                    if not inappropriate:
-                        liked = like_image(self.browser)
-
-                        if liked:
-                            liked_img += 1
-                            checked_img = True
-                            temp_comments = []
-                            commenting = randint(0, 100) <= self.comment_percentage
-                            following = randint(0, 100) <= self.follow_percentage
-
-                            if self.use_clarifai and (following or commenting):
-                                try:
-                                    checked_img, temp_comments = \
-                                        check_image(self.browser, self.clarifai_id,
-                                                    self.clarifai_secret,
-                                                    self.clarifai_img_tags,
-                                                    self.clarifai_full_match)
-                                except Exception as err:
-                                    print('Image check error: {}'.format(err))
-                                    self.logFile.write('Image check error: {}\n'.format(err))
-
-                            if self.do_comment and user_name not in self.dont_include \
-                                    and checked_img and commenting:
-                                if temp_comments:
-                                    # Use clarifai related comments only!
-                                    comments = temp_comments
-                                elif is_video:
-                                    comments = self.comments + self.video_comments
-                                else:
-                                    comments = self.comments + self.photo_comments
-                                commented += comment_image(self.browser, comments)
-                            else:
-                                print('--> Not commented')
-                                sleep(1)
-
-                            if self.do_follow and user_name not in self.dont_include \
-                                    and checked_img and following \
-                                    and self.follow_restrict.get(user_name, 0) < self.follow_times:
-                                followed += follow_user(self.browser, self.follow_restrict, self.username, user_name)
-                            else:
-                                print('--> Not following')
-                                sleep(1)
-                        else:
-                            already_liked += 1
-                            if is_random:
-
-                                repickedNum = -1
-                                while repickedNum == -1 or raw_links[repickedNum] not in picked_lnks:
-                                    repickedNum = randint(0, len(raw_links)-1)
-                                    print("PICKED - > " + str(repickedNum) + " -__- " + str(len(raw_links)))
-                                picked_lnks.append(raw_links[repickedNum])
-                                print("--------------> REPICKING -> " + str(raw_links[repickedNum]))
-                    else:
-                        print('--> Image not liked: {}'.format(reason))
-                        inap_img += 1
-                except NoSuchElementException as err:
-                    print('Invalid Page: {}'.format(err))
-                    self.logFile.write('Invalid Page: {}\n'.format(err))
-
-                print('')
-                self.logFile.write('\n')
-
-        print('Liked: {}'.format(liked_img))
-        print('Already Liked: {}'.format(already_liked))
-        print('Inappropriate: {}'.format(inap_img))
-        print('Commented: {}'.format(commented))
-        print('Followed: {}'.format(followed))
-
-        self.logFile.write('Liked: {}\n'.format(liked_img))
-        self.logFile.write('Already Liked: {}\n'.format(already_liked))
-        self.logFile.write('Inappropriate: {}\n'.format(inap_img))
-        self.logFile.write('Commented: {}\n'.format(commented))
-        self.logFile.write('Followed: {}\n'.format(followed))
-
-        self.followed += followed
-
-        return self
-
-
     def __init__(self, username=None, password=None, nogui=False, selenium_local_session=True, use_firefox=False, page_delay=25):
         if nogui:
             self.display = Display(visible=0, size=(800, 600))
@@ -534,6 +394,127 @@ class InstaPy:
                                     and self.follow_restrict.get(user_name, 0) < self.follow_times:
                                 followed += follow_user(self.browser, self.follow_restrict, self.username, user_name)
 
+                            else:
+                                print('--> Not following')
+                                sleep(1)
+                        else:
+                            already_liked += 1
+                    else:
+                        print('--> Image not liked: {}'.format(reason))
+                        inap_img += 1
+                except NoSuchElementException as err:
+                    print('Invalid Page: {}'.format(err))
+                    self.logFile.write('Invalid Page: {}\n'.format(err))
+
+                print('')
+                self.logFile.write('\n')
+
+        print('Liked: {}'.format(liked_img))
+        print('Already Liked: {}'.format(already_liked))
+        print('Inappropriate: {}'.format(inap_img))
+        print('Commented: {}'.format(commented))
+        print('Followed: {}'.format(followed))
+
+        self.logFile.write('Liked: {}\n'.format(liked_img))
+        self.logFile.write('Already Liked: {}\n'.format(already_liked))
+        self.logFile.write('Inappropriate: {}\n'.format(inap_img))
+        self.logFile.write('Commented: {}\n'.format(commented))
+        self.logFile.write('Followed: {}\n'.format(followed))
+
+        self.followed += followed
+
+        return self
+
+    def like_by_user(self, user_names, amount=10, random = False, media=None):
+        if self.aborting:
+            return self
+        liked_img = 0
+        already_liked = 0
+        inap_img = 0
+        commented = 0
+        followed = 0
+
+        user_names = user_names or []
+
+        for index, user_name in enumerate(user_names):
+            print('User_name [{}/{}]'.format(index + 1, len(user_names)))
+            print('--> {}'.format(user_name.encode('utf-8')))
+            self.logFile.write('User_name [{}/[]]'.format(index + 1, len(user_names)))
+            self.logFile.write('--> {}\n'.format(user_name.encode('utf-8')))
+
+            _amount = amount
+
+            try:
+                raw_links = get_posts_by_user(self.browser, user_name, _amount, random)
+            except NoSuchElementException:
+                print('Too few images, aborting')
+                self.logFile.write('Too few images, aborting\n')
+
+                self.aborting = True
+                return self
+            picked_lnks = raw_links
+
+            if _amount > len(picked_lnks):
+                _amount = len(picked_lnks)
+
+            for i, link in enumerate(picked_lnks):
+                print('[{}/{}]'.format(i + 1, _amount))
+                self.logFile.write('[{}/{}]'.format(i + 1, _amount))
+                self.logFile.write(link)
+                if random:
+                    sh_pick = randint(0,10)
+                    if sh_pick < 6:
+                        print('--> Image not liked: Randomly Skipped.')
+                        _amount += 1
+                        continue
+                if i >= _amount:
+                    print('-->  Finished')
+                    break
+                try:
+                    inappropriate, user_name, is_video, reason = \
+                        check_link(self.browser, link, self.dont_like, self.ignore_if_contains, self.ignore_users,
+                                   self.username, self.like_by_followers_upper_limit,
+                                   self.like_by_followers_lower_limit)
+
+                    if not inappropriate:
+                        liked = like_image(self.browser)
+
+                        if liked:
+                            liked_img += 1
+                            checked_img = True
+                            temp_comments = []
+                            commenting = randint(0, 100) <= self.comment_percentage
+                            following = randint(0, 100) <= self.follow_percentage
+
+                            if self.use_clarifai and (following or commenting):
+                                try:
+                                    checked_img, temp_comments = \
+                                        check_image(self.browser, self.clarifai_id,
+                                                    self.clarifai_secret,
+                                                    self.clarifai_img_tags,
+                                                    self.clarifai_full_match)
+                                except Exception as err:
+                                    print('Image check error: {}'.format(err))
+                                    self.logFile.write('Image check error: {}\n'.format(err))
+
+                            if self.do_comment and user_name not in self.dont_include \
+                                    and checked_img and commenting:
+                                if temp_comments:
+                                    # Use clarifai related comments only!
+                                    comments = temp_comments
+                                elif is_video:
+                                    comments = self.comments + self.video_comments
+                                else:
+                                    comments = self.comments + self.photo_comments
+                                commented += comment_image(self.browser, comments)
+                            else:
+                                print('--> Not commented')
+                                sleep(1)
+
+                            if self.do_follow and user_name not in self.dont_include \
+                                    and checked_img and following \
+                                    and self.follow_restrict.get(user_name, 0) < self.follow_times:
+                                followed += follow_user(self.browser, self.follow_restrict, self.username, user_name)
                             else:
                                 print('--> Not following')
                                 sleep(1)

--- a/instapy/like_util.py
+++ b/instapy/like_util.py
@@ -4,8 +4,48 @@ import re
 from math import ceil
 from re import findall
 from selenium.webdriver.common.keys import Keys
-
+from .util import formatNumber
 from .time_util import sleep
+import random
+
+def get_posts_by_user(browser, user_name, amount=10, random=False):
+    userlink = 'https://www.instagram.com/' + user_name
+    browser.get(userlink) #//*[@id="react-root"]/section/main/article/ul/li[1]/span/span
+    postCount = formatNumber(browser.find_element_by_xpath("//li[1]/span/span").text)
+
+    body_elem = browser.find_element_by_tag_name('body')
+
+
+    #//*[@id="react-root"]/section/main/article/div[2]/div[1]/div[1]/div[1]/a/div
+    #//*[@id="react-root"]/section/main/article/div[2]/div[1]/div[1]/div[1]/a/div/div[1]/img
+    #browser.find_elements_by_xpath("//div/div/div/a/div")
+
+    #posts = browser.find_elements_by_xpath("//div/div/div/a/div")
+
+
+    oldPosY = -1
+    posY = int(browser.execute_script("return window.scrollY;"))
+    while oldPosY != posY:
+        oldPosY = posY
+        loadMoreBtn = browser.find_elements_by_xpath("//a[text()='Load more']")
+        if len(loadMoreBtn) > 0:
+            print("---> Load more button found.")
+            loadMoreBtn[0].click()
+            sleep(1)
+        body_elem.send_keys(Keys.END)
+        sleep(1)
+        posY = int(browser.execute_script("return window.scrollY;"))
+
+
+
+
+    posts = browser.find_elements_by_xpath('//*[@id="react-root"]/section/main/article/div/div/div/div/a')
+    posts = [x.get_attribute('href') for x in posts]
+
+    #posts[x].get_attribute('href')
+    #print("POST COUNT: " + str(len(posts)))
+    return posts
+
 
 
 def get_links_for_location(browser, location, amount, media=None):
@@ -298,6 +338,7 @@ def like_image(browser):
     else:
         print('--> Invalid Like Element!')
         return False
+
 
 
 def get_tags(browser, url):

--- a/instapy/like_util.py
+++ b/instapy/like_util.py
@@ -10,18 +10,10 @@ import random
 
 def get_posts_by_user(browser, user_name, amount=10, random=False):
     userlink = 'https://www.instagram.com/' + user_name
-    browser.get(userlink) #//*[@id="react-root"]/section/main/article/ul/li[1]/span/span
+    browser.get(userlink)
     postCount = formatNumber(browser.find_element_by_xpath("//li[1]/span/span").text)
 
     body_elem = browser.find_element_by_tag_name('body')
-
-
-    #//*[@id="react-root"]/section/main/article/div[2]/div[1]/div[1]/div[1]/a/div
-    #//*[@id="react-root"]/section/main/article/div[2]/div[1]/div[1]/div[1]/a/div/div[1]/img
-    #browser.find_elements_by_xpath("//div/div/div/a/div")
-
-    #posts = browser.find_elements_by_xpath("//div/div/div/a/div")
-
 
     oldPosY = -1
     posY = int(browser.execute_script("return window.scrollY;"))
@@ -37,13 +29,9 @@ def get_posts_by_user(browser, user_name, amount=10, random=False):
         posY = int(browser.execute_script("return window.scrollY;"))
 
 
-
-
     posts = browser.find_elements_by_xpath('//*[@id="react-root"]/section/main/article/div/div/div/div/a')
     posts = [x.get_attribute('href') for x in posts]
 
-    #posts[x].get_attribute('href')
-    #print("POST COUNT: " + str(len(posts)))
     return posts
 
 

--- a/instapy/unfollow_util.py
+++ b/instapy/unfollow_util.py
@@ -176,7 +176,7 @@ def follow_through_dialog(browser, user_name, amount, dont_include, login, follo
     follow_buttons = dialog.find_elements_by_xpath("//div/div/span/button[text()='Follow']")
 
     person_list = []
-
+    followed_person_list = []
     for person in follow_buttons:
 
         if person and hasattr(person, 'text') and person.text:
@@ -211,6 +211,7 @@ def follow_through_dialog(browser, user_name, amount, dont_include, login, follo
             if person not in dont_include:
 
                 followNum += 1
+                followed_person_list.append(str(person))
                 button.click()
                 log_followed_pool(login, user_name)
                 follow_restrict[user_name] = follow_restrict.get(user_name, 0) + 1
@@ -237,7 +238,7 @@ def follow_through_dialog(browser, user_name, amount, dont_include, login, follo
     except BaseException as e:
         print("follow loop error \n", str(e))
 
-    return followNum
+    return followed_person_list
 
 def follow_given_user_followers(browser, user_name, amount, dont_include, login, follow_restrict, random):
     browser.get('https://www.instagram.com/' + user_name)


### PR DESCRIPTION
This pull request adds the features requested in #484.

**like_by_users(['natgeo', 'geo'], amount=10, random=True)**

- Moves to the user's profile page and like the given amount of photos
- The image picking can be either random or top-down.
- Includes the restrictions and settings set up before calling the method (including e.g. comment-ratio and like restrictions)
- Clarifai is being used
- Uses built-in follow_user and like_image
- Uses built-in log system

**set_user_interact(amount=10, random=True)**
- Set interaction parameters for `follow_user_follower(['natgeo', 'geo'], amount=20, random=True, interact=True)` and `follow_user_following(['natgeo', 'geo'], amount=20, random=True, interact=True)`
- In this case, for every user of the 20 randomly selected, move to their profile and randomly choose 10 pictures to be liked. 

**get_posts_by_user()**
- Moves to a user profile and returns the posts.
- Scrolls automatically 

**follow_user_followers**
- Now includes interact parameter, calls like_by_user

**follow_user_following**
- Now includes interact parameter, calls like_by_user

**There is a example given in the examples file
There is documentation added in the README**


