### PR TITLE
locate button xpath only if text is exactly the follow word

### DIFF
--- a/instapy/unfollow_util.py
+++ b/instapy/unfollow_util.py
@@ -194,7 +194,7 @@ def follow_user(browser, follow_restrict, login, user_name):
 
     try:
         follow_button = browser.find_element_by_xpath(
-            "//*[contains(text(), 'Follow')]")
+                "//button[text()='Follow']")
 
         # Do we still need this sleep?
         sleep(2)


### PR DESCRIPTION
//*[contains(text(), 'Follow')] matchs the "Following" word too, that means that if even we were already Following this profile, it would try to Follow it again, resulting in a unfollow action.