### PR TITLE
Added unfollow_after arg to unfollow_users to Delayed Unfollow

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,13 +288,20 @@ session.interact_user_followers(['natgeo'], amount=10, randomize=True)
 # onlyInstapyMethod is using only when onlyInstapyFollowed = True
 # sleep_delay sets the time it will sleep every 10 profile unfollow, default
 # is 10min
-
 session.unfollow_users(amount=10, onlyInstapyFollowed = True, onlyInstapyMethod = 'FIFO', sleep_delay=60 )
 
 # You can only unfollow user that won't follow you back by adding
 # onlyNotFollowMe = True it still only support on profile following
 # you should disable onlyInstapyFollowed when use this
 session.unfollow_users(amount=10, onlyNotFollowMe=True, sleep_delay=60)
+
+# You can also unfollow users only after following them certain amount of time,
+# this will provide seamless unfollow activity without the notice of the targeted user
+# To use, just add `unfollow_after` argument with the desired time, e.g.
+session.unfollow_users(amount=10, onlyInstapyFollowed = True, onlyInstapyMethod = 'FIFO', sleep_delay=600, unfollow_after=48*60*60)
+# will unfollow users only after following them 48 hours (2 days), since `unfollow_after`s value
+# is seconds, you can simply give it `unfollow_after=100` to unfollow after 100 seconds,
+# but `1*60*60` (which is equal to 1 hour or 3600 seconds) style is a lot simpler to use 👍
 ```
 
 ### Don't unfollow active users

--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -4,6 +4,7 @@ import json
 import logging
 from math import ceil
 import os
+from platform import python_version
 from datetime import datetime
 from sys import maxsize
 import random
@@ -476,6 +477,7 @@ class InstaPy:
 
             if self.follow_restrict.get(acc_to_follow, 0) < self.follow_times:
                 followed += follow_given_user(self.browser,
+                                              self.username,
                                               acc_to_follow,
                                               self.follow_restrict,
                                               self.blacklist,
@@ -1487,11 +1489,20 @@ class InstaPy:
                        onlyInstapyFollowed=False,
                        onlyInstapyMethod='FIFO',
                        sleep_delay=600,
-                       onlyNotFollowMe=False):
+                       onlyNotFollowMe=False,
+                       unfollow_after=None):
         """Unfollows (default) 10 users from your following list"""
-        self.automatedFollowedPool = set_automated_followed_pool(self.username,
-                                                                 self.logger,
-                                                                 self.logfolder)
+        
+        if unfollow_after is not None:
+            if not python_version().startswith(('2.7', '3')):
+                self.logger.info("`unfollow_after` argument is not available for Python versions below 2.7")
+                unfollow_after = None
+        
+        if onlyInstapyFollowed:
+            self.automatedFollowedPool = set_automated_followed_pool(self.username,
+                                                                     self.logger,
+                                                                     self.logfolder,
+                                                                     unfollow_after)
 
         try:
             unfollowNumber = unfollow(self.browser,

--- a/instapy/like_util.py
+++ b/instapy/like_util.py
@@ -529,8 +529,11 @@ def check_link(browser,
     for dont_likes_regex in dont_like_regex:
         quash = re.search(dont_likes_regex, image_text, re.IGNORECASE)
         if quash:
-            quashed = (quash.group(0)).split('#')[1]
-            iffy = (re.split(r'\W+', dont_likes_regex))[3]
+            quashed = (((quash.group(0)).split('#')[1]).split(' ')[0]).split('\n')[0]   # dismiss possible space and newlines
+            iffy = ((re.split(r'\W+', dont_likes_regex))[3] if dont_likes_regex.endswith('*([^\\d\\w]|$)') else   # 'word' without format
+                     (re.split(r'\W+', dont_likes_regex))[1] if dont_likes_regex.endswith('+([^\\d\\w]|$)') else   # '[word'
+                      (re.split(r'\W+', dont_likes_regex))[3] if dont_likes_regex.startswith('#[\\d\\w]+') else     # ']word'
+                       (re.split(r'\W+', dont_likes_regex))[1])                                                    # '#word'
             inapp_unit = ('Inappropriate! ~ contains \'{}\''.format(quashed) if quashed == iffy else
                               'Inappropriate! ~ contains \'{}\' in \'{}\''.format(iffy, quashed))
             return True, user_name, is_video, inapp_unit

--- a/instapy/print_log_writer.py
+++ b/instapy/print_log_writer.py
@@ -18,12 +18,12 @@ def log_follower_num(browser, username, logfolder):
     return followed_by
 
 
-def log_followed_pool(login, followed, logger, logfolder):
+def log_followed_pool(login, followed, logger, logfolder, logtime):
     """Prints and logs the followed to
     a seperate file"""
     try:
         with open('{0}{1}_followedPool.csv'.format(logfolder, login), 'a+') as followPool:
-            followPool.write('{},\n'.format(followed))
+            followPool.write('{} ~ {},\n'.format(logtime, followed))
     except BaseException as e:
         logger.error("log_followed_pool error {}".format(str(e)))
 
@@ -57,4 +57,4 @@ def log_record_all_followed(login, followed, logger, logfolder):
         with open('{0}{1}_record_all_followed.csv'.format(logfolder, login), 'a+') as followPool:
             followPool.write('{},\n'.format(followed))
     except BaseException as e:
-        logger.error("log__record_all_followed_pool error {}".format(str(e)))
+        logger.error("log_record_all_followed_pool error {}".format(str(e)))

--- a/instapy/unfollow_util.py
+++ b/instapy/unfollow_util.py
@@ -1,6 +1,7 @@
 """Module which handles the follow features like unfollowing and following"""
 import json
 import csv
+from datetime import datetime, timedelta
 from .time_util import sleep
 from .util import delete_line_from_file
 from .util import scroll_bottom
@@ -16,14 +17,31 @@ import random
 import os
 
 
-def set_automated_followed_pool(username, logger, logfolder):
+def set_automated_followed_pool(username, logger, logfolder, unfollow_after):
     automatedFollowedPool = []
     try:
         with open('{0}{1}_followedPool.csv'.format(logfolder, username), 'r+') as followedPoolFile:
             reader = csv.reader(followedPoolFile)
-            automatedFollowedPool = [row[0] for row in reader]
+            for row in reader:
+                if unfollow_after is not None:
+                    try:
+                        ftime = datetime.strptime(row[0].split(' ~ ')[0], '%Y-%m-%d %H:%M')
+                        ftimestamp = (ftime - datetime(1970, 1, 1)).total_seconds()
+                        realtimestamp = (datetime.now() - datetime(1970, 1, 1)).total_seconds()
+                        if realtimestamp - ftimestamp > unfollow_after:
+                            fword = row[0].split(' ~ ')[1]
+                            automatedFollowedPool.append(fword)
+                    except ValueError:
+                        fword = row[0]
+                        automatedFollowedPool.append(fword)
+                else:
+                    try:
+                        fword = row[0].split(' ~ ')[1]
+                    except IndexError:
+                        fword = row[0]
+                    automatedFollowedPool.append(fword)
 
-        logger.info("Number of people followed automatically remaining: {}"
+        logger.info("Number of users available to unfollow: {}"
                     .format(len(automatedFollowedPool)))
 
         followedPoolFile.close()
@@ -372,7 +390,8 @@ def follow_user(browser, follow_restrict, login, user_name, blacklist, logger, l
             update_activity('follows')
 
         logger.info('--> Now following')
-        log_followed_pool(login, user_name, logger, logfolder)
+        logtime = datetime.now().strftime('%Y-%m-%d %H:%M')
+        log_followed_pool(login, user_name, logger, logfolder, logtime)
         follow_restrict[user_name] = follow_restrict.get(user_name, 0) + 1
         if blacklist['enabled'] is True:
             action = 'followed'
@@ -403,6 +422,7 @@ def unfollow_user(browser, logger):
 
 
 def follow_given_user(browser,
+                      login,
                       acc_to_follow,
                       follow_restrict,
                       blacklist,
@@ -420,6 +440,8 @@ def follow_given_user(browser,
         click_element(browser, follow_button) # unfollow_button.send_keys("\n")
         update_activity('follows')
         logger.info('---> Now following: {}'.format(acc_to_follow))
+        logtime = datetime.now().strftime('%Y-%m-%d %H:%M')
+        log_followed_pool(login, acc_to_follow, logger, logfolder, logtime)
         follow_restrict[acc_to_follow] = follow_restrict.get(
             acc_to_follow, 0) + 1
 
@@ -539,7 +561,8 @@ def follow_through_dialog(browser,
 
 
                 click_element(browser, button) # button.send_keys("\n")
-                log_followed_pool(login, person, logger, logfolder)
+                logtime = datetime.now().strftime('%Y-%m-%d %H:%M')
+                log_followed_pool(login, person, logger, logfolder, logtime)
 
                 update_activity('follows')
 

--- a/instapy/util.py
+++ b/instapy/util.py
@@ -172,7 +172,7 @@ def delete_line_from_file(filepath, lineToDelete, logger):
 
         f = open(file_path_Temp, "w")
         for line in lines:
-            if line != lineToDelete:
+            if not line.endswith(lineToDelete):
                 f.write(line)
             else:
                 logger.info("{} removed from csv".format(line))


### PR DESCRIPTION
 As of @underclass [issued](https://github.com/timgrossmann/InstaPy/issues/1330)
### I've added a new argument:  **`unfollow_after`** 
to `unfollow_users` feature, in order to unfollow users **_after_** following them certain amount of time..
```python
unfollow_users (amount=10,
                onlyInstapyFollowed=True, onlyInstapyMethod='FIFO',
                sleep_delay=600,                   
                onlyNotFollowMe=False,
                unfollow_after=24*60*60)  #here, will unfollow every single user
                                          #after following at least a day
