### PR TITLE
Store username in statistics sqlite DB

### DIFF
--- a/instapy/comment_util.py
+++ b/instapy/comment_util.py
@@ -33,7 +33,7 @@ def open_comment_section(browser):
         print(missing_comment_elem_warning)
 
 
-def comment_image(browser, username, comments, blacklist, logger, logfolder):
+def comment_image(browser, username, comments, blacklist, logger, logfolder, insta_username):
     """Checks if it should comment on the image"""
     rand_comment = (choice(comments).format(username))
     rand_comment = emoji.demojize(rand_comment)
@@ -53,7 +53,7 @@ def comment_image(browser, username, comments, blacklist, logger, logfolder):
         comment_input[0].send_keys("\b")
         comment_input = get_comment_input(browser)
         comment_input[0].submit()
-        update_activity('comments', username=username)
+        update_activity('comments', insta_username=insta_username)
         if blacklist['enabled'] is True:
             action = 'commented'
             add_user_to_blacklist(

--- a/instapy/comment_util.py
+++ b/instapy/comment_util.py
@@ -53,7 +53,7 @@ def comment_image(browser, username, comments, blacklist, logger, logfolder):
         comment_input[0].send_keys("\b")
         comment_input = get_comment_input(browser)
         comment_input[0].submit()
-        update_activity('comments')
+        update_activity('comments', username=username)
         if blacklist['enabled'] is True:
             action = 'commented'
             add_user_to_blacklist(

--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -472,7 +472,8 @@ class InstaPy:
                                               self.follow_restrict,
                                               self.blacklist,
                                               self.logger,
-                                              self.logfolder)
+                                              self.logfolder
+                                              self.username)
                 self.followed += followed
                 self.logger.info('Followed: {}'.format(str(followed)))
                 followed = 0
@@ -1515,7 +1516,7 @@ class InstaPy:
                                     '--> Image not liked: {}'.format(reason))
                                 inap_img += 1
                                 if reason == 'Inappropriate' and unfollow:
-                                    unfollow_user(self.browser, self.logger)
+                                    unfollow_user(self.browser, self.logger, self.username)
                         except NoSuchElementException as err:
                             self.logger.error('Invalid Page: {}'.format(err))
 

--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -64,7 +64,8 @@ class InstaPy:
                  proxy_address=None,
                  proxy_port=0,
                  bypass_suspicious_attempt=False,
-                 multi_logs=False):
+                 multi_logs=False,
+                 daily_limit=False):
 
         if nogui:
             self.display = Display(visible=0, size=(800, 600))
@@ -127,6 +128,8 @@ class InstaPy:
         self.bypass_suspicious_attempt = bypass_suspicious_attempt
 
         self.aborting = False
+
+        self.daily_limit = False
 
         # Assign logger
         self.logger = self.get_instapy_logger(show_logs)
@@ -647,13 +650,14 @@ class InstaPy:
             return self
 
         # Check limit hasn't already been reached
-        cur_status = get_activity(self.username)
-        if cur_status['likes'] >= amount:
-            self.logger.info('Like limit reached')
-            return self
-        else:
-            # Deduct any work done already
-            amount = amount - cur_status['likes']
+        if self.daily_limit:
+            cur_status = get_activity(self.username)
+            if cur_status['likes'] >= amount:
+                self.logger.info('Like limit reached')
+                return self
+            else:
+                # Deduct any work done already
+                amount = amount - cur_status['likes']
 
         liked_img = 0
         already_liked = 0
@@ -1607,13 +1611,14 @@ class InstaPy:
 
 
         # Check limit hasn't already been reached
-        cur_status = get_activity(self.username)
-        if cur_status['follows'] >= amount:
-            self.logger.info('Follow limit reached')
-            return self
-        else:
-            # Deduct any work done already
-            amount = amount - cur_status['follows']
+        if self.daily_limit:
+            cur_status = get_activity(self.username)
+            if cur_status['follows'] >= amount:
+                self.logger.info('Follow limit reached')
+                return self
+            else:
+                # Deduct any work done already
+                amount = amount - cur_status['follows']
 
         inap_img = 0
         followed = 0
@@ -1682,3 +1687,12 @@ class InstaPy:
         self.followed += followed
 
         return self
+
+    def set_daily_limit(self, enabled=False):
+        """Defines if limits should be per-run or per-day"""
+        if self.aborting:
+            return self
+
+        self.daily_limit = enabled
+        return self
+

--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -31,6 +31,7 @@ from .time_util import sleep
 from .time_util import set_sleep_percentage
 from .util import get_active_users
 from .util import validate_username
+from .util import get_activity
 from .unfollow_util import get_given_user_followers
 from .unfollow_util import get_given_user_following
 from .unfollow_util import unfollow
@@ -645,6 +646,15 @@ class InstaPy:
         if self.aborting:
             return self
 
+        # Check limit hasn't already been reached
+        cur_status = get_activity(self.username)
+        if cur_status['likes'] >= amount:
+            self.logger.info('Like limit reached')
+            return self
+        else:
+            # Deduct any work done already
+            amount = amount - cur_status['likes']
+
         liked_img = 0
         already_liked = 0
         inap_img = 0
@@ -780,8 +790,7 @@ class InstaPy:
                                                         user_name,
                                                         self.blacklist,
                                                         self.logger,
-                                                        self.logfolder,
-                                                        self.username)
+                                                        self.logfolder)
                             else:
                                 self.logger.info('--> Not following')
                                 sleep(1)
@@ -1595,6 +1604,16 @@ class InstaPy:
                      use_smart_hashtags=False):
         if self.aborting:
             return self
+
+
+        # Check limit hasn't already been reached
+        cur_status = get_activity(self.username)
+        if cur_status['follows'] >= amount:
+            self.logger.info('Follow limit reached')
+            return self
+        else:
+            # Deduct any work done already
+            amount = amount - cur_status['follows']
 
         inap_img = 0
         followed = 0

