### PR TITLE
Update like_util.py, error when potency_ratio = None

### DIFF
--- a/instapy/like_util.py
+++ b/instapy/like_util.py
@@ -547,10 +547,10 @@ def check_link(browser, link, dont_like, ignore_if_contains, ignore_users, usern
         # update server calls
         update_activity()
         sleep(1)
-        if potency_ratio is not None:
-            if potency_ratio < 0:
-                potency_ratio *= -1
-                reverse_relationship = True
+        
+        if potency_ratio and potency_ratio < 0:
+            potency_ratio *= -1
+            reverse_relationship = True
             
         if followers_count and following_count:
             relationship_ratio = (followers_count/following_count

--- a/instapy/like_util.py
+++ b/instapy/like_util.py
@@ -547,10 +547,10 @@ def check_link(browser, link, dont_like, ignore_if_contains, ignore_users, usern
         # update server calls
         update_activity()
         sleep(1)
-
-        if potency_ratio < 0:
-            potency_ratio *= -1
-            reverse_relationship = True
+        if potency_ratio is not None:
+            if potency_ratio < 0:
+                potency_ratio *= -1
+                reverse_relationship = True
             
         if followers_count and following_count:
             relationship_ratio = (followers_count/following_count


### PR DESCRIPTION
Qulu fella told me to do a PR, its my first time hope im doing it right 

potency_ratio=None causes error when used with interact_with_user [#1910](https://github.com/timgrossmann/InstaPy/issues/1910)
```
Traceback (most recent call last):
  File "quickstart.py", line 45, in <module>
    session.interact_by_users(users[:2], amount=1)
  File "C:\Users\marti\OneDrive\Proj\InstaPy-master\instapy\instapy.py", line 1307, in interact_by_users
    self.logger)
  File "C:\Users\marti\OneDrive\Proj\InstaPy-master\instapy\like_util.py", line 551, in check_link
    if potency_ratio < 0:
TypeError: '<' not supported between instances of 'NoneType' and 'int'
```