### PR TITLE
Fixed docker hostname on debian and arch and wait for service is loaded on port 4444

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
  version: '3'
  services:
    web:
-     command: python docker_quickstart.py
+     command: ["./wait-for-selenium.sh", "http://selenium:4444/wd/hub", "--", "python", "docker_quickstart.py"]
      environment:
        - PYTHONUNBUFFERED=0
      build:
@@ -10,6 +10,7 @@
      depends_on:
        - selenium
    selenium:
+       container_name: selenium
        image: selenium/standalone-chrome-debug
        ports:
          - "5900:5900"

--- a/wait-for-selenium.sh
+++ b/wait-for-selenium.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# wait-for-selenium.sh
+
+set -e
+
+url="$1"
+shift
+cmd="$@"
+
+until wget -O- "$url"; do
+  >&2 echo "Selenium is unavailable - sleeping"
+  sleep 1
+done
+
+>&2 echo "Selenium is up - executing command"
+exec $cmd


### PR DESCRIPTION
When I tried the `docker-compose up --build` command on ubuntu there were no problems. Then I tried this on arch linux and debian with less luck. 

_There were some problems._

**Problem 1:**
Random generated hostnames by docker-compose v3
The hostnames defined in the scripts were `http://selenium:4444` and many pullrequests suggest you should change it to the ip. Then I got myself thinking docker generates hostnames why bypass them to fix this issue? The problem with docker-compose is it behaves different on other operating systems. So then I looked to the hostnames in ubuntu and they were `selenium`. Then I saw the debian hostname this was completly off `instagramselenium_selenium_1`. 

TLDR;
The fix was very easy, we make now use of:

```
container_name: selenium
``` 

**Problem 2:**
The web container `depends_on` the selenium container, but it only will wait until it is booted. It will not check if the selenium service is ready on port 4444. So it wil crash.
I looked into healthchecks which is possible in docker-compose, but you can not depend on it in docker-compose version 3 (it was possible in version 2.1). So then I took a look in the documentation and they said we should create a bash script for it:
https://docs.docker.com/compose/startup-order/

TLD;
So the fix was to create a bash script and wait for the service is ready on port 444.

Now your command:
```
docker-compose up --build
```

Will work on debian and arch linux to.

(p.s. sorry for my dunglish)