### PR TITLE
Detect likers past 20 on posts by scrolling

### DIFF
--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -1773,7 +1773,7 @@ class InstaPy:
 
         return
 
-    def set_dont_unfollow_active_users(self, enabled=False, posts=4):
+    def set_dont_unfollow_active_users(self, enabled=False, posts=4, boundary=500):
         """Prevents unfollow followers who have liked one of
         your latest X posts"""
 
@@ -1785,6 +1785,7 @@ class InstaPy:
         active_users = get_active_users(self.browser,
                                         self.username,
                                         posts,
+                                        boundary,
                                         self.logger)
 
         for user in active_users:

--- a/instapy/util.py
+++ b/instapy/util.py
@@ -139,16 +139,17 @@ def get_active_users(browser, username, posts, boundary, logger):
     # posts argument is the number of posts to collect usernames
     logger.info("Getting active users who liked the latest {} posts:\n  {}".format(posts, message))
 
-    for count in range(1, posts):
+    for count in range(1, posts + 1):
         try:
+            sleep_actual(2)
             likes_count = format_number(browser.find_element_by_xpath(
                 "//a[contains(@class, '_nzn1h')]/span").text)
 
             browser.find_element_by_xpath(
                 "//a[contains(@class, '_nzn1h')]").click()
-            sleep(4)
+            sleep_actual(5)
 
-            logger.info("We are here")
+
             dialog = browser.find_element_by_xpath(
                 "//div[text()='Likes']/following-sibling::div")
 
@@ -165,14 +166,13 @@ def get_active_users(browser, username, posts, boundary, logger):
                         return false;}
                     ''', dialog)
 
-                logger.info("Scrolled Once")
                 if sc_rolled > 91 or too_many_requests > 1:  # old value 100
                     logger.info("Too Many Requests sent! ~will sleep some :>")
-                    sleep(600)
+                    sleep_actual(600)
                     sc_rolled = 0
                     too_many_requests = 0 if too_many_requests >= 1 else too_many_requests
                 else:
-                    sleep(4.2)  # old value 5.6
+                    sleep_actual(1.2)  # old value 5.6
                     sc_rolled += 1
 
                 tmp_list = browser.find_elements_by_xpath(
@@ -193,27 +193,28 @@ def get_active_users(browser, username, posts, boundary, logger):
                             too_many_requests += 1
                             scroll_it = True
                             nap_it = 4 if try_again == 0 else 7
-                            sleep(nap_it)
+                            sleep_actual(nap_it)
 
             tmp_list = browser.find_elements_by_xpath(
                 "//a[contains(@class, '_2g7d5')]")
-            logger.info("Post {}  |  Likers: found {}, catched {}".format(count + 1, likes_count, len(tmp_list)))
+            logger.info("Post {}  |  Likers: found {}, catched {}".format(count, likes_count, len(tmp_list)))
 
         except NoSuchElementException:
             try:
                 tmp_list = browser.find_elements_by_xpath(
                     "//div[contains(@class, '_3gwk6')]/a")
+                if len(tmp_list) > 0:
+                    logger.info("Post {}  |  Likers: found {}, catched {}".format(count, len(tmp_list), len(tmp_list)))
             except NoSuchElementException:
                 logger.error('There is some error searching active users')
 
         if len(tmp_list) is not 0:
             for user in tmp_list:
-                logger.info(user.text)
                 active_users.append(user.text)
 
-        sleep(1)
+        sleep_actual(1)
         # if not reached posts(parameter) value, continue
-        if count + 1 != posts:
+        if count +1 != posts +1 and count != 0:
             try:
                 # click next button
                 browser.find_element_by_xpath(
@@ -224,12 +225,14 @@ def get_active_users(browser, username, posts, boundary, logger):
 
     real_time = time.time()
     diff_in_minutes = int((real_time - start_time) / 60)
+    diff_in_seconds = int((real_time - start_time) % 60)
     # delete duplicated users
     active_users = list(set(active_users))
     logger.info(
-        "Gathered total of {} unique active followers from the latest {} posts in {} minutes".format(len(active_users),
+        "Gathered total of {} unique active followers from the latest {} posts in {} minutes and {} seconds".format(len(active_users),
                                                                                                      posts,
-                                                                                                     diff_in_minutes))
+                                                                                                     diff_in_minutes,
+                                                                                                     diff_in_seconds))
 
     return active_users
 


### PR DESCRIPTION
Fixes issue #1819 .

The issue is that it detects only the first 20 users that liked a post. This pull requests implements code by @uluQulu that contains a scroller to go through the list of likes. 

Note: Video likes do not show up on a desktop and won't be found by this function.

Boundary controls the amount of likes that should be looked at so that users can control how long they want the function to take.

if Bounday = 0 then grab only visible names as the default
if Boundary = None then grab all the usernames that liked a photo
if Boundary = xx then grab xx amount of likers starting from the top. 

