### PR TITLE
Removed unnecessary import condition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,6 +96,10 @@ ENV/
 # Mac files
 .DS_Store
 
+# Storage
+instapy.db
+logs/
+
 # Editors
 .idea
 .vscode

--- a/instapy/login_util.py
+++ b/instapy/login_util.py
@@ -91,6 +91,9 @@ def login_user(browser,
                switch_language=True,
                bypass_suspicious_attempt=False):
     """Logins the user with the given username and password"""
+    assert username, 'Username not provided'
+    assert password, 'Password not provided'
+
     browser.get('https://www.instagram.com')
     # update server calls
     update_activity()
@@ -121,10 +124,6 @@ def login_user(browser,
         print("Issue with cookie for user " + username
               + ". Creating new cookie...")
 
-
-
-
-
     # Changes instagram language to english, to ensure no errors ensue from
     # having the site on a different language
     # Might cause problems if the OS language is english
@@ -137,7 +136,6 @@ def login_user(browser,
         "//article/div/div/p/a[text()='Log in']")
     if login_elem is not None:
         ActionChains(browser).move_to_element(login_elem).click().perform()
-
 
     # Enter username and password and logs the user in
     # Sometimes the element name isn't 'Username' and 'Password'

--- a/instapy/settings.py
+++ b/instapy/settings.py
@@ -1,3 +1,10 @@
+import os
+
+
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
 class Settings:
-    database_location = "./db/instapy.db"
-    browser_location = "./assets/chromedriver"
+    log_location = os.path.join(BASE_DIR, 'logs')
+    database_location = os.path.join(BASE_DIR, 'db', 'instapy.db')
+    chromedriver_location = os.path.join(BASE_DIR, 'assets', 'chromedriver')

--- a/quickstart.py
+++ b/quickstart.py
@@ -4,15 +4,18 @@ insta_username = ''
 insta_password = ''
 
 # set headless_browser=True if you want to run InstaPy on a server
-try:
-    # set these if you're locating the library in the /usr/lib/pythonX.X/ directory
-    # Settings.database_location = '/path/to/instapy.db'
-    # Settings.browser_location = '/path/to/chromedriver'
 
-    session = InstaPy(username=insta_username,
-                      password=insta_password,
-                      headless_browser=False,
-                      multi_logs=True)
+# set these in instapy/settings.py if you're locating the
+# library in the /usr/lib/pythonX.X/ directory:
+#   Settings.database_location = '/path/to/instapy.db'
+#   Settings.chromedriver_location = '/path/to/chromedriver'
+
+session = InstaPy(username=insta_username,
+                  password=insta_password,
+                  headless_browser=False,
+                  multi_logs=True)
+
+try:
     session.login()
 
     # settings
@@ -24,6 +27,9 @@ try:
 
     # actions
     session.like_by_tags(['natgeo'], amount=1)
+
+except Exception as e:
+    print(e)
 
 finally:
     # end the bot session

--- a/tests/test_instapy.py
+++ b/tests/test_instapy.py
@@ -1,4 +1,8 @@
-from instapy.instapy import InstaPy
+from unittest.mock import patch
+
+import pytest
+
+from instapy.instapy import InstaPy, InstaPyError
 
 
 def test_like_by_users_with_no_usernames():
@@ -6,3 +10,12 @@ def test_like_by_users_with_no_usernames():
     instapy = InstaPy(selenium_local_session=False)
     res = instapy.like_by_users([])
     assert isinstance(res, InstaPy)
+
+
+@patch('instapy.instapy.load_follow_restriction')
+def test_set_use_clarifai_raises_on_windows(load_follow_restriction):
+    """windows not supported"""
+    instapy = InstaPy(selenium_local_session=False)
+    with patch('instapy.instapy.os'):
+        with pytest.raises(InstaPyError):
+            instapy.set_use_clarifai()


### PR DESCRIPTION
Removed the import condition for clarify which causes an exception. Fixes #1579 

Moved the session creation outside try-except to prevent error for `session is undefined` and added printing of the exception to get better stacktraces in issues.

Made the paths in settings relative to settings path, otherwise exception if ran from different directory. Changed browser_location as it points to the chromedriver specifically. Ref #1627 

Asserting username and passwords to prevent `None type errors`