--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -472,7 +472,7 @@ class InstaPy:
                                               self.follow_restrict,
                                               self.blacklist,
                                               self.logger,
-                                              self.logfolder
+                                              self.logfolder,
                                               self.username)
                 self.followed += followed
                 self.logger.info('Followed: {}'.format(str(followed)))
@@ -671,7 +671,8 @@ class InstaPy:
                                           amount,
                                           self.logger,
                                           media,
-                                          skip_top_posts)
+                                          skip_top_posts,
+                                          self.username)
             except NoSuchElementException:
                 self.logger.error('Too few images, skipping this tag')
                 continue
@@ -697,7 +698,8 @@ class InstaPy:
                         liked = like_image(self.browser,
                                            user_name,
                                            self.blacklist,
-                                           self.logger)
+                                           self.logger,
+                                           self.username)
 
                         if liked:
 
@@ -778,7 +780,8 @@ class InstaPy:
                                                         user_name,
                                                         self.blacklist,
                                                         self.logger,
-                                                        self.logfolder)
+                                                        self.logfolder,
+                                                        self.username)
                             else:
                                 self.logger.info('--> Not following')
                                 sleep(1)
@@ -1616,7 +1619,8 @@ class InstaPy:
                                           amount,
                                           self.logger,
                                           media,
-                                          skip_top_posts)
+                                          skip_top_posts,
+                                          self.username)
             except NoSuchElementException:
                 self.logger.error('Too few images, skipping this tag')
                 continue

--- a/instapy/like_util.py
+++ b/instapy/like_util.py
@@ -17,7 +17,7 @@ def get_links_from_feed(browser, amount, num_of_search, logger):
 
     browser.get('https://www.instagram.com')
     # update server calls
-    update_activity()
+    update_activity(username=username)
     sleep(2)
 
     for i in range(num_of_search + 1):
