### PR TITLE
Fix following link

### DIFF
--- a/instapy/unfollow_util.py
+++ b/instapy/unfollow_util.py
@@ -45,7 +45,7 @@ def unfollow(browser, username, amount, dont_include, onlyInstapyFollowed, autom
         raise RuntimeWarning('There are 0 people to unfollow')
 
     try:
-        following_link = browser.find_elements_by_xpath('//a[@href="/' + user_name + '/following/"]')
+        following_link = browser.find_elements_by_xpath('//a[@href="/' + username + '/following/"]')
         following_link[0].click()
     except BaseException as e:
         print("following_link error \n", str(e))


### PR DESCRIPTION
The unfollow method is being sent `username` as a param but inside the method we're looking for `user_name` creating an error `('following_link error \n', "global name 'user_name' is not defined")`.

This bug was introduced today in https://github.com/timgrossmann/InstaPy/commit/a6f93227c4ea8cb5cae90b4523b021c632273d21