### PR TITLE
Logs in separate files for every start

### DIFF
--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -167,7 +167,7 @@ class InstaPy:
             # initialize and setup logging system for the InstaPy object
             logger = logging.getLogger(__name__)
             logger.setLevel(logging.DEBUG)
-            file_handler = logging.FileHandler('{}general.log'.format(self.logfolder))
+            file_handler = logging.FileHandler('{}'.format(self.logfolder) + 'general' + datetime.now().strftime('_%Y_%m_%d_%H_%M_%S') + '.log')
             file_handler.setLevel(logging.DEBUG)
             extra = {"username": self.username}
             logger_formatter = logging.Formatter('%(levelname)s [%(asctime)s] [%(username)s]  %(message)s', datefmt='%Y-%m-%d %H:%M:%S')


### PR DESCRIPTION
Change "general.log" to "general_2018_03_02_16_34_48.log".
This helps to find the correct log if necessary.  
For me it was much more useful than a single large file.
Perhaps it will be needed by someone else.