### PR TITLE
Fix typo in variable name: user_name --> username

### DIFF
--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -706,7 +706,7 @@ class InstaPy:
             following = randint(0, 100) <= self.follow_percentage
             if (self.do_follow and username not in self.dont_include
                     and checked_img and following
-                    and self.follow_restrict.get(user_name, 0) < self.follow_times):
+                    and self.follow_restrict.get(username, 0) < self.follow_times):
                 followed += follow_user(self.browser, self.follow_restrict, self.username, username)
             else:
                 print('--> Not following')

--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -704,9 +704,9 @@ class InstaPy:
             self.logFile.write('--> {}\n'.format(username.encode('utf-8')))
 
             following = randint(0, 100) <= self.follow_percentage
-            if self.do_follow and username not in self.dont_include \
-                    and checked_img and following \
-                    and self.follow_restrict.get(user_name, 0) < self.follow_times:
+            if (self.do_follow and username not in self.dont_include
+                    and checked_img and following
+                    and self.follow_restrict.get(user_name, 0) < self.follow_times):
                 followed += follow_user(self.browser, self.follow_restrict, self.username, username)
             else:
                 print('--> Not following')


### PR DESCRIPTION
Was found via #713
* Also put multi-line if statement in parentheses to avoid using backslashs like the plague that they are (See PEP8). 
* A problem remains that __checked_img__ is an undefined name in this context.  It is defined as a local variable in several other functions/methods but it is not defined until 50 lines later in this one.