### PR TITLE
Paunocu's fix the sleep ceil

### DIFF
--- a/instapy/unfollow_util.py
+++ b/instapy/unfollow_util.py
@@ -225,7 +225,7 @@ def follow_through_dialog(browser, user_name, amount, dont_include, login, follo
                 if delay < 60:
                     print('sleeping for about {} seconds'.format(delay))
                 else:
-                    print('sleeping for about {} minutes'.format(ceil(delay/60)))
+                    print('sleeping for about {} minutes'.format(delay/60))
                 sleep(delay)
                 hasSlept = True
                 continue


### PR DESCRIPTION
Its a very nice a pull request it fixes the problem "can't multiply sequence by non-int of type 'float'" while adding the option for non integer sleeps.
There is no reason to force the sleep to be a integer. it also doesnt work on some operational sysmtem