### PR TITLE
Update Dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,7 +4,6 @@
 /docker_conf/
 /assets/
 /setup.py
-/requirements.txt
 /LICENSE
 /.gitignore
 /docker-prod.yml


### PR DESCRIPTION
How could we build the project without the requirements?

```
Step 5/7 : COPY requirements.txt /config/
ERROR: Service 'web' failed to build: COPY failed: stat /var/lib/docker/tmp/docker-builder593609171/requirements.txt: no such file or directory
```