```
_Time counts uniquely for every single user, after it is followed by InstaPy.._
**Actually**, it can be `unfollow_after=500` (will unfollow users if **500 seconds** of follow time passes), but
having it **`hours*minutes*seconds`** **is easier** than big numbers, such as `168*60*60` equals to a week (in other words `604800` seconds)

[]      []      []       []       []      []      []

###   DETAILS
Well, I have changed the logging style of followed people in
`myusername_followedPool.csv` of `./logs/username/`
 **from** just names, as
```python
myfirstfollower_cool,
mysecondfollower_wow,
```
 **to** include the time it is followed, e.g.,
```python
2018-02-01 02:54 ~ myfirstfollower_cool,
2018-02-01 03:17 ~ mysecondfollower_wow,
```
**so** if `unfollow_after` is not None **it will compare** each user's followed time with realtime and generate available users list to unfollow in return..
if `unfollow_after` is None (or not included in `unfollow_users()`) it will **not** compare againist time, and will return a list of **all** followed users.

[]      []      []       []       []      []      []

**Notice 1:** **Old usernames** in `myusername_followedPool.csv` **without datetime entry**, will **not** be **compared** againist time in any case. And will be added to any unfollow list.

**Notice 2:** **Currently this works **only with** `onlyInstapyFollowed=True` method.** 
_you don't need to disable unfollow_after parameter while using another method.._

_**tbh** another method of `onlyNotFollowMe` is just unfollowing every user, while may you have followed some users without InstaPy that it factically is impossible to record their follow time accurately to compare in `unfollow_after`.._

[]      []      []       []       []      []      []

**Fix:** _Also, fixed_ **missing** `log_followed_pool` _line_ at `follow_given_user`(called from `follow_by_list` feature) of `unfollow_util.py`, **now** it is recording every followed user from `follow_by_list` feature to `myusername_followedPool.csv` file.