### PR TITLE
Implemented option to execute script with Headless Chrome in the InstaPy constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Table of Contents
 * [Emoji Support](#emoji-support)
 * [Clarifai ImageAPI](#clarifai-imageapi)
 * [Running on a Server](#running-on-a-server)
-* [Running on a headless browser](#running-on-a-headless-browser)
+* [Running on a Headless Browser](#running-on-a-headless-browser)
 * [Running with Docker microservices manual](#running-with-docker-microservices-manual)
 * [Running all-in-one with Docker (obsolete)](#running-all-in-one-with-docker-obsolete)
 * [Automate with cron](#automate-with-cron)
@@ -507,9 +507,9 @@ Use the `nogui` parameter to interact with virtual display
 session = InstaPy(username='test', password='test', nogui=True)
 ```
 
-## Running on a headless browser
+## Running on a Headless Browser
 
-Note: Chrome only! Must user chromedriver v2.9+ 
+**Note:** Chrome only! Must user chromedriver v2.9+ 
 
 Use `headless_browser` parameter to run the bot via the CLI. Works great if running the scripts locally, or to deploy on a server. No GUI, less CPU intensive. [Example](http://g.recordit.co/BhEgXANLhJ.gif)
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Table of Contents
 * [Emoji Support](#emoji-support)
 * [Clarifai ImageAPI](#clarifai-imageapi)
 * [Running on a Server](#running-on-a-server)
+* [Running on a headless browser](#running-on-a-headless-browser)
 * [Running with Docker microservices manual](#running-with-docker-microservices-manual)
 * [Running all-in-one with Docker (obsolete)](#running-all-in-one-with-docker-obsolete)
 * [Automate with cron](#automate-with-cron)
@@ -504,6 +505,16 @@ Use the `nogui` parameter to interact with virtual display
 
 ```
 session = InstaPy(username='test', password='test', nogui=True)
+```
+
+## Running on a headless browser
+
+Note: Chrome only! Must user chromedriver v2.9+ 
+
+Use `headless_browser` parameter to run the bot via the CLI. Works great if running the scripts locally, or to deploy on a server. No GUI, less CPU intensive. [Example](http://g.recordit.co/BhEgXANLhJ.gif)
+
+```
+session = InstaPy(username='test', password='test', headless_browser=True)
 ```
 
 ## Running with Docker microservices manual

--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -164,7 +164,7 @@ class InstaPy:
             if self.headless_browser:
                 chrome_options.add_argument('--headless')
                 user_agent = "Chrome" # Replaces browser User Agent from "HeadlessChrome".
-                chrome_options.add_argument(f'user-agent={user_agent}')
+                chrome_options.add_argument('user-agent={user_agent}'.format(user_agent=user_agent))
 
             # managed_default_content_settings.images = 2: Disable images load,
             # this setting can improve pageload & save bandwidth

--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -53,13 +53,15 @@ class InstaPy:
                  selenium_local_session=True,
                  use_firefox=False,
                  page_delay=25,
-                 show_logs=True):
+                 show_logs=True,
+                 headless_browser=False):
 
         if nogui:
             self.display = Display(visible=0, size=(800, 600))
             self.display.start()
 
         self.browser = None
+        self.headless_browser = headless_browser
 
         self.username = username or os.environ.get('INSTA_USER')
         self.password = password or os.environ.get('INSTA_PW')
@@ -156,6 +158,13 @@ class InstaPy:
             chrome_options.add_argument('--no-sandbox')
             chrome_options.add_argument('--lang=en-US')
             chrome_options.add_argument('--disable-setuid-sandbox')
+            
+            ## This option implements Chrome Headless, a new (late 2017) GUI-less browser
+            ## Must be Chromedriver 2.9 and above.
+            if self.headless_browser:
+                chrome_options.add_argument('--headless')
+                user_agent = "Chrome" # Replaces browser User Agent from "HeadlessChrome".
+                chrome_options.add_argument(f'user-agent={user_agent}')
 
             # managed_default_content_settings.images = 2: Disable images load,
             # this setting can improve pageload & save bandwidth


### PR DESCRIPTION
Use `headless_browser=True` in the constructor to enable Headless
Chrome - executing your scripts without a Chrome window or GUI opening.
It’s all done in the CLI! Excellent for servers or running in the
background while consuming less CPU.