### PR TITLE
184_bug_fix

### DIFF
--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -532,6 +532,9 @@ class InstaPy:
         commented = 0
         followed = 0
 
+        # deletes white spaces in tags
+        tags = list(map(str.strip, tags))
+
         tags = tags or []
 
         for index, tag in enumerate(tags):


### PR DESCRIPTION
#184 small bug fix, deletes white spaces in tags (like_by_tags) to prevent find for inexistent tags