### PR TITLE
Use send_keys on like buttons too

### DIFF
--- a/instapy/like_util.py
+++ b/instapy/like_util.py
@@ -425,7 +425,7 @@ def check_link(browser, link, dont_like, ignore_if_contains, ignore_users,
 
 def like_image(browser):
     """Likes the browser opened image"""
-    like_elem = browser.find_elements_by_xpath("//a[@role='button']/span[text()='Like']")
+    like_elem = browser.find_elements_by_xpath("//a[@role='button']/span[text()='Like']/..")
     liked_elem = browser.find_elements_by_xpath("//a[@role='button']/span[text()='Unlike']")
 
     if len(like_elem) == 1:

--- a/instapy/like_util.py
+++ b/instapy/like_util.py
@@ -425,12 +425,11 @@ def check_link(browser, link, dont_like, ignore_if_contains, ignore_users,
 
 def like_image(browser):
     """Likes the browser opened image"""
-    like_elem = browser.find_elements_by_xpath("//a[@role = 'button']/span[text()='Like']")
-    liked_elem = browser.find_elements_by_xpath("//a[@role = 'button']/span[text()='Unlike']")
+    like_elem = browser.find_elements_by_xpath("//a[@role='button']/span[text()='Like']")
+    liked_elem = browser.find_elements_by_xpath("//a[@role='button']/span[text()='Unlike']")
 
     if len(like_elem) == 1:
-        browser.execute_script(
-            "document.getElementsByClassName('" + like_elem[0].get_attribute("class") + "')[0].click()")
+        like_elem[0].send_keys("\n")
         print('--> Image Liked!')
         sleep(2)
         return True


### PR DESCRIPTION
Following the idea from the pull request #589 we should get rid of the click triggered via execute_script.
I'm actually asking myself why we were getting the className from the xpath element and then using javascript to get it again by className to finally click on it 😆