### PR TITLE
Update for dialog selection in unfollow_util.py

### DIFF
--- a/instapy/unfollow_util.py
+++ b/instapy/unfollow_util.py
@@ -263,7 +263,7 @@ def unfollow(browser,
 
         # find dialog box
         dialog = browser.find_element_by_xpath(
-            '/html/body/div[4]/div/div[2]/div')
+            "//div[text()='Following']/following-sibling::div")
 
         # scroll down the page
         scroll_bottom(browser, dialog, allfollowing)


### PR DESCRIPTION
I realized that after #1009 the scroll bottom method was not working correctly anymore. The dialog selection is now correct and hopefully more robust than the previous one.