### PR TITLE
avoid setuid sandbox type

### DIFF
--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -155,6 +155,7 @@ class InstaPy:
             chrome_options.add_argument('--dns-prefetch-disable')
             chrome_options.add_argument('--no-sandbox')
             chrome_options.add_argument('--lang=en-US')
+            chrome_options.add_argument('--disable-setuid-sandbox')
 
             # managed_default_content_settings.images = 2: Disable images load,
             # this setting can improve pageload & save bandwidth


### PR DESCRIPTION
I tested it for 3/4 hours without **element no visible**.

(Tested on MacOS and Linux Debian)

When testing it, please remember to update InstaPy and chrome driver to latest version.