### PR TITLE
validate user before interact in interact_user_followers

### DIFF
--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -752,7 +752,7 @@ class InstaPy:
                                            self.like_by_followers_upper_limit,
                                            self.like_by_followers_lower_limit)
             if valid_user is not True:
-                print(valid_user)
+                self.logger.info(valid_user)
                 continue
 
             try:

--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -29,6 +29,7 @@ from .print_log_writer import log_follower_num
 from .time_util import sleep
 from .time_util import set_sleep_percentage
 from .util import get_active_users
+from .util import validate_username
 from .unfollow_util import get_given_user_followers
 from .unfollow_util import get_given_user_following
 from .unfollow_util import unfollow
@@ -743,6 +744,16 @@ class InstaPy:
                 'Username [{}/{}]'.format(index + 1, len(usernames)))
             self.logger.info('--> {}'.format(username.encode('utf-8')))
             following = random.randint(0, 100) <= self.follow_percentage
+
+            valid_user = validate_username(self.browser,
+                                           username,
+                                           self.ignore_users,
+                                           self.blacklist,
+                                           self.like_by_followers_upper_limit,
+                                           self.like_by_followers_lower_limit)
+            if valid_user is not True:
+                print(valid_user)
+                continue
 
             try:
                 links = get_links_for_username(

--- a/instapy/util.py
+++ b/instapy/util.py
@@ -6,6 +6,38 @@ from selenium.common.exceptions import NoSuchElementException
 import sqlite3
 
 
+def validate_username(browser,
+                      username,
+                      ignore_users,
+                      blacklist,
+                      like_by_followers_upper_limit,
+                      like_by_followers_lower_limit):
+    """Check if we can interact with the user"""
+
+    if username in ignore_users:
+        return ('---> {} is in ignore_users list, skipping '
+                'user...'.format(username))
+    if username in blacklist:
+        return '---> {} is in blacklist, skipping user...'
+
+    browser.get('https://www.instagram.com/{}'.format(username))
+    sleep(1)
+    try:
+        followers = (formatNumber(browser.find_element_by_xpath("//a[contains"
+                     "(@href,'followers')]/span").text))
+    except NoSuchElementException:
+        return '---> {} account is private, skipping user...'.format(username)
+
+    if followers > like_by_followers_upper_limit:
+        return '---> User {} exceeds followers limit'.format(username)
+    elif followers < like_by_followers_lower_limit:
+        return ('---> {}, number of followers does not reach '
+                'minimum'.format(username))
+
+    # if everything ok
+    return True
+
+
 def update_activity(action=None):
     """Record every Instagram server call (page load, content load, likes,
     comments, follows, unfollow)."""


### PR DESCRIPTION
bug fix for #818 

Validation added before user interaction, so we don't need to interact if the user doesnt meets requirements

1. not in blacklist
2. not in dont_include
3. respecting upper followers count limit
4. respecting lower followers count limit
5. not interacting with private accounts