### PR TITLE
Update and rename How_To_DO_Ubuntu.md to How_To_DO_Ubuntu_on_Digital_…

### DIFF
--- a/docs/How_To_DO_Ubuntu_on_Digital_Ocean.md
+++ b/docs/How_To_DO_Ubuntu_on_Digital_Ocean.md
@@ -4,6 +4,7 @@
 - #### Make sure to use the 1GB RAM version (or better)
 
 - #### Make sure to set ```nogui=True``` in your InstaPy file
+- #### Note that current Chrome browser and chromedriver needed for the install only support 64-bit architecture. 
 
 ### General dependencies
 


### PR DESCRIPTION
…Ocean.md

clarified that the guide is for DO in the file title, commented that chrome browser is only available 64-bit.