### PR TITLE
Fix unfollow=False issue in "Like by Feed" def

### DIFF
--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -1449,7 +1449,7 @@ class InstaPy:
                                 self.logger.info(
                                     '--> Image not liked: {}'.format(reason))
                                 inap_img += 1
-                                if reason == 'Inappropriate':
+                                if reason == 'Inappropriate' and unfollow:
                                     unfollow_user(self.browser, self.logger)
                         except NoSuchElementException as err:
                             self.logger.error('Invalid Page: {}'.format(err))


### PR DESCRIPTION
  Either way, unfollow=False will not stop unfollowing inappropriate media owners. Actually, stopping unfollow in certain inappropriate medias is **vital**. Such as, i dont want to like #food pics but it should not unfollow everybody with that tag.
 Or maybe, **much better**, there could be some improvement to unfollow tool, like if it gets certain amount of inappropriate tags in a media, it should do unfollow (e.g. very inappropriate).