### PR TITLE
Add docker alpine image

### DIFF
--- a/docker_conf/alpine/Dockerfile
+++ b/docker_conf/alpine/Dockerfile
@@ -1,0 +1,18 @@
+FROM gliderlabs/alpine:3.3
+
+RUN apk add --update \
+    git \
+    python \
+    python-dev \
+    py-pip \
+    build-base \
+  && pip install virtualenv \
+  && rm -rf /var/cache/apk/*
+
+RUN mkdir /code && mkdir /config
+
+WORKDIR /code
+COPY ./requirements.txt /config/
+ONBUILD RUN virtualenv /env && /env/bin/pip install -r /code/requirements.txt
+
+COPY ./ /code/%

--- a/docker_conf/alpine/Dockerfile
+++ b/docker_conf/alpine/Dockerfile
@@ -9,10 +9,16 @@ RUN apk add --update \
   && pip install virtualenv \
   && rm -rf /var/cache/apk/*
 
-RUN mkdir /code && mkdir /config
+RUN mkdir /code 
+RUN mkdir /config
+RUN mkdir /srv
 
 WORKDIR /code
 COPY ./requirements.txt /config/
-ONBUILD RUN virtualenv /env && /env/bin/pip install -r /code/requirements.txt
+RUN pip install -r /config/requirements.txt
+
+# Add wait-for
+ADD https://raw.githubusercontent.com/Eficode/wait-for/master/wait-for /code
+RUN chmod 755 /code/wait-for
 
 COPY ./ /code/%


### PR DESCRIPTION
In preparation for deploying InstaPy in Docker Swarm, I created an additional Dockerfile using Alpine instead of Python base image, because:

1. The image can be auto-built using docker hub, making it quick to integrate into swarm
2. The alpine image is 329MB, whereas the python image is 807MB

I'll send another PR for a docker-compose file which will actually _use_ the alpine image, this is just a preparatory contribution.