### PR TITLE
Updated docker-compose.yml for setting hostname default

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@
      depends_on:
        - selenium
    selenium:
+       container_name: selenium
        image: selenium/standalone-chrome-debug
        ports:
          - "5900:5900"


### PR DESCRIPTION
Docker generates hostnames that will not match:
- http://selenium:4444/wd/hub

So now we set the `container_name: selenium` to a default value so it will work. No need for setting the ip anymore.