### PR TITLE
Removes Record activity functionality for windows users

### DIFF
--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -38,6 +38,7 @@ from .unfollow_util import dump_follow_restriction
 from .unfollow_util import set_automated_followed_pool
 import random
 import csv
+import os
 
 
 class InstaPy:
@@ -106,6 +107,12 @@ class InstaPy:
 
         if selenium_local_session:
             self.set_selenium_local_session()
+
+        if os.name == 'nt':
+            error_msg = ('Sorry, Record Activity is not working on Windows. '
+                         'We\'re working to fix this soon!')
+            print(error_msg)
+            self.logFile.write('error_msg\n')
 
     def set_selenium_local_session(self):
         """Starts local session for a selenium server.

--- a/instapy/util.py
+++ b/instapy/util.py
@@ -1,8 +1,8 @@
 import re
-import os
 import csv
 import datetime
 import shutil
+import os
 from .time_util import sleep
 from selenium.common.exceptions import NoSuchElementException
 from tempfile import NamedTemporaryFile
@@ -119,21 +119,6 @@ def add_user_to_blacklist(browser, username, campaign, action):
 
     print('--> {} added to blacklist for {} campaign (action: {})'
           .format(username, campaign, action))
-=======
-                    # add header to the new file (temporary file)
-                    writer.writeheader()
-                    writer.writerow({
-                        'date': today,
-                        'likes': row['likes'],
-                        'comments': row['comments'],
-                        'follows': row['follows'],
-                        'unfollows': row['unfollows'],
-                        'server_calls': row['server_calls']
-                    })
-
-        # move temporary file to activity.csv (updating csv file)
-        shutil.move(tmpfile.name, './logs/activity.csv')
->>>>>>> tracking activities, not recording as expected yet
 
 
 def get_active_users(browser, username, posts):

--- a/instapy/util.py
+++ b/instapy/util.py
@@ -12,6 +12,10 @@ def update_activity(action=None):
     """Record every Instagram server call (page load, content load, likes,
     comments, follows, unfollow)."""
 
+    # workaround for windows users, they cant use it in this way, we need to
+    if os.name == 'nt':
+        return
+
     # file header
     fieldnames = [
         'date', 'likes', 'comments', 'follows', 'unfollows', 'server_calls']

--- a/instapy/util.py
+++ b/instapy/util.py
@@ -1,8 +1,8 @@
 import re
+import os
 import csv
 import datetime
 import shutil
-import os.path
 from .time_util import sleep
 from selenium.common.exceptions import NoSuchElementException
 from tempfile import NamedTemporaryFile
@@ -119,6 +119,21 @@ def add_user_to_blacklist(browser, username, campaign, action):
 
     print('--> {} added to blacklist for {} campaign (action: {})'
           .format(username, campaign, action))
+=======
+                    # add header to the new file (temporary file)
+                    writer.writeheader()
+                    writer.writerow({
+                        'date': today,
+                        'likes': row['likes'],
+                        'comments': row['comments'],
+                        'follows': row['follows'],
+                        'unfollows': row['unfollows'],
+                        'server_calls': row['server_calls']
+                    })
+
+        # move temporary file to activity.csv (updating csv file)
+        shutil.move(tmpfile.name, './logs/activity.csv')
+>>>>>>> tracking activities, not recording as expected yet
 
 
 def get_active_users(browser, username, posts):


### PR DESCRIPTION
There is a problem on windows when we try to delete a temporary file. To fix this, the solution is ugly, needs extra win32 libs. I think it's a good idea for now to not provide this functionality to windows users.