### PR TITLE
fix the sys.meta_path is None, Python is likely shutting down error

### DIFF
--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -1545,7 +1545,7 @@ class InstaPy:
         """Closes the current session"""
         dump_follow_restriction(self.follow_restrict)
         self.browser.delete_all_cookies()
-        self.browser.close()
+        self.browser.quit()
 
         if self.nogui:
             self.display.stop()


### PR DESCRIPTION
I have test it locally, it all working fine. Please have someone else take a look and test it as well.

`sys.meta_path is None, Python is likely shutting down` error is preventing the Chromedriver close properly. 