### PR TITLE
Update logging instantiation

### DIFF
--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -43,6 +43,10 @@ from .unfollow_util import dump_follow_restriction
 from .unfollow_util import set_automated_followed_pool
 
 
+# Set a logger cache outside the InstaPy object to avoid re-instantiation issues
+loggers = {}
+
+
 class InstaPy:
     """Class to be instantiated to use the script"""
 
@@ -116,20 +120,8 @@ class InstaPy:
 
         self.aborting = False
 
-        # initialize and setup logging system
-        self.logger = logging.getLogger(__name__)
-        self.logger.setLevel(logging.DEBUG)
-        file_handler = logging.FileHandler('./logs/general.log')
-        file_handler.setLevel(logging.DEBUG)
-        logger_formatter = logging.Formatter('%(levelname)s - %(message)s')
-        file_handler.setFormatter(logger_formatter)
-        self.logger.addHandler(file_handler)
-
-        if show_logs is True:
-            console_handler = logging.StreamHandler()
-            console_handler.setLevel(logging.DEBUG)
-            console_handler.setFormatter(logger_formatter)
-            self.logger.addHandler(console_handler)
+        # Assign logger
+        self.logger = self.get_instapy_logger(show_logs)
 
         if selenium_local_session:
             self.set_selenium_local_session()
@@ -138,6 +130,32 @@ class InstaPy:
             error_msg = ('Sorry, Record Activity is not working on Windows. '
                          'We\'re working to fix this soon!')
             self.logger.warning(error_msg)
+
+    def get_instapy_logger(self, show_logs):
+        """
+        Handles the creation and retrieval of loggers to avoid re-instantiation.
+        """
+        existing_logger = loggers.get(__name__)
+        if existing_logger is not None:
+            return existing_logger
+        else:
+            # initialize and setup logging system for the InstaPy object
+            logger = logging.getLogger(__name__)
+            logger.setLevel(logging.DEBUG)
+            file_handler = logging.FileHandler('./logs/general.log')
+            file_handler.setLevel(logging.DEBUG)
+            logger_formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s', datefmt='%Y-%m-%d %H:%M:%S')
+            file_handler.setFormatter(logger_formatter)
+            logger.addHandler(file_handler)
+
+            if show_logs is True:
+                console_handler = logging.StreamHandler()
+                console_handler.setLevel(logging.DEBUG)
+                console_handler.setFormatter(logger_formatter)
+                logger.addHandler(console_handler)
+
+            loggers[__name__] = logger
+            return logger
 
     def set_selenium_local_session(self):
         """Starts local session for a selenium server.
@@ -1578,7 +1596,7 @@ class InstaPy:
                                                         self.username,
                                                         user_name,
                                                         self.blacklist,
-                                                        self.logger)                        
+                                                        self.logger)
                     else:
                         self.logger.info(
                             '--> User not followed: {}'.format(reason))


### PR DESCRIPTION
I don't believe there was an issue for this, but I encountered an error where the log messages were duplicating themselves multiple times. The issue had to do with instantiating the `logging.getLogger(__name__)` singleton multiple times.

I was using the [retrying library](https://github.com/rholder/retrying) in my quickstart file as follows:

```python
@retry(stop_max_attempt_number=20)
def main():
    session = InstaPy(username=insta_username, password=insta_password)
    ...
```
However, because I would re-instantiate the `InstaPy` object upon each retry, it would add additional loggers to the existing logging instance. This resulted in duplicate output.

I have updated the logging setup in the instapy file to avoid this issue (by retrieving an existing logger from a cache if one has already been created).

This appears to be working great for me.

Open to any feedback as needed. Hopefully this solves similar issues that others have seen.