### PR TITLE
remove sleep between finding element and using it

### DIFF
--- a/instapy/unfollow_util.py
+++ b/instapy/unfollow_util.py
@@ -389,9 +389,6 @@ def follow_user(browser, follow_restrict, login, user_name, blacklist, logger, l
         follow_button = browser.find_element_by_xpath(
                 "//button[text()='Follow']")
 
-        # Do we still need this sleep?
-        sleep(2)
-
         if follow_button.is_displayed():
             click_element(browser, follow_button) # follow_button.click()
             update_activity('follows')


### PR DESCRIPTION
As it might lead to an exception:
"StaleElementReferenceException"

according to :
https://stackoverflow.com/questions/16166261/selenium-webdriver-how-to-resolve-stale-element-reference-exception
1. An element that is found on a web page referenced as a WebElement in WebDriver then the DOM changes
(probably due to JavaScript functions) that WebElement goes stale.
2. The element has been deleted entirely.