### PR TITLE
Removed /requirements.txt from dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,7 +4,6 @@
 /docker_conf/
 /assets/
 /setup.py
-/requirements.txt
 /LICENSE
 /.gitignore
 /docker-prod.yml


### PR DESCRIPTION
Removed /requirements.txt from dockerignore or else the docker-compose.yml won't build. The pip install -r requirements.txt command fails when /requirements.txt is ignored.

- Even the COPY command will fail fstat because there is no /requirements.txt.