### PR TITLE
missing self.logfolder argument to follow_user

### DIFF
--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -1640,7 +1640,8 @@ class InstaPy:
                                                         self.username,
                                                         user_name,
                                                         self.blacklist,
-                                                        self.logger)
+                                                        self.logger,
+                                                        self.logfolder)
                     else:
                         self.logger.info(
                             '--> User not followed: {}'.format(reason))


### PR DESCRIPTION
`follow_by_tags` calls were failing since `follow_user` was called with 6, instead of 7 arguments, as `self.logfolder` was missing.