### PR TITLE
Fix Ignore if contains

### DIFF
--- a/instapy/like_util.py
+++ b/instapy/like_util.py
@@ -536,7 +536,7 @@ def check_link(browser, link, dont_like, ignore_if_contains, ignore_users, usern
         return True, user_name, is_video, 'Username'
 
     if any((word in image_text for word in ignore_if_contains)):
-        return True, user_name, is_video, 'None'
+        return False, user_name, is_video, 'None'
 
     dont_like_regex = []
 


### PR DESCRIPTION
If any of the words that are given in this list appear in the description, we want to interact with the post instead of passing it as inappropriate