### PR TITLE
Removed maximze window this causes problems with docker

### DIFF
--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -150,7 +150,6 @@ class InstaPy:
 
         self.browser = webdriver.Remote(command_executor=selenium_url,
                                         desired_capabilities=DesiredCapabilities.CHROME)
-        self.browser.maximize_window()
         self.logFile.write('Session started - %s\n' \
                            % (datetime.now().strftime('%Y-%m-%d %H:%M:%S')))
 


### PR DESCRIPTION
There are issues with docker and the maximizing of your chrome window:
https://github.com/SeleniumHQ/docker-selenium/issues/396

I am having these problems on Ubuntu and Debian and arch.

We are using the standalone version, so I suggest to remove it or set a default.