### PR TITLE
updates chrome driver version (2.36)

### DIFF
--- a/docs/How_To_DO_Ubuntu_on_Digital_Ocean.md
+++ b/docs/How_To_DO_Ubuntu_on_Digital_Ocean.md
@@ -35,7 +35,7 @@ $ sudo rm google-chrome-stable_current_amd64.deb
 
 ```bash
 $ git clone https://github.com/timgrossmann/InstaPy.git
-$ wget "https://chromedriver.storage.googleapis.com/2.34/chromedriver_linux64.zip"
+$ wget "https://chromedriver.storage.googleapis.com/2.36/chromedriver_linux64.zip"
 $ unzip chromedriver_linux64
 $ mv chromedriver InstaPy/assets/chromedriver
 $ chmod +x InstaPy/assets/chromedriver

--- a/docs/How_To_DO_Ubuntu_on_Digital_Ocean.md
+++ b/docs/How_To_DO_Ubuntu_on_Digital_Ocean.md
@@ -35,7 +35,8 @@ $ sudo rm google-chrome-stable_current_amd64.deb
 
 ```bash
 $ git clone https://github.com/timgrossmann/InstaPy.git
-$ wget "https://chromedriver.storage.googleapis.com/2.36/chromedriver_linux64.zip"
+$ latest_version=$(wget https://chromedriver.storage.googleapis.com/LATEST_RELEASE -O -)
+$ wget https://chromedriver.storage.googleapis.com/${latest_version}/chromedriver_linux64.zip
 $ unzip chromedriver_linux64
 $ mv chromedriver InstaPy/assets/chromedriver
 $ chmod +x InstaPy/assets/chromedriver


### PR DESCRIPTION
I tried to setup InstaPy on cloud server following the instructions on docs, and there was an error 

> ImportError: sys.meta_path is None, Python is likely shutting down

So looking through the traceback I've found this 

> InstaPyError: chromedriver 2.34 is not supported, expects 2.36+

Updating chromedriver solved the problem