### PR TITLE
Fix duplicated console log issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@ __pycache__/
 *$py.class
 
 quickstart.py
-quickstart-worker.py
 
 # C extensions
 *.so

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ __pycache__/
 *$py.class
 
 quickstart.py
+quickstart-worker.py
 
 # C extensions
 *.so

--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -169,30 +169,28 @@ class InstaPy:
         """
         Handles the creation and retrieval of loggers to avoid re-instantiation.
         """
-        existing_logger = loggers.get(__name__)
-        if existing_logger is not None:
-            return existing_logger
-        else:
-            # initialize and setup logging system for the InstaPy object
-            logger = logging.getLogger(__name__)
-            logger.setLevel(logging.DEBUG)
-            file_handler = logging.FileHandler('{}general.log'.format(self.logfolder))
-            file_handler.setLevel(logging.DEBUG)
-            extra = {"username": self.username}
-            logger_formatter = logging.Formatter('%(levelname)s [%(asctime)s] [%(username)s]  %(message)s', datefmt='%Y-%m-%d %H:%M:%S')
-            file_handler.setFormatter(logger_formatter)
-            logger.addHandler(file_handler)
+        # initialize and setup logging system for the InstaPy object
+        logger = logging.getLogger(__name__)
+        if (logger.hasHandlers()):
+            logger.handlers.clear()
+        logger.setLevel(logging.DEBUG)
+        file_handler = logging.FileHandler('{}general.log'.format(self.logfolder))
+        file_handler.setLevel(logging.DEBUG)
+        extra = {"username": self.username}
+        logger_formatter = logging.Formatter('%(levelname)s [%(asctime)s] [%(username)s]  %(message)s', datefmt='%Y-%m-%d %H:%M:%S')
+        file_handler.setFormatter(logger_formatter)
+        logger.addHandler(file_handler)
 
-            if show_logs is True:
-                console_handler = logging.StreamHandler()
-                console_handler.setLevel(logging.DEBUG)
-                console_handler.setFormatter(logger_formatter)
-                logger.addHandler(console_handler)
+        if show_logs is True:
+            console_handler = logging.StreamHandler()
+            console_handler.setLevel(logging.DEBUG)
+            console_handler.setFormatter(logger_formatter)
+            logger.addHandler(console_handler)
 
-            logger = logging.LoggerAdapter(logger, extra)
+        logger = logging.LoggerAdapter(logger, extra)
 
-            loggers[__name__] = logger
-            return logger
+        loggers[__name__] = logger
+        return logger
 
     def set_selenium_local_session(self):
         """Starts local session for a selenium server.


### PR DESCRIPTION
Fix an issue that cause duplicated console info

Basically similar issue as described from PR #1255 but the fix he put in there wasn't real fix. the issue was the console_handler get duplicated. There is no need check if a logger already existed or not, consider the logger is singleton and always be the same object regardless what. reference from the official logging module page `Loggers have the following attributes and methods. Note that Loggers are never instantiated directly, but always through the module-level function logging.getLogger(name). Multiple calls to getLogger() with the same name will always return a reference to the same Logger object.`

the real fix is this part:

```
        if (logger.hasHandlers()):
            logger.handlers.clear()
```