### PR TITLE
Additionally provide html for no element found errors

### DIFF
--- a/quickstart.py
+++ b/quickstart.py
@@ -1,4 +1,8 @@
-import traceback
+import os
+import time
+from tempfile import gettempdir
+
+from selenium.common.exceptions import NoSuchElementException
 
 from instapy import InstaPy
 
@@ -31,8 +35,15 @@ try:
     session.like_by_tags(['natgeo'], amount=1)
 
 except Exception as exc:
+    # if changes to IG layout, upload the file to help us locate the change
+    if isinstance(exc, NoSuchElementException):
+        file_path = os.path.join(gettempdir(), '{}.html'.format(time.strftime('%Y%m%d-%H%M%S')))
+        with open(file_path, 'wb') as fp:
+            fp.write(session.browser.page_source.encode('utf8'))
+        print('{0}\nIf raising an issue, please also upload the file located at:\n{1}\n{0}'.format(
+            '*' * 70, file_path))
     # full stacktrace when raising Github issue
-    traceback.print_exc(exc)
+    raise
 
 finally:
     # end the bot session


### PR DESCRIPTION
I've noticed that `traceback` fails with selenium errors :(
But, can just raise and have same effect...

Also, create file to help us debug issues with elements not found: ref #1621 