### PR TITLE
#402 #425 #336 fix selenium exception on follow button

### DIFF
--- a/instapy/unfollow_util.py
+++ b/instapy/unfollow_util.py
@@ -202,8 +202,8 @@ def follow_given_user(browser, acc_to_follow, follow_restrict):
     print('--> {} instagram account is opened...'.format(acc_to_follow))
 
     try:
-        follow_button = browser.find_element_by_xpath("//*[contains(text(), 'Follow')]")
         sleep(10)
+        follow_button = browser.find_element_by_xpath("//*[text()='Follow']")
         follow_button.send_keys("\n")
         
         print('---> Now following: {}'.format(acc_to_follow))


### PR DESCRIPTION
These issues shared the same exception message:
`element is not attached to the page document`

After looking into the function `follow_given_user` and move the line `browser.find_element_by_xpath(...)` below `sleep(10)` the issue gone away.

Also the xpath selection expression was: `"//*[contains(text(), 'Follow')]"`
which will also match "Following", therefore changed to `"//*[text()='Follow']"`
