### PR TITLE
fixes an issue when running unfollow_users with onlyNotFollowMe

### DIFF
--- a/instapy/unfollow_util.py
+++ b/instapy/unfollow_util.py
@@ -160,7 +160,8 @@ def unfollow(browser,
                     .format(graphql_followers, str(json.dumps(variables)))
                 )
                 if i != 0:
-                    del variables['after']
+                    if 'after' in variables:
+                        del variables['after']
                     url = (
                         '{}&variables={}'
                         .format(graphql_following, str(json.dumps(variables)))


### PR DESCRIPTION
a chrome "element not found" error happens -- the specific Python exception mentions a KeyError on the 'after' key. the commit in this PR fixes this issue.

this relates to issue #1242 