### PR TITLE
Solution to #503

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,7 +374,7 @@ InstaPy(username='test', password='test')\
 #if secret and proj_id are not set, it will get the environment Variables
 # 'CLARIFAI_API_KEY'
 
-session.set_use_clarifai(enabled=True, secret='xyz', proj_id='123')
+session.set_use_clarifai(enabled=True, api_key='xxx')
 ```
 ### Filtering inappropriate images
 

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ session.follow_by_list(accs, times=1)
 # The usernames can be either a list or a string
 # The amount is for each account, in this case 30 users will be followed
 # If random is false it will pick in a top-down fashion
- 
+
 session.follow_user_followers(['friend1', 'friend2', 'friend3'], amount=10, random=False)
 ```
 
@@ -171,7 +171,7 @@ session.follow_user_followers(['friend1', 'friend2', 'friend3'], amount=10, rand
 # The usernames can be either a list or a string
 # The amount is for each account, in this case 30 users will be followed
 # If random is false it will pick in a top-down fashion
- 
+
 session.follow_user_following(['friend1', 'friend2', 'friend3'], amount=10, random=False)
 ```
 
@@ -183,7 +183,7 @@ session.follow_user_following(['friend1', 'friend2', 'friend3'], amount=10, rand
 # Take into account the other set options like the comment rate
 # and the filtering for inappropriate words or users
 
-session.set_user_interact(amount=5, random=True, percentage=50, media='Photo') 
+session.set_user_interact(amount=5, random=True, percentage=50, media='Photo')
 session.follow_user_followers(['friend1', 'friend2', 'friend3'], amount=10, random=False, interact=True)
 ```
 
@@ -344,11 +344,10 @@ InstaPy(username='test', password='test', use_firefox=True, page_delay=25)\
 
 ###### Note: Head over to [https://developer.clarifai.com/signup/](https://developer.clarifai.com/signup/) and create a free account, once you’re logged in go to [https://developer.clarifai.com/account/applications/](https://developer.clarifai.com/account/applications/) and create a new application. You can find the client ID and Secret there. You get 5000 API-calls free/month.
 
-If you want the script to get your Clarifai_ID and Clarifai_Secret for your environment, you can do:
+If you want the script to get your CLARIFAI_API_KEY for your environment, you can do:
 
 ```
-export CLARIFAI_ID="<ProjectID>"
-export CLARIFAI_SECRET="<Project Secret>"
+export CLARIFAI_API_KEY="<API KEY>"
 ```
 ### Example with Imagecontent handling
 
@@ -373,7 +372,7 @@ InstaPy(username='test', password='test')\
 ```python
 #default enabled=False , enables the checking with the clarifai api (image tagging)
 #if secret and proj_id are not set, it will get the environment Variables
-# 'Clarifai_SECRET' and 'CLARIFAI_ID'
+# 'CLARIFAI_API_KEY'
 
 session.set_use_clarifai(enabled=True, secret='xyz', proj_id='123')
 ```
@@ -422,7 +421,7 @@ docker-compose up -d --build
 
 That's all! At this step, you are already successfully running your personal bot!
 
-### 3. See what your bot can do right now 
+### 3. See what your bot can do right now
 
 Run your VNC viewer, and type address and port `localhost:5900`. The password is `secret`.
 
@@ -447,7 +446,7 @@ Use it to help us with development and test instapy! `docker-dev.yml` file.
 docker-compose -f docker-dev.yml up -d
 ```
 
-After striking this command, you can access your bot by VNC on the adress  `localhost:5901`, the password is `secret`. 
+After striking this command, you can access your bot by VNC on the adress  `localhost:5901`, the password is `secret`.
 
 But there is more! There is a fully accessible bash console with all code mounted at the path `/code`. When you hack some files they are dynamically updated inside your container.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -315,7 +315,7 @@ InstaPy(username='test', password='test')\
 #if api_key is not set, it will get the environment Variables
 # 'CLARIFAI_API_KEY'
 
-session.set_use_clarifai(enabled=True, secret='xyz', proj_id='123')
+session.set_use_clarifai(enabled=True, api_key='xxx')
 ```
 ### Filtering inappropriate images
 
@@ -645,7 +645,7 @@ InstaPy(username='test', password='test')\
 #if secret and proj_id are not set, it will get the environment Variables
 # 'CLARIFAI_API_KEY'
 
-session.set_use_clarifai(enabled=True, secret='xyz', proj_id='123')
+session.set_use_clarifai(enabled=True, api_key='xxx')
 ```
 ##### Filtering inappropriate images
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -285,11 +285,10 @@ crontab -e
 
 ###### Note: Head over to [https://developer.clarifai.com/signup/](https://developer.clarifai.com/signup/) and create a free account, once you’re logged in go to [https://developer.clarifai.com/account/applications/](https://developer.clarifai.com/account/applications/) and create a new application. You can find the client ID and Secret there. You get 5000 API-calls free/month.
 
-If you want the script to get your Clarifai_ID and Clarifai_Secret for your environment, you can do:
+If you want the script to get your Clarifai_API_KEY from your environment, you can do:
 
 ```
-export CLARIFAI_ID="<ProjectID>"
-export CLARIFAI_SECRET="<Project Secret>"
+export CLARIFAI_API_KEY="<API Key>"
 ```
 ### Example with Imagecontent handling
 
@@ -313,8 +312,8 @@ InstaPy(username='test', password='test')\
 
 ```python
 #default enabled=False , enables the checking with the clarifai api (image tagging)
-#if secret and proj_id are not set, it will get the environment Variables
-# 'Clarifai_SECRET' and 'CLARIFAI_ID'
+#if api_key is not set, it will get the environment Variables
+# 'CLARIFAI_API_KEY'
 
 session.set_use_clarifai(enabled=True, secret='xyz', proj_id='123')
 ```
@@ -518,16 +517,16 @@ session.set_comments(['Great Video!'], media='Video')
 
 ##### Emoji Support  
 You can use Unicode characters (like Emoji) in your comments
-1. You have to convert your comment to Unicode. This can safely be done by adding an u in front of the opening apostrophe: 
+1. You have to convert your comment to Unicode. This can safely be done by adding an u in front of the opening apostrophe:
 
 ```session.set_comments([u'This post is 🔥',u'More emojis are always better 💯',u'I love your posts 😍😍😍']);```
 
 ```session.set_comments([u'Emoji text codes are also supported :100: :thumbsup: :thumbs_up: \u2764 💯💯']);```
 
-Emoji text codes are implemented using 2 different naming codes. A complete list of emojis codes can be found on the [Python Emoji Github](https://github.com/carpedm20/emoji/blob/master/emoji/unicode_codes.py), but you can use the alternate shorted naming scheme found for Emoji text codes [here](https://www.webpagefx.com/tools/emoji-cheat-sheet). Note: Every Emoji has not been tested. Please report any inconsistancies. 
+Emoji text codes are implemented using 2 different naming codes. A complete list of emojis codes can be found on the [Python Emoji Github](https://github.com/carpedm20/emoji/blob/master/emoji/unicode_codes.py), but you can use the alternate shorted naming scheme found for Emoji text codes [here](https://www.webpagefx.com/tools/emoji-cheat-sheet). Note: Every Emoji has not been tested. Please report any inconsistancies.
 
 
-> **Legacy Emoji Support** 
+> **Legacy Emoji Support**
 >
 > You can still use Unicode strings in your comments, but there are some limitations.
 > 1. You can use only Unicode characters with no more than 4 characters and you have to use the unicode code (e. g. ```\u1234```). You find a list of emoji with unicode codes on [Wikipedia](https://en.wikipedia.org/wiki/Emoji#Unicode_blocks), but there is also a list of working emoji in ```/assets```  
@@ -616,11 +615,10 @@ crontab -e
 
 ###### Note: Head over to https://developer.clarifai.com/signup/ and create a free account, once you're logged in go to https://developer.clarifai.com/account/applications/ and create a new application. You can find the client ID and Secret there. You get 5000 API-calls free/month.  
 
-If you want the script to get your Clarifai_ID and Clarifai_Secret for your environment, you can do:
+If you want the script to get your CLARIFAI_API_KEY from your environment, you can do:
 
 ```
-export CLARIFAI_ID="<ProjectID>"
-export CLARIFAI_SECRET="<Project Secret>"
+export CLARIFAI_API_KEY="<API KEY>"
 ```
 #### Example with Imagecontent handling
 
@@ -645,7 +643,7 @@ InstaPy(username='test', password='test')\
 ```python
 #default enabled=False , enables the checking with the clarifai api (image tagging)
 #if secret and proj_id are not set, it will get the environment Variables
-# 'Clarifai_SECRET' and 'CLARIFAI_ID'
+# 'CLARIFAI_API_KEY'
 
 session.set_use_clarifai(enabled=True, secret='xyz', proj_id='123')
 ```

--- a/examples/example.py
+++ b/examples/example.py
@@ -23,7 +23,7 @@ session.set_do_follow(enabled=True, percentage=10)
 """Image Check with Image tagging api"""
 # default enabled=False , enables the checking with the clarifai api (image tagging)
 # if secret and proj_id are not set, it will get the environment Variables
-# 'Clarifai_SECRET' and 'CLARIFAI_ID'
+# 'CLARIFAI_API_KEY'
 session.set_use_clarifai(enabled=True, secret='xyz', proj_id='123')
 #                                        ^
 # ^If specified once, you don't need to add them again
@@ -77,7 +77,7 @@ session.follow_user_followers(['friend1', 'friend2', 'friend3'], amount=10, rand
 # and randomly choose 5 pictures to be liked.
 # Take into account the other set options like the comment rate
 # and the filtering for inappropriate words or users
-session.set_user_interact(amount=5, random=True, percentage=50, media='Photo') 
+session.set_user_interact(amount=5, random=True, percentage=50, media='Photo')
 session.follow_user_followers(['friend1', 'friend2', 'friend3'], amount=10, random=False, interact=True)
 
 # follows the people that a given user is following
@@ -87,7 +87,7 @@ session.follow_user_following('friend2', amount=10, random=True)
 # and randomly choose 5 pictures to be liked.
 # Take into account the other set options like the comment rate
 # and the filtering for inappropriate words or users
-session.set_user_interact(amount=5, random=True, percentage=50, media='Photo') 
+session.set_user_interact(amount=5, random=True, percentage=50, media='Photo')
 session.follow_user_following(['friend1', 'friend2', 'friend3'], amount=10, random=False, interact=True)
 
 

--- a/examples/example.py
+++ b/examples/example.py
@@ -24,7 +24,7 @@ session.set_do_follow(enabled=True, percentage=10)
 # default enabled=False , enables the checking with the clarifai api (image tagging)
 # if secret and proj_id are not set, it will get the environment Variables
 # 'CLARIFAI_API_KEY'
-session.set_use_clarifai(enabled=True, secret='xyz', proj_id='123')
+session.set_use_clarifai(enabled=True, api_key='xxx')
 #                                        ^
 # ^If specified once, you don't need to add them again
 

--- a/instapy/clarifai_util.py
+++ b/instapy/clarifai_util.py
@@ -3,9 +3,9 @@ the image for invalid content"""
 from clarifai.client import ClarifaiApi
 
 
-def check_image(browser, clarifai_id, clarifai_secret, img_tags, full_match=False):
+def check_image(browser, clarifai_api_key, img_tags, full_match=False):
     """Uses the link to the image to check for invalid content in the image"""
-    clarifai_api = ClarifaiApi(clarifai_id, clarifai_secret)
+    clarifai_api = ClarifaiApi(clarifai_api_key)
 
     img_link = get_imagelink(browser)
     result = clarifai_api.tag_image_urls(img_link)

--- a/instapy/clarifai_util.py
+++ b/instapy/clarifai_util.py
@@ -1,15 +1,18 @@
 """Module which handles the clarifai api and checks
 the image for invalid content"""
-from clarifai.client import ClarifaiApi
-
+from clarifai import rest
+from clarifai.rest import ClarifaiApp, Image as ClImage
 
 def check_image(browser, clarifai_api_key, img_tags, full_match=False):
     """Uses the link to the image to check for invalid content in the image"""
-    clarifai_api = ClarifaiApi(clarifai_api_key)
+    clarifai_api = ClarifaiApp(api_key=clarifai_api_key)
 
     img_link = get_imagelink(browser)
-    result = clarifai_api.tag_image_urls(img_link)
-    clarifai_tags = result['results'][0]['result']['tag']['classes']
+    # Uses Clarifai's v2 API
+    model = clarifai_api.models.get('general-v1.3')
+    image = ClImage(url=img_link)
+    result = model.predict([image])
+    clarifai_tags = [concept.get('name').lower() for concept in result['outputs'][0]['data']['concepts']]
 
     for (tags, should_comment, comments) in img_tags:
         if should_comment:
@@ -33,5 +36,5 @@ def given_tags_in_result(search_tags, clarifai_tags, full_match=False):
 
 def get_imagelink(browser):
     """Gets the imagelink from the given webpage open in the browser"""
-    return browser.find_element_by_xpath('//img[@class = "_icyx7"]') \
+    return browser.find_element_by_xpath('//img[@class = "_2di5p"]') \
         .get_attribute('src')

--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -79,8 +79,7 @@ class InstaPy:
         self.user_interact_random = False
 
         self.use_clarifai = False
-        self.clarifai_secret = None
-        self.clarifai_id = None
+        self.clarifai_api_key = None
         self.clarifai_img_tags = []
         self.clarifai_full_match = False
 
@@ -124,7 +123,7 @@ class InstaPy:
             # 'profile': {
             #   'password_manager_enabled': False
             # }
-            
+
             chrome_prefs = {
                 'intl.accept_languages': 'en-US'
             }
@@ -261,7 +260,7 @@ class InstaPy:
         self.switch_language = option
         return self
 
-    def set_use_clarifai(self, enabled=False, secret=None, proj_id=None, full_match=False):
+    def set_use_clarifai(self, enabled=False, api_key=None, full_match=False):
         """Defines if the clarifai img api should be used
         Which 'project' will be used (only 5000 calls per month)"""
         if self.aborting:
@@ -269,15 +268,10 @@ class InstaPy:
 
         self.use_clarifai = enabled
 
-        if secret is None and self.clarifai_secret is None:
-            self.clarifai_secret = environ.get('CLARIFAI_SECRET')
-        elif secret:
-            self.clarifai_secret = secret
-
-        if proj_id is None and self.clarifai_id is None:
-            self.clarifai_id = environ.get('CLARIFAI_ID')
-        elif proj_id is not None:
-            self.clarifai_id = proj_id
+        if api_key is None and self.clarifai_api_key is None:
+            self.clarifai_api_key = environ.get('CLARIFAI_API_KEY')
+        elif api_key is not None:
+            self.clarifai_api_key = api_key
 
         self.clarifai_full_match = full_match
 
@@ -378,7 +372,7 @@ class InstaPy:
                             if self.use_clarifai and (following or commenting):
                                 try:
                                     checked_img, temp_comments = \
-                                        check_image(self.browser, self.clarifai_id,
+                                        check_image(self.browser, self.clarifai_api_key,
                                                     self.clarifai_secret,
                                                     self.clarifai_img_tags,
                                                     self.clarifai_full_match)
@@ -489,7 +483,7 @@ class InstaPy:
                             if self.use_clarifai and (following or commenting):
                                 try:
                                     checked_img, temp_comments = \
-                                        check_image(self.browser, self.clarifai_id,
+                                        check_image(self.browser, self.clarifai_api_key,
                                                     self.clarifai_secret,
                                                     self.clarifai_img_tags,
                                                     self.clarifai_full_match)
@@ -553,7 +547,7 @@ class InstaPy:
 
         total_liked_img = 0
         already_liked = 0
-        inap_img = 0 
+        inap_img = 0
         commented = 0
 
         usernames = usernames or []
@@ -575,7 +569,7 @@ class InstaPy:
             if links == False:
                 continue
 
-            # Reset like counter for every username 
+            # Reset like counter for every username
             liked_img = 0
 
             for i, link in enumerate(links):
@@ -609,7 +603,7 @@ class InstaPy:
                             if self.use_clarifai and (following or commenting):
                                 try:
                                     checked_img, temp_comments = \
-                                        check_image(self.browser, self.clarifai_id,
+                                        check_image(self.browser, self.clarifai_api_key,
                                                     self.clarifai_secret,
                                                     self.clarifai_img_tags,
                                                     self.clarifai_full_match)
@@ -632,7 +626,7 @@ class InstaPy:
 
                         else:
                             already_liked += 1
-                    
+
                     else:
                         print('--> Image not liked: {}'.format(reason))
                         inap_img += 1

--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -372,8 +372,8 @@ class InstaPy:
                             if self.use_clarifai and (following or commenting):
                                 try:
                                     checked_img, temp_comments = \
-                                        check_image(self.browser, self.clarifai_api_key,
-                                                    self.clarifai_secret,
+                                        check_image(self.browser,
+                                                    self.clarifai_api_key,
                                                     self.clarifai_img_tags,
                                                     self.clarifai_full_match)
                                 except Exception as err:
@@ -483,8 +483,8 @@ class InstaPy:
                             if self.use_clarifai and (following or commenting):
                                 try:
                                     checked_img, temp_comments = \
-                                        check_image(self.browser, self.clarifai_api_key,
-                                                    self.clarifai_secret,
+                                        check_image(self.browser,
+                                                    self.clarifai_api_key,
                                                     self.clarifai_img_tags,
                                                     self.clarifai_full_match)
                                 except Exception as err:
@@ -603,8 +603,8 @@ class InstaPy:
                             if self.use_clarifai and (following or commenting):
                                 try:
                                     checked_img, temp_comments = \
-                                        check_image(self.browser, self.clarifai_api_key,
-                                                    self.clarifai_secret,
+                                        check_image(self.browser,
+                                                    self.clarifai_api_key,
                                                     self.clarifai_img_tags,
                                                     self.clarifai_full_match)
                                 except Exception as err:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ __author__ = 'Tim Grossmann'
 
 requirements = [
     'selenium==2.53.6',
-    'clarifai==2.0.20',
+    'clarifai==2.0.31',
     'pyvirtualdisplay',
     'emoji'
 ]


### PR DESCRIPTION
Clarifai recently changed the way users could access their API (traditionally done with app_id and app_secret). Now they only provide an api_key and will deprecate the old way sometime towards end of 2017. 

This pull request removes app_id and app_secret from the API call and replaces it with api_key and updates the documentation. Clarifai's V2 API also only supports matching input photos against an existing model so that was updated in the clarifai_util.py file as well. 

Documentation was also updated.