### PR TITLE
Readme fix for set_unfollow_active_users

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ session.unfollow_users(amount=10, onlyNotFollowMe=True, sleep_delay=60)
 ```python
 # Prevents unfollow followers who have liked one of your latest 5 posts
 
-session.set_dont_unfollow_active_users(enabled=False, posts=5)
+session.set_dont_unfollow_active_users(enabled=True, posts=5)
 ```
 
 ### Interactions based on the number of followers a user has


### PR DESCRIPTION
In order to prevent unfollowing active users, enabled=True has to be used