@@ -67,7 +67,7 @@ def get_links_for_location(browser,
 
     browser.get('https://www.instagram.com/explore/locations/' + location)
     # update server calls
-    update_activity()
+    update_activity(username=username)
     sleep(2)
 
     # clicking load more
@@ -93,14 +93,14 @@ def get_links_for_location(browser,
             body_elem.send_keys(Keys.END)
             sleep(2)
             # update server calls
-            update_activity()
+            update_activity(username=username)
     else:
         abort = False
         body_elem.send_keys(Keys.END)
         sleep(2)
         click_element(browser, load_button) # load_button.click()
         # update server calls
-        update_activity()
+        update_activity(username=username)
 
     body_elem.send_keys(Keys.HOME)
     sleep(1)
@@ -136,7 +136,7 @@ def get_links_for_location(browser,
             before_load = total_links
             body_elem.send_keys(Keys.END)
             # update server calls
-            update_activity()
+            update_activity(username=username)
             sleep(1)
             body_elem.send_keys(Keys.HOME)
             sleep(1)
@@ -174,7 +174,7 @@ def get_links_for_tag(browser,
     browser.get('https://www.instagram.com/explore/tags/'
                 + (tag[1:] if tag[:1] == '#' else tag))
     # update server calls
-    update_activity()
+    update_activity(username=username)
     sleep(2)
 
     # clicking load more
@@ -200,14 +200,14 @@ def get_links_for_tag(browser,
             body_elem.send_keys(Keys.END)
             sleep(2)
             # update server calls
-            update_activity()
+            update_activity(username=username)
     else:
         abort = False
         body_elem.send_keys(Keys.END)
         sleep(2)
         click_element(browser, load_button) # load_button.click()
         # update server calls
-        update_activity()
+        update_activity(username=username)
 
     body_elem.send_keys(Keys.HOME)
     sleep(1)
@@ -250,7 +250,7 @@ def get_links_for_tag(browser,
             before_load = total_links
             body_elem.send_keys(Keys.END)
             # update server calls
-            update_activity()
+            update_activity(username=username)
             sleep(1)
             body_elem.send_keys(Keys.HOME)
             sleep(1)
@@ -291,7 +291,7 @@ def get_links_for_username(browser,
     # Get  user profile page
     browser.get('https://www.instagram.com/' + username)
     # update server calls
-    update_activity()
+    update_activity(username=username)
 
     body_elem = browser.find_element_by_tag_name('body')
 
@@ -325,14 +325,14 @@ def get_links_for_username(browser,
             body_elem.send_keys(Keys.END)
             sleep(2)
             # update server calls
-            update_activity()
+            update_activity(username=username)
     else:
         abort = False
         body_elem.send_keys(Keys.END)
         sleep(2)
         click_element(browser, load_button) # load_button.click()
         # update server calls
-        update_activity()
+        update_activity(username=username)
 
     body_elem.send_keys(Keys.HOME)
     sleep(2)
@@ -375,7 +375,7 @@ def get_links_for_username(browser,
             before_load = total_links
             body_elem.send_keys(Keys.END)
             # update server calls
-            update_activity()
+            update_activity(username=username)
             sleep(1)
             body_elem.send_keys(Keys.HOME)
             sleep(1)
@@ -408,7 +408,7 @@ def check_link(browser,
 
     browser.get(link)
     # update server calls
-    update_activity()
+    update_activity(username=username)
     sleep(2)
 
     """Check if the Post is Valid/Exists"""
@@ -477,14 +477,14 @@ def check_link(browser,
         userlink = 'https://www.instagram.com/' + user_name
         browser.get(userlink)
         # update server calls
-        update_activity()
+        update_activity(username=username)
         sleep(1)
         num_followers = browser.execute_script(
             "return window._sharedData.entry_data."
             "ProfilePage[0].user.followed_by.count")
         browser.get(link)
         # update server calls
-        update_activity()
+        update_activity(username=username)
         sleep(1)
         logger.info('Number of Followers: {}'.format(num_followers))
 
@@ -546,7 +546,7 @@ def like_image(browser, username, blacklist, logger):
         click_element(browser, like_elem[0])
 
         logger.info('--> Image Liked!')
-        update_activity('likes')
+        update_activity('likes', username=username)
         if blacklist['enabled'] is True:
             action = 'liked'
             add_user_to_blacklist(
@@ -566,7 +566,7 @@ def get_tags(browser, url):
     """Gets all the tags of the given description in the url"""
     browser.get(url)
     # update server calls
-    update_activity()
+    update_activity(username=username)
     sleep(1)
 
     graphql = browser.execute_script(

--- a/instapy/like_util.py
+++ b/instapy/like_util.py
@@ -484,7 +484,7 @@ def check_link(browser,
         sleep(1)
         num_followers = browser.execute_script(
             "return window._sharedData.entry_data."
-            "ProfilePage[0].user.followed_by.count")
+            "ProfilePage[0].graphql.user.edge_followed_by.count")
         browser.get(link)
         # update server calls
         update_activity(insta_username=username)

--- a/instapy/like_util.py
+++ b/instapy/like_util.py
@@ -12,12 +12,12 @@ from .util import add_user_to_blacklist
 from .util import click_element
 
 
-def get_links_from_feed(browser, amount, num_of_search, logger):
+def get_links_from_feed(browser, amount, num_of_search, logger, insta_username):
     """Fetches random number of links from feed and returns a list of links"""
 
     browser.get('https://www.instagram.com')
     # update server calls
-    update_activity(username=username)
+    update_activity(insta_username=insta_username)
     sleep(2)
 
     for i in range(num_of_search + 1):
@@ -51,7 +51,8 @@ def get_links_for_location(browser,
                            amount,
                            logger,
                            media=None,
-                           skip_top_posts=True):
+                           skip_top_posts=True,
+                           insta_username=None):
 
     """Fetches the number of links specified
     by amount and returns a list of links"""
@@ -67,7 +68,7 @@ def get_links_for_location(browser,
 
     browser.get('https://www.instagram.com/explore/locations/' + location)
     # update server calls
-    update_activity(username=username)
+    update_activity(insta_username=insta_username)
     sleep(2)
 
     # clicking load more
@@ -93,14 +94,14 @@ def get_links_for_location(browser,
             body_elem.send_keys(Keys.END)
             sleep(2)
             # update server calls
-            update_activity(username=username)
+            update_activity(insta_username=insta_username)
     else:
         abort = False
         body_elem.send_keys(Keys.END)
         sleep(2)
         click_element(browser, load_button) # load_button.click()
         # update server calls
-        update_activity(username=username)
+        update_activity(insta_username=insta_username)
 
     body_elem.send_keys(Keys.HOME)
     sleep(1)
@@ -136,7 +137,7 @@ def get_links_for_location(browser,
             before_load = total_links
             body_elem.send_keys(Keys.END)
             # update server calls
-            update_activity(username=username)
+            update_activity(insta_username=insta_username)
             sleep(1)
             body_elem.send_keys(Keys.HOME)
             sleep(1)
@@ -158,7 +159,8 @@ def get_links_for_tag(browser,
                       amount,
                       logger,
                       media=None,
-                      skip_top_posts=True):
+                      skip_top_posts=True,
+                      insta_username=None):
     """Fetches the number of links specified
     by amount and returns a list of links"""
     if media is None:
@@ -174,7 +176,7 @@ def get_links_for_tag(browser,
     browser.get('https://www.instagram.com/explore/tags/'
                 + (tag[1:] if tag[:1] == '#' else tag))
     # update server calls
-    update_activity(username=username)
+    update_activity(insta_username=insta_username)
     sleep(2)
 
     # clicking load more
@@ -200,14 +202,14 @@ def get_links_for_tag(browser,
             body_elem.send_keys(Keys.END)
             sleep(2)
             # update server calls
-            update_activity(username=username)
+            update_activity(insta_username=insta_username)
     else:
         abort = False
         body_elem.send_keys(Keys.END)
         sleep(2)
         click_element(browser, load_button) # load_button.click()
         # update server calls
-        update_activity(username=username)
+        update_activity(insta_username=insta_username)
 
     body_elem.send_keys(Keys.HOME)
     sleep(1)
@@ -250,7 +252,7 @@ def get_links_for_tag(browser,
             before_load = total_links
             body_elem.send_keys(Keys.END)
             # update server calls
-            update_activity(username=username)
+            update_activity(insta_username=insta_username)
             sleep(1)
             body_elem.send_keys(Keys.HOME)
             sleep(1)
@@ -272,7 +274,8 @@ def get_links_for_username(browser,
                            amount,
                            logger,
                            randomize=False,
-                           media=None):
+                           media=None,
+                           insta_username=None):
 
     """Fetches the number of links specified
     by amount and returns a list of links"""
@@ -291,7 +294,7 @@ def get_links_for_username(browser,
     # Get  user profile page
     browser.get('https://www.instagram.com/' + username)
     # update server calls
-    update_activity(username=username)
+    update_activity(insta_username=insta_username)
 
     body_elem = browser.find_element_by_tag_name('body')
 
@@ -325,14 +328,14 @@ def get_links_for_username(browser,
             body_elem.send_keys(Keys.END)
             sleep(2)
             # update server calls
-            update_activity(username=username)
+            update_activity(insta_username=insta_username)
     else:
         abort = False
         body_elem.send_keys(Keys.END)
         sleep(2)
         click_element(browser, load_button) # load_button.click()
         # update server calls
-        update_activity(username=username)
+        update_activity(insta_username=insta_username)
 
     body_elem.send_keys(Keys.HOME)
     sleep(2)
@@ -375,7 +378,7 @@ def get_links_for_username(browser,
             before_load = total_links
             body_elem.send_keys(Keys.END)
             # update server calls
-            update_activity(username=username)
+            update_activity(insta_username=insta_username)
             sleep(1)
             body_elem.send_keys(Keys.HOME)
             sleep(1)
@@ -408,7 +411,7 @@ def check_link(browser,
 
     browser.get(link)
     # update server calls
-    update_activity(username=username)
+    update_activity(insta_username=username)
     sleep(2)
 
     """Check if the Post is Valid/Exists"""
@@ -477,14 +480,14 @@ def check_link(browser,
         userlink = 'https://www.instagram.com/' + user_name
         browser.get(userlink)
         # update server calls
-        update_activity(username=username)
+        update_activity(insta_username=username)
         sleep(1)
         num_followers = browser.execute_script(
             "return window._sharedData.entry_data."
             "ProfilePage[0].user.followed_by.count")
         browser.get(link)
         # update server calls
-        update_activity(username=username)
+        update_activity(insta_username=username)
         sleep(1)
         logger.info('Number of Followers: {}'.format(num_followers))
 
@@ -533,7 +536,7 @@ def check_link(browser,
     return False, user_name, is_video, 'None'
 
 
-def like_image(browser, username, blacklist, logger):
+def like_image(browser, username, blacklist, logger, insta_username):
     """Likes the browser opened image"""
     like_elem = browser.find_elements_by_xpath(
         "//a[@role='button']/span[text()='Like']/..")
@@ -546,7 +549,7 @@ def like_image(browser, username, blacklist, logger):
         click_element(browser, like_elem[0])
 
         logger.info('--> Image Liked!')
-        update_activity('likes', username=username)
+        update_activity('likes', insta_username=insta_username)
         if blacklist['enabled'] is True:
             action = 'liked'
             add_user_to_blacklist(
@@ -562,11 +565,11 @@ def like_image(browser, username, blacklist, logger):
         return False
 
 
-def get_tags(browser, url):
+def get_tags(browser, url, insta_username):
     """Gets all the tags of the given description in the url"""
     browser.get(url)
     # update server calls
-    update_activity(username=username)
+    update_activity(insta_username=insta_username)
     sleep(1)
 
     graphql = browser.execute_script(

--- a/instapy/login_util.py
+++ b/instapy/login_util.py
@@ -93,7 +93,7 @@ def login_user(browser,
     """Logins the user with the given username and password"""
     browser.get('https://www.instagram.com')
     # update server calls
-    update_activity()
+    update_activity(username=username)
 
     # try to load cookie from username
     try:
@@ -138,7 +138,7 @@ def login_user(browser,
         "//form/span/button[text()='Log in']")
     ActionChains(browser).move_to_element(login_button).click().perform()
     # update server calls
-    update_activity()
+    update_activity(username=username)
 
     if bypass_suspicious_attempt is True:
         bypass_suspicious_login(browser)

--- a/instapy/login_util.py
+++ b/instapy/login_util.py
@@ -93,7 +93,7 @@ def login_user(browser,
     """Logins the user with the given username and password"""
     browser.get('https://www.instagram.com')
     # update server calls
-    update_activity(username=username)
+    update_activity(insta_username=username)
 
     # try to load cookie from username
     try:
@@ -138,7 +138,7 @@ def login_user(browser,
         "//form/span/button[text()='Log in']")
     ActionChains(browser).move_to_element(login_button).click().perform()
     # update server calls
-    update_activity(username=username)
+    update_activity(insta_username=insta_username)
 
     if bypass_suspicious_attempt is True:
         bypass_suspicious_login(browser)

--- a/instapy/login_util.py
+++ b/instapy/login_util.py
@@ -138,7 +138,7 @@ def login_user(browser,
         "//form/span/button[text()='Log in']")
     ActionChains(browser).move_to_element(login_button).click().perform()
     # update server calls
-    update_activity(insta_username=insta_username)
+    update_activity(insta_username=username)
 
     if bypass_suspicious_attempt is True:
         bypass_suspicious_login(browser)

--- a/instapy/print_log_writer.py
+++ b/instapy/print_log_writer.py
@@ -9,7 +9,7 @@ def log_follower_num(browser, username, logfolder):
 
     followed_by = browser.execute_script(
         "return window._sharedData.""entry_data.ProfilePage[0]."
-        "user.followed_by.count")
+        "graphql.user.edge_followed_by.count")
 
     with open('{}followerNum.txt'.format(logfolder), 'a') as numFile:
         numFile.write(

--- a/instapy/unfollow_util.py
+++ b/instapy/unfollow_util.py
@@ -42,14 +42,15 @@ def unfollow(browser,
              sleep_delay,
              onlyNotFollowMe,
              logger,
-             logfolder):
+             logfolder,
+             insta_username):
 
     """unfollows the given amount of users"""
     unfollowNum = 0
 
     browser.get('https://www.instagram.com/' + username)
     # update server calls
-    update_activity(username=username)
+    update_activity(insta_username=insta_username)
 
     #  check how many poeple we are following
     #  throw RuntimeWarning if we are 0 people following
@@ -101,7 +102,7 @@ def unfollow(browser,
                         unfollowNum += 1
                         click_element(browser, follow_button) # follow_button.click()
                         
-                        update_activity('unfollows', username=username)
+                        update_activity('unfollows', insta_username=insta_username)
 
                         delete_line_from_file('{0}{1}_followedPool.csv'.format(logfolder, username), person +
                                               ",\n", logger)
@@ -263,7 +264,7 @@ def unfollow(browser,
             
             click_element(browser, following_link[0]) # following_link[0].click()
             # update server calls
-            update_activity(username=username)
+            update_activity(insta_username=insta_username)
         except BaseException as e:
             logger.error("following_link error {}".format(str(e)))
 
@@ -310,7 +311,7 @@ def unfollow(browser,
                 if person not in dont_include:
                     unfollowNum += 1
                     click_element(browser, button) # button.click()
-                    update_activity('unfollows', username=username)
+                    update_activity('unfollows', insta_username=insta_username)
 
                     logger.info(
                         '--> Ongoing Unfollow {}, now unfollowing: {}'
@@ -330,7 +331,7 @@ def unfollow(browser,
     return unfollowNum
 
 
-def follow_user(browser, follow_restrict, login, user_name, blacklist, logger, logfolder):
+def follow_user(browser, follow_restrict, login, user_name, blacklist, logger, logfolder, insta_username):
     """Follows the user of the currently opened image"""
 
     try:
@@ -342,7 +343,7 @@ def follow_user(browser, follow_restrict, login, user_name, blacklist, logger, l
 
         if follow_button.is_displayed():
             click_element(browser, follow_button) # follow_button.click()
-            update_activity('follows', username=user_name)
+            update_activity('follows', insta_username=insta_username)
         else:
             browser.execute_script(
                 "arguments[0].style.visibility = 'visible'; "
@@ -350,7 +351,7 @@ def follow_user(browser, follow_restrict, login, user_name, blacklist, logger, l
                 "arguments[0].style.width = '10px'; "
                 "arguments[0].style.opacity = 1", follow_button)
             click_element(browser, follow_button) # follow_button.click()
-            update_activity('follows', username=user_name)
+            update_activity('follows', insta_username=insta_username)
 
         logger.info('--> Now following')
         log_followed_pool(login, user_name, logger, logfolder)
@@ -368,7 +369,7 @@ def follow_user(browser, follow_restrict, login, user_name, blacklist, logger, l
         return 0
 
 
-def unfollow_user(browser, logger, username):
+def unfollow_user(browser, logger, username, insta_username):
     """Unfollows the user of the currently opened image"""
 
     unfollow_button = browser.find_element_by_xpath(
@@ -377,7 +378,7 @@ def unfollow_user(browser, logger, username):
     if unfollow_button.text == 'Following':
         click_element(browser, unfollow_button) # unfollow_button.send_keys("\n")
         
-        update_activity('unfollows', username=username)
+        update_activity('unfollows', insta_username=insta_username)
         logger.warning('--> User unfollowed due to Inappropriate Content')
         sleep(3)
         return 1
@@ -388,19 +389,19 @@ def follow_given_user(browser,
                       follow_restrict,
                       blacklist,
                       logger,
-                      logfolder
-                      username):
+                      logfolder,
+                      insta_username):
     """Follows a given user."""
     browser.get('https://www.instagram.com/' + acc_to_follow)
     # update server calls
-    update_activity(username=username)
+    update_activity(insta_username=insta_username)
     logger.info('--> {} instagram account is opened...'.format(acc_to_follow))
 
     try:
         sleep(10)
         follow_button = browser.find_element_by_xpath("//*[text()='Follow']")
         click_element(browser, follow_button) # unfollow_button.send_keys("\n")
-        update_activity('follows', username=username)
+        update_activity('follows', insta_username=insta_username)
         logger.info('---> Now following: {}'.format(acc_to_follow))
         follow_restrict[acc_to_follow] = follow_restrict.get(
             acc_to_follow, 0) + 1
@@ -432,7 +433,8 @@ def follow_through_dialog(browser,
                           logger,
                           logfolder,
                           follow_times,
-                          callbacks=[]):
+                          callbacks=[],
+                          insta_username=None):
     sleep(2)
     person_followed = []
     real_amount = amount
@@ -523,7 +525,7 @@ def follow_through_dialog(browser,
                 click_element(browser, button) # button.send_keys("\n")
                 log_followed_pool(login, person, logger, logfolder)
 
-                update_activity('follows', username=user_name)
+                update_activity('follows', insta_username=insta_username)
 
                 follow_restrict[person] = follow_restrict.get(person, 0) + 1
 
@@ -567,11 +569,12 @@ def get_given_user_followers(browser,
                              dont_include,
                              login,
                              randomize,
-                             logger):
+                             logger,
+                             insta_username):
 
     browser.get('https://www.instagram.com/' + user_name)
     # update server calls
-    update_activity(username=username)
+    update_activity(insta_username=insta_username)
 
     # check how many poeple are following this user.
     # throw RuntimeWarning if we are 0 people following this user or
@@ -587,7 +590,7 @@ def get_given_user_followers(browser,
         '//a[@href="/' + user_name + '/followers/"]')
     click_element(browser, following_link[0]) # following_link.send_keys("\n")
     # update server calls
-    update_activity(username=username)
+    update_activity(insta_username=insta_username)
 
     sleep(2)
 
@@ -632,11 +635,12 @@ def get_given_user_following(browser,
                              dont_include,
                              login,
                              randomize,
-                             logger):
+                             logger,
+                             insta_username):
 
     browser.get('https://www.instagram.com/' + user_name)
     # update server calls
-    update_activity(username=username)
+    update_activity(insta_username=insta_username)
 
     #  check how many poeple are following this user.
     #  throw RuntimeWarning if we are 0 people following this user
@@ -651,7 +655,7 @@ def get_given_user_following(browser,
             '//a[@href="/' + user_name + '/following/"]')
         click_element(browser, following_link[0]) # following_link.send_keys("\n")
         # update server calls
-        update_activity(username=username)
+        update_activity(insta_username=insta_username)
     except BaseException as e:
         logger.error("following_link error {}".format(str(e)))
 
@@ -703,11 +707,12 @@ def follow_given_user_followers(browser,
                                 blacklist,
                                 logger,
                                 logfolder,
-                                follow_times):
+                                follow_times,
+                                insta_username):
 
     browser.get('https://www.instagram.com/' + user_name)
     # update server calls
-    update_activity(username=username)
+    update_activity(insta_username=insta_username)
 
     #  check how many poeple are following this user.
     #  throw RuntimeWarning if we are 0 people following this user
@@ -722,7 +727,7 @@ def follow_given_user_followers(browser,
             '//a[@href="/' + user_name + '/followers/"]')
         click_element(browser, following_link[0]) # following_link.send_keys("\n")
         # update server calls
-        update_activity(username=username)
+        update_activity(insta_username=insta_username)
     except BaseException as e:
         logger.error("following_link error {}".format(str(e)))
 
@@ -755,11 +760,12 @@ def follow_given_user_following(browser,
                                 blacklist,
                                 logger,
                                 logfolder,
-                                follow_times):
+                                follow_times,
+                                insta_username):
 
     browser.get('https://www.instagram.com/' + user_name)
     # update server calls
-    update_activity(username=username)
+    update_activity(insta_username=insta_username)
 
     #  check how many poeple are following this user.
     #  throw RuntimeWarning if we are 0 people following this user
@@ -774,7 +780,7 @@ def follow_given_user_following(browser,
             '//a[@href="/' + user_name + '/following/"]')
         click_element(browser, following_link[0]) # following_link.send_keys("\n")
         # update server calls
-        update_activity(username=username)
+        update_activity(insta_username=insta_username)
     except BaseException as e:
         logger.error("following_link error {}".format(str(e)))
 

--- a/instapy/unfollow_util.py
+++ b/instapy/unfollow_util.py
@@ -42,15 +42,14 @@ def unfollow(browser,
              sleep_delay,
              onlyNotFollowMe,
              logger,
-             logfolder,
-             insta_username):
+             logfolder):
 
     """unfollows the given amount of users"""
     unfollowNum = 0
 
     browser.get('https://www.instagram.com/' + username)
     # update server calls
-    update_activity(insta_username=insta_username)
+    update_activity(insta_username=username)
 
     #  check how many poeple we are following
     #  throw RuntimeWarning if we are 0 people following
@@ -102,7 +101,7 @@ def unfollow(browser,
                         unfollowNum += 1
                         click_element(browser, follow_button) # follow_button.click()
                         
-                        update_activity('unfollows', insta_username=insta_username)
+                        update_activity('unfollows', insta_username=username)
 
                         delete_line_from_file('{0}{1}_followedPool.csv'.format(logfolder, username), person +
                                               ",\n", logger)
@@ -136,7 +135,7 @@ def unfollow(browser,
             browser.get(
                 'https://www.instagram.com/' + username + '/?__a=1')
             pre = browser.find_element_by_tag_name("pre").text
-            user_data = json.loads(pre)['user']
+            user_data = json.loads(pre)['graphql']['user']
         except BaseException as e:
             print("unable to get user information\n", str(e))
 
@@ -264,7 +263,7 @@ def unfollow(browser,
             
             click_element(browser, following_link[0]) # following_link[0].click()
             # update server calls
-            update_activity(insta_username=insta_username)
+            update_activity(insta_username=username)
         except BaseException as e:
             logger.error("following_link error {}".format(str(e)))
 
@@ -311,7 +310,7 @@ def unfollow(browser,
                 if person not in dont_include:
                     unfollowNum += 1
                     click_element(browser, button) # button.click()
-                    update_activity('unfollows', insta_username=insta_username)
+                    update_activity('unfollows', insta_username=username)
 
                     logger.info(
                         '--> Ongoing Unfollow {}, now unfollowing: {}'

--- a/instapy/unfollow_util.py
+++ b/instapy/unfollow_util.py
@@ -331,7 +331,7 @@ def unfollow(browser,
     return unfollowNum
 
 
-def follow_user(browser, follow_restrict, login, user_name, blacklist, logger, logfolder, insta_username):
+def follow_user(browser, follow_restrict, login, user_name, blacklist, logger, logfolder):
     """Follows the user of the currently opened image"""
 
     try:
@@ -343,7 +343,7 @@ def follow_user(browser, follow_restrict, login, user_name, blacklist, logger, l
 
         if follow_button.is_displayed():
             click_element(browser, follow_button) # follow_button.click()
-            update_activity('follows', insta_username=insta_username)
+            update_activity('follows', insta_username=login)
         else:
             browser.execute_script(
                 "arguments[0].style.visibility = 'visible'; "
@@ -351,7 +351,7 @@ def follow_user(browser, follow_restrict, login, user_name, blacklist, logger, l
                 "arguments[0].style.width = '10px'; "
                 "arguments[0].style.opacity = 1", follow_button)
             click_element(browser, follow_button) # follow_button.click()
-            update_activity('follows', insta_username=insta_username)
+            update_activity('follows', insta_username=login)
 
         logger.info('--> Now following')
         log_followed_pool(login, user_name, logger, logfolder)
@@ -369,7 +369,7 @@ def follow_user(browser, follow_restrict, login, user_name, blacklist, logger, l
         return 0
 
 
-def unfollow_user(browser, logger, username, insta_username):
+def unfollow_user(browser, logger, username):
     """Unfollows the user of the currently opened image"""
 
     unfollow_button = browser.find_element_by_xpath(
@@ -378,7 +378,7 @@ def unfollow_user(browser, logger, username, insta_username):
     if unfollow_button.text == 'Following':
         click_element(browser, unfollow_button) # unfollow_button.send_keys("\n")
         
-        update_activity('unfollows', insta_username=insta_username)
+        update_activity('unfollows', insta_username=username)
         logger.warning('--> User unfollowed due to Inappropriate Content')
         sleep(3)
         return 1

--- a/instapy/unfollow_util.py
+++ b/instapy/unfollow_util.py
@@ -49,7 +49,7 @@ def unfollow(browser,
 
     browser.get('https://www.instagram.com/' + username)
     # update server calls
-    update_activity()
+    update_activity(username=username)
 
     #  check how many poeple we are following
     #  throw RuntimeWarning if we are 0 people following
@@ -101,7 +101,7 @@ def unfollow(browser,
                         unfollowNum += 1
                         click_element(browser, follow_button) # follow_button.click()
                         
-                        update_activity('unfollows')
+                        update_activity('unfollows', username=username)
 
                         delete_line_from_file('{0}{1}_followedPool.csv'.format(logfolder, username), person +
                                               ",\n", logger)
@@ -263,7 +263,7 @@ def unfollow(browser,
             
             click_element(browser, following_link[0]) # following_link[0].click()
             # update server calls
-            update_activity()
+            update_activity(username=username)
         except BaseException as e:
             logger.error("following_link error {}".format(str(e)))
 
@@ -274,7 +274,7 @@ def unfollow(browser,
             "//div[text()='Following']/following-sibling::div")
 
         # scroll down the page
-        scroll_bottom(browser, dialog, allfollowing)
+        scroll_bottom(browser, dialog, allfollowing, username)
 
         # get persons, unfollow buttons, and length of followed pool
         person_list_a = dialog.find_elements_by_tag_name("a")
@@ -310,7 +310,7 @@ def unfollow(browser,
                 if person not in dont_include:
                     unfollowNum += 1
                     click_element(browser, button) # button.click()
-                    update_activity('unfollows')
+                    update_activity('unfollows', username=username)
 
                     logger.info(
                         '--> Ongoing Unfollow {}, now unfollowing: {}'
@@ -342,7 +342,7 @@ def follow_user(browser, follow_restrict, login, user_name, blacklist, logger, l
 
         if follow_button.is_displayed():
             click_element(browser, follow_button) # follow_button.click()
-            update_activity('follows')
+            update_activity('follows', username=user_name)
         else:
             browser.execute_script(
                 "arguments[0].style.visibility = 'visible'; "
@@ -350,7 +350,7 @@ def follow_user(browser, follow_restrict, login, user_name, blacklist, logger, l
                 "arguments[0].style.width = '10px'; "
                 "arguments[0].style.opacity = 1", follow_button)
             click_element(browser, follow_button) # follow_button.click()
-            update_activity('follows')
+            update_activity('follows', username=user_name)
 
         logger.info('--> Now following')
         log_followed_pool(login, user_name, logger, logfolder)
@@ -368,7 +368,7 @@ def follow_user(browser, follow_restrict, login, user_name, blacklist, logger, l
         return 0
 
 
-def unfollow_user(browser, logger):
+def unfollow_user(browser, logger, username):
     """Unfollows the user of the currently opened image"""
 
     unfollow_button = browser.find_element_by_xpath(
@@ -377,7 +377,7 @@ def unfollow_user(browser, logger):
     if unfollow_button.text == 'Following':
         click_element(browser, unfollow_button) # unfollow_button.send_keys("\n")
         
-        update_activity('unfollows')
+        update_activity('unfollows', username=username)
         logger.warning('--> User unfollowed due to Inappropriate Content')
         sleep(3)
         return 1
@@ -388,18 +388,19 @@ def follow_given_user(browser,
                       follow_restrict,
                       blacklist,
                       logger,
-                      logfolder):
+                      logfolder
+                      username):
     """Follows a given user."""
     browser.get('https://www.instagram.com/' + acc_to_follow)
     # update server calls
-    update_activity()
+    update_activity(username=username)
     logger.info('--> {} instagram account is opened...'.format(acc_to_follow))
 
     try:
         sleep(10)
         follow_button = browser.find_element_by_xpath("//*[text()='Follow']")
         click_element(browser, follow_button) # unfollow_button.send_keys("\n")
-        update_activity('follows')
+        update_activity('follows', username=username)
         logger.info('---> Now following: {}'.format(acc_to_follow))
         follow_restrict[acc_to_follow] = follow_restrict.get(
             acc_to_follow, 0) + 1
@@ -444,7 +445,7 @@ def follow_through_dialog(browser,
       "//div[text()='Followers' or text()='Following']/following-sibling::div")
 
     # scroll down the page
-    scroll_bottom(browser, dialog, allfollowing)
+    scroll_bottom(browser, dialog, allfollowing, user_name)
 
     # get follow buttons. This approch will find the follow buttons and
     # ignore the Unfollow/Requested buttons.
@@ -460,7 +461,7 @@ def follow_through_dialog(browser,
     while (total_list < amount) and not abort:
         amount_left = amount - total_list
         before_scroll = total_list
-        scroll_bottom(browser, dialog, amount_left)
+        scroll_bottom(browser, dialog, amount_left, user_name)
         sleep(1)
         follow_buttons = dialog.find_elements_by_xpath(
             "//div/div/span/button[text()='Follow']")
@@ -522,7 +523,7 @@ def follow_through_dialog(browser,
                 click_element(browser, button) # button.send_keys("\n")
                 log_followed_pool(login, person, logger, logfolder)
 
-                update_activity('follows')
+                update_activity('follows', username=user_name)
 
                 follow_restrict[person] = follow_restrict.get(person, 0) + 1
 
@@ -570,7 +571,7 @@ def get_given_user_followers(browser,
 
     browser.get('https://www.instagram.com/' + user_name)
     # update server calls
-    update_activity()
+    update_activity(username=username)
 
     # check how many poeple are following this user.
     # throw RuntimeWarning if we are 0 people following this user or
@@ -586,7 +587,7 @@ def get_given_user_followers(browser,
         '//a[@href="/' + user_name + '/followers/"]')
     click_element(browser, following_link[0]) # following_link.send_keys("\n")
     # update server calls
-    update_activity()
+    update_activity(username=username)
 
     sleep(2)
 
@@ -595,7 +596,7 @@ def get_given_user_followers(browser,
         "//div[text()='Followers']/following-sibling::div")
 
     # scroll down the page
-    scroll_bottom(browser, dialog, allfollowing)
+    scroll_bottom(browser, dialog, allfollowing, user_name)
 
     # get follow buttons. This approch will find the follow buttons and
     # ignore the Unfollow/Requested buttons.
@@ -635,7 +636,7 @@ def get_given_user_following(browser,
 
     browser.get('https://www.instagram.com/' + user_name)
     # update server calls
-    update_activity()
+    update_activity(username=username)
 
     #  check how many poeple are following this user.
     #  throw RuntimeWarning if we are 0 people following this user
@@ -650,7 +651,7 @@ def get_given_user_following(browser,
             '//a[@href="/' + user_name + '/following/"]')
         click_element(browser, following_link[0]) # following_link.send_keys("\n")
         # update server calls
-        update_activity()
+        update_activity(username=username)
     except BaseException as e:
         logger.error("following_link error {}".format(str(e)))
 
@@ -661,7 +662,7 @@ def get_given_user_following(browser,
         "//div[text()='Following']/following-sibling::div")
 
     # scroll down the page
-    scroll_bottom(browser, dialog, allfollowing)
+    scroll_bottom(browser, dialog, allfollowing, user_name)
 
     # get follow buttons. This approch will find the follow buttons and
     # ignore the Unfollow/Requested buttons.
@@ -706,7 +707,7 @@ def follow_given_user_followers(browser,
 
     browser.get('https://www.instagram.com/' + user_name)
     # update server calls
-    update_activity()
+    update_activity(username=username)
 
     #  check how many poeple are following this user.
     #  throw RuntimeWarning if we are 0 people following this user
@@ -721,7 +722,7 @@ def follow_given_user_followers(browser,
             '//a[@href="/' + user_name + '/followers/"]')
         click_element(browser, following_link[0]) # following_link.send_keys("\n")
         # update server calls
-        update_activity()
+        update_activity(username=username)
     except BaseException as e:
         logger.error("following_link error {}".format(str(e)))
 
@@ -758,7 +759,7 @@ def follow_given_user_following(browser,
 
     browser.get('https://www.instagram.com/' + user_name)
     # update server calls
-    update_activity()
+    update_activity(username=username)
 
     #  check how many poeple are following this user.
     #  throw RuntimeWarning if we are 0 people following this user
@@ -773,7 +774,7 @@ def follow_given_user_following(browser,
             '//a[@href="/' + user_name + '/following/"]')
         click_element(browser, following_link[0]) # following_link.send_keys("\n")
         # update server calls
-        update_activity()
+        update_activity(username=username)
     except BaseException as e:
         logger.error("following_link error {}".format(str(e)))
 

--- a/instapy/util.py
+++ b/instapy/util.py
@@ -87,6 +87,22 @@ def update_activity(action=None, insta_username=None):
         # commit
         conn.commit()
 
+def dict_factory(cursor, row):
+    """Map row data to column name"""
+    d = {}
+    for idx, col in enumerate(cursor.description):
+        d[col[0]] = row[idx]
+    return d
+
+def get_activity(insta_username):
+    """Get current activity from database"""
+    conn = sqlite3.connect('./db/instapy.db')
+    conn.row_factory = dict_factory
+    with conn:
+        cur = conn.cursor()
+        cur.execute("SELECT * FROM statistics WHERE created == date('now') AND username == ?", (insta_username,))
+        row = cur.fetchone()
+    return row
 
 def add_user_to_blacklist(browser, username, campaign, action, logger, logfolder):
 

--- a/instapy/util.py
+++ b/instapy/util.py
@@ -39,7 +39,7 @@ def validate_username(browser,
     return True
 
 
-def update_activity(action=None, username):
+def update_activity(action=None, insta_username=None):
     """Record every Instagram server call (page load, content load, likes,
     comments, follows, unfollow)."""
 
@@ -56,13 +56,13 @@ def update_activity(action=None, username):
             pass
 
         # collect today data
-        cur.execute("SELECT * FROM statistics WHERE created == date('now') AND username == %s", (username))
+        cur.execute("SELECT * FROM statistics WHERE created == date('now') AND username == ?", (insta_username,))
         data = cur.fetchone()
 
         if data is None:
             # create a new record for the new day
             cur.execute("INSERT INTO statistics VALUES "
-                        "(0, 0, 0, 0, 1, date('now'), %s)", (username))
+                        "(0, 0, 0, 0, 1, date('now'), ?)", (insta_username,))
         else:
             # sqlite3.Row' object does not support item assignment -> so,
             # convert it into a new dict
@@ -81,9 +81,9 @@ def update_activity(action=None, username):
 
             sql = ("UPDATE statistics set likes = ?, comments = ?, "
                    "follows = ?, unfollows = ?, server_calls = ? "
-                   "WHERE created == date('now') AND username == %s", (username))
+                   "WHERE created == date('now') AND username == ?")
             cur.execute(sql, (data['likes'], data['comments'], data['follows'],
-                              data['unfollows'], data['server_calls']))
+                              data['unfollows'], data['server_calls'], insta_username))
         # commit
         conn.commit()
 


### PR DESCRIPTION
Added updates to store the account's Instagram username in the statistics table. Useful if you run with multiple accounts and want to see stats. Also added DB check to see if any likes/follows have been completed already to prevent going over daily limits when Selenium crashes. Set this to default off.