### PR TITLE
added interact option to like_by_tags #894

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,14 @@ Example:
 session.like_by_tags(['natgeo', 'world'], amount=10)
 ```
 
+### Like by Tags and interact with user
+
+```python
+# Like posts based on hashtags and like 3 posts of its poster
+session.set_user_interact(amount=3, randomize=True, percentage=100, media='Photo')
+session.like_by_tags(['natgeo', 'world'], amount=10, interact=True)
+```
+
 ### Like by Feeds
 
 ```python

--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -606,7 +606,8 @@ class InstaPy:
                      amount=50,
                      media=None,
                      skip_top_posts=True,
-                     use_smart_hashtags=False):
+                     use_smart_hashtags=False,
+                     interact=False):
         """Likes (default) 50 images per given tag"""
         if self.aborting:
             return self
@@ -666,6 +667,26 @@ class InstaPy:
                                            self.logger)
 
                         if liked:
+
+                            if interact:
+                                username = (self.browser.
+                                    find_element_by_xpath(
+                                        '//article/header/div[2]/'
+                                        'div[1]/div/a'))
+
+                                username = username.get_attribute("title")
+                                name = []
+                                name.append(username)
+
+                                self.logger.info(
+                                    '--> User followed: {}'
+                                    .format(name))
+                                self.like_by_users(
+                                    name,
+                                    self.user_interact_amount,
+                                    self.user_interact_random,
+                                    self.user_interact_media)
+
                             liked_img += 1
                             checked_img = True
                             temp_comments = []

--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -109,7 +109,7 @@ class InstaPy:
         self.clarifai_img_tags = []
         self.clarifai_full_match = False
 
-        self.like_by_followers_upper_limit = 0
+        self.like_by_followers_upper_limit = 90000
         self.like_by_followers_lower_limit = 0
 
         self.bypass_suspicious_attempt = bypass_suspicious_attempt


### PR DESCRIPTION
I had the same issue mentioned in #894 and did not get it to work, so I basically copied the interact parts from like_by_feed and added them to like_by_tags. 

But the like_by_user called in like_by_tags didn't seem to work without a proper like_by_followers_upper_limit (because of util.py:31 with like_by_followers_upper_limit set to 0). So i figured the most simple way is to change the default value of like_by_followers_upper_limit to 90000. I don't really see a reason why it should make any problems, but i'm not 100% sure that's why i mentioned it. 