### PR TITLE
Change click() to .send_keys("\n")

### DIFF
--- a/instapy/unfollow_util.py
+++ b/instapy/unfollow_util.py
@@ -9,6 +9,7 @@ from .util import scroll_bottom
 from .util import formatNumber
 from .print_log_writer import log_followed_pool
 from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.common.action_chains import ActionChains
 import random
 
 def set_automated_followed_pool(username):
@@ -168,7 +169,7 @@ def follow_given_user(browser, acc_to_follow, follow_restrict):
     follow_button = browser.find_element_by_xpath("//*[contains(text(), 'Follow')]")
     sleep(10)
     if follow_button.text == 'Follow':
-        follow_button.click()
+        follow_button..send_keys("\n")
         print('---> Now following: {}'.format(acc_to_follow))
         print('*' * 20)
         follow_restrict[acc_to_follow] = follow_restrict.get(acc_to_follow, 0) + 1

--- a/instapy/unfollow_util.py
+++ b/instapy/unfollow_util.py
@@ -169,7 +169,7 @@ def follow_given_user(browser, acc_to_follow, follow_restrict):
     follow_button = browser.find_element_by_xpath("//*[contains(text(), 'Follow')]")
     sleep(10)
     if follow_button.text == 'Follow':
-        follow_button..send_keys("\n")
+        follow_button.send_keys("\n")
         print('---> Now following: {}'.format(acc_to_follow))
         print('*' * 20)
         follow_restrict[acc_to_follow] = follow_restrict.get(acc_to_follow, 0) + 1


### PR DESCRIPTION
If the button is covered for some reason. The error "Element ... is not clickable at point" shows up. This bypasses that and clicks no matter what. I am running this on OS X, and Ubuntu. Don't know if it will work elsewhere. 