### PR TITLE
Revised `like_by_users` feature to speed up the process

### DIFF
--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -676,7 +676,7 @@ class InstaPy:
                 self.logger.info(link)
 
                 try:
-                    inappropriate, user_name, is_video, reason = (
+                    inappropriate, user_name, is_video, reason, scope = (
                         check_link(self.browser,
                                    link,
                                    self.dont_like,
@@ -834,7 +834,7 @@ class InstaPy:
                 self.logger.info(link)
 
                 try:
-                    inappropriate, user_name, is_video, reason = (
+                    inappropriate, user_name, is_video, reason, scope = (
                         check_link(self.browser,
                                    link,
                                    self.dont_like,
@@ -992,7 +992,7 @@ class InstaPy:
                 self.logger.info(link)
 
                 try:
-                    inappropriate, user_name, is_video, reason = (
+                    inappropriate, user_name, is_video, reason, scope = (
                         check_link(self.browser,
                                    link,
                                    self.dont_like,
@@ -1145,6 +1145,10 @@ class InstaPy:
         usernames = usernames or []
 
         for index, username in enumerate(usernames):
+
+            potency_ratio = self.potency_ratio
+            delimit_by_numbers = self.delimit_by_numbers
+
             self.logger.info(
                 'Username [{}/{}]'.format(index + 1, len(usernames)))
             self.logger.info('--> {}'.format(username.encode('utf-8')))
@@ -1203,15 +1207,15 @@ class InstaPy:
                 self.logger.info(link)
 
                 try:
-                    inappropriate, user_name, is_video, reason = (
+                    inappropriate, user_name, is_video, reason, scope = (
                         check_link(self.browser,
                                    link,
                                    self.dont_like,
                                    self.ignore_if_contains,
                                    self.ignore_users,
                                    self.username,
-                                   self.potency_ratio,
-                                   self.delimit_by_numbers,
+                                   potency_ratio,
+                                   delimit_by_numbers,
                                    self.max_followers,
                                    self.max_following,
                                    self.min_followers,
@@ -1219,9 +1223,19 @@ class InstaPy:
                                    self.logger)
                     )
 
+                    if inappropriate==False:
+                        # Skip verifying relationship bounds in further posts of this user cos it is already verified
+                        potency_ratio = None
+                        delimit_by_numbers = False
+                    elif scope=="Relationship bounds":
+                        # Skip this user completely cos of relationship bounds is not verified
+                        self.logger.info(
+                            '--> {} ~skipping user'.format(reason.encode('utf-8')))
+                        break
+
                     if not inappropriate and self.delimit_liking:
                         self.liking_approved = verify_liking(self.browser, self.max_likes, self.min_likes, self.logger)
-                    
+
                     if not inappropriate and self.liking_approved:
                         liked = like_image(self.browser,
                                            user_name,
@@ -1363,7 +1377,7 @@ class InstaPy:
                 self.logger.info(link)
 
                 try:
-                    inappropriate, user_name, is_video, reason = (
+                    inappropriate, user_name, is_video, reason, scope = (
                         check_link(self.browser,
                                    link,
                                    self.dont_like,
@@ -1796,7 +1810,7 @@ class InstaPy:
                         self.logger.info(link)
 
                         try:
-                            inappropriate, user_name, is_video, reason = (
+                            inappropriate, user_name, is_video, reason, scope = (
                                 check_link(self.browser,
                                            link,
                                            self.dont_like,
@@ -2044,7 +2058,7 @@ class InstaPy:
                 self.logger.info(link)
 
                 try:
-                    inappropriate, user_name, is_video, reason = (
+                    inappropriate, user_name, is_video, reason, scope = (
                         check_link(self.browser,
                                    link,
                                    self.dont_like,

--- a/instapy/like_util.py
+++ b/instapy/like_util.py
@@ -13,6 +13,7 @@ from .time_util import sleep
 from .util import update_activity
 from .util import add_user_to_blacklist
 from .util import click_element
+from .unfollow_util import get_relationship_counts
 
 
 def get_links_from_feed(browser, amount, num_of_search, logger):
@@ -438,7 +439,7 @@ def check_link(browser, link, dont_like, ignore_if_contains, ignore_users, usern
 
     if post_page is None:
         logger.warning('Unavailable Page: {}'.format(link.encode('utf-8')))
-        return True, None, None, 'Unavailable Page'
+        return True, None, None, 'Unavailable Page', "Failure"
 
     """Gets the description of the link and checks for the dont_like tags"""
     graphql = 'graphql' in post_page[0]
@@ -498,123 +499,75 @@ def check_link(browser, link, dont_like, ignore_if_contains, ignore_users, usern
     """Checks the potential of target user by relationship status in order to delimit actions within the desired boundary"""
     if potency_ratio or delimit_by_numbers and (max_followers or max_following or min_followers or min_following):
 
-        userlink = 'https://www.instagram.com/' + user_name
-        browser.get(userlink)
-
-        # update server calls
-        update_activity()
-        sleep(1)
-
         relationship_ratio = None
         reverse_relationship = False
 
-        try:
-            followers_count = format_number(browser.find_element_by_xpath("//a[contains"
-                                    "(@href,'followers')]/span").text)
-        except NoSuchElementException:
-            try:
-                followers_count = browser.execute_script(
-                    "return window._sharedData.entry_data."
-                    "ProfilePage[0].graphql.user.edge_followed_by.count")
-            except WebDriverException:
-                try:
-                    browser.execute_script("location.reload()")
-                    followers_count = browser.execute_script(
-                        "return window._sharedData.entry_data."
-                        "ProfilePage[0].graphql.user.edge_followed_by.count")
-                except WebDriverException:            
-                    try:
-                        followers_count = format_number(browser.find_element_by_xpath(
-                                        "//li[2]/a/span[contains(@class, '_fd86t')]").text)
-                    except NoSuchElementException:
-                        logger.info("Error occured during getting the followers count of '{}'\n".format(user_name))
-                        followers_count = None
-        
-        try:
-            following_count = format_number(browser.find_element_by_xpath("//a[contains"
-                                    "(@href,'following')]/span").text)
-        except NoSuchElementException:
-            try:
-                following_count = browser.execute_script(
-                    "return window._sharedData.entry_data."
-                    "ProfilePage[0].graphql.user.edge_follow.count")
-            except WebDriverException:
-                try:
-                    browser.execute_script("location.reload()")
-                    following_count = browser.execute_script(
-                        "return window._sharedData.entry_data."
-                        "ProfilePage[0].graphql.user.edge_follow.count")
-                except WebDriverException:
-                    try:
-                        following_count = format_number(browser.find_element_by_xpath(
-                                            "//li[3]/a/span[contains(@class, '_fd86t')]").text)
-                    except NoSuchElementException:
-                        logger.info("\nError occured during getting the following count of '{}'\n".format(user_name))
-                        following_count = None
-            
+        # Get followers & following counts
+        followers_count, following_count = get_relationship_counts(browser, user_name, logger)
+
         browser.get(link)
         # update server calls
         update_activity()
         sleep(1)
-        
+
         if potency_ratio and potency_ratio < 0:
             potency_ratio *= -1
             reverse_relationship = True
-            
+
         if followers_count and following_count:
             relationship_ratio = (followers_count/following_count
                                    if not reverse_relationship
                                     else following_count/followers_count)
-        
+
         logger.info('User: {} >> followers: {}  |  following: {}  |  relationship ratio: {}'.format(user_name,
         followers_count if followers_count else 'unknown',
         following_count if following_count else 'unknown',
         float("{0:.2f}".format(relationship_ratio)) if relationship_ratio else 'unknown'))
-        
+
         if followers_count  or following_count:
             if potency_ratio and not delimit_by_numbers:
                 if relationship_ratio and relationship_ratio < potency_ratio:
                         return True, user_name, is_video, \
                             "{} is not a {} with the relationship ratio of {}".format(
                             user_name, "potential user" if not reverse_relationship else "massive follower",
-                            float("{0:.2f}".format(relationship_ratio)))
+                            float("{0:.2f}".format(relationship_ratio))), "Relationship bounds"
 
             elif delimit_by_numbers:
                 if followers_count:
                     if max_followers:
                         if followers_count > max_followers:
                             return True, user_name, is_video, \
-                                "User {}'s followers count exceeds maximum limit".format(user_name)
+                                "User {}'s followers count exceeds maximum limit".format(user_name), "Relationship bounds"
                     if min_followers:
                         if followers_count < min_followers:
                             return True, user_name, is_video, \
-                                "User {}'s followers count is less than minimum limit".format(user_name)
-                if following_count:                
+                                "User {}'s followers count is less than minimum limit".format(user_name), "Relationship bounds"
+                if following_count:
                     if max_following:
                         if following_count > max_following:
                             return True, user_name, is_video, \
-                                "User {}'s following count exceeds maximum limit".format(user_name)
+                                "User {}'s following count exceeds maximum limit".format(user_name), "Relationship bounds"
                     if min_following:
                         if following_count < min_following:
                             return True, user_name, is_video, \
-                                "User {}'s following count is less than minimum limit".format(user_name)
+                                "User {}'s following count is less than minimum limit".format(user_name), "Relationship bounds"
                 if potency_ratio:
                     if relationship_ratio and relationship_ratio < potency_ratio:
                         return True, user_name, is_video, \
                             "{} is not a {} with the relationship ratio of {}".format(
                             user_name, "potential user" if not reverse_relationship else "massive follower",
-                            float("{0:.2f}".format(relationship_ratio)))
-                            
+                            float("{0:.2f}".format(relationship_ratio))), "Relationship bounds"
+
 
     logger.info('Link: {}'.format(link.encode('utf-8')))
     logger.info('Description: {}'.format(image_text.encode('utf-8')))
 
     """Check if the user_name is in the ignore_users list"""
     if (user_name in ignore_users) or (user_name == username):
-        return True, user_name, is_video, 'Username'
+        return True, user_name, is_video, 'Username', "Undesired user"
 
     if any((word in image_text for word in ignore_if_contains)):
-        return False, user_name, is_video, 'None'
+        return False, user_name, is_video, 'None', "Pass"
 
     dont_like_regex = []
 
@@ -640,9 +593,9 @@ def check_link(browser, link, dont_like, ignore_if_contains, ignore_users, usern
             inapp_unit = 'Inappropriate! ~ contains "{}"'.format(
                 quashed if iffy == quashed else
                 '" in "'.join([str(iffy), str(quashed)]))
-            return True, user_name, is_video, inapp_unit
+            return True, user_name, is_video, inapp_unit, "Undesired word"
 
-    return False, user_name, is_video, 'None'
+    return False, user_name, is_video, 'None', "Success"
 
 
 def like_image(browser, username, blacklist, logger, logfolder):

--- a/instapy/unfollow_util.py
+++ b/instapy/unfollow_util.py
@@ -921,7 +921,7 @@ def get_relationship_counts(browser, username, logger):
                     followers_count = format_number(browser.find_element_by_xpath(
                                     "//li[2]/a/span[contains(@class, '_fd86t')]").text)
                 except NoSuchElementException:
-                    logger.info("Error occured during getting the followers count of '{}'\n".format(user_name))
+                    logger.info("Error occured during getting the followers count of '{}'\n".format(username))
                     followers_count = None
 
     try:
@@ -943,7 +943,7 @@ def get_relationship_counts(browser, username, logger):
                     following_count = format_number(browser.find_element_by_xpath(
                                         "//li[3]/a/span[contains(@class, '_fd86t')]").text)
                 except NoSuchElementException:
-                    logger.info("\nError occured during getting the following count of '{}'\n".format(user_name))
+                    logger.info("\nError occured during getting the following count of '{}'\n".format(username))
                     following_count = None
     
     return followers_count, following_count

--- a/instapy/unfollow_util.py
+++ b/instapy/unfollow_util.py
@@ -12,6 +12,7 @@ from .util import click_element
 from .print_log_writer import log_followed_pool
 from .print_log_writer import log_uncertain_unfollowed_pool
 from .print_log_writer import log_record_all_unfollowed
+from selenium.common.exceptions import WebDriverException
 from selenium.common.exceptions import NoSuchElementException
 import random
 import os
@@ -890,3 +891,59 @@ def load_follow_restriction(logfolder):
 
     with open(filename) as followResFile:
         return json.load(followResFile)
+
+
+def get_relationship_counts(browser, username, logger):
+    """ Gets the followers & following counts of a given user """
+    userlink = 'https://www.instagram.com/' + username
+    browser.get(userlink)
+
+    # update server calls
+    update_activity()
+    sleep(1)
+
+    try:
+        followers_count = format_number(browser.find_element_by_xpath("//a[contains"
+                                "(@href,'followers')]/span").text)
+    except NoSuchElementException:
+        try:
+            followers_count = browser.execute_script(
+                "return window._sharedData.entry_data."
+                "ProfilePage[0].graphql.user.edge_followed_by.count")
+        except WebDriverException:
+            try:
+                browser.execute_script("location.reload()")
+                followers_count = browser.execute_script(
+                    "return window._sharedData.entry_data."
+                    "ProfilePage[0].graphql.user.edge_followed_by.count")
+            except WebDriverException:
+                try:
+                    followers_count = format_number(browser.find_element_by_xpath(
+                                    "//li[2]/a/span[contains(@class, '_fd86t')]").text)
+                except NoSuchElementException:
+                    logger.info("Error occured during getting the followers count of '{}'\n".format(user_name))
+                    followers_count = None
+
+    try:
+        following_count = format_number(browser.find_element_by_xpath("//a[contains"
+                                "(@href,'following')]/span").text)
+    except NoSuchElementException:
+        try:
+            following_count = browser.execute_script(
+                "return window._sharedData.entry_data."
+                "ProfilePage[0].graphql.user.edge_follow.count")
+        except WebDriverException:
+            try:
+                browser.execute_script("location.reload()")
+                following_count = browser.execute_script(
+                    "return window._sharedData.entry_data."
+                    "ProfilePage[0].graphql.user.edge_follow.count")
+            except WebDriverException:
+                try:
+                    following_count = format_number(browser.find_element_by_xpath(
+                                        "//li[3]/a/span[contains(@class, '_fd86t')]").text)
+                except NoSuchElementException:
+                    logger.info("\nError occured during getting the following count of '{}'\n".format(user_name))
+                    following_count = None
+    
+    return followers_count, following_count


### PR DESCRIPTION
_`like_by_users` is prob my fav feature to have fun sometimes liking bunch of pics but it has an unwanted behavior should be changed.._
**Currently**, `check_link` utility is visiting the user's profile page in every posts in order to find followers & following counts.
_And it does **the same** for the feature of `like_by_users` where, from the same user(s) it views bunch of posts and visits profile page in each post to get those values..._
#### It is simply unwanted behavior. So I **modified** a few lines:
**Now** when a user's relationship bounds **is matched** for once, it **will not be checked** in the next posts of that same user again.
**Similarly**, if a user's relationship bounds **is not matched** with the range desired, then it **will simply skip** that user _without seeing further posts_.
>This applies to all features using `like_by_users` method and affected features are:
`interact_user_followers`, 
`interact_user_following`, 
`follow_user_followers`,
`follow_user_following`,
`like_by_feed`,
`like_by_tags`,
and `like_by_users` itself :)

**The result** is lots of saved `time` and less web `requests` sent. 

**_Also_**, **moved** the process of _getting follower and following counts_ into **a new** function for the _ease of maintenance_ and _to make usable_ in other places, too, e.g., right from quickstart scripts...
_e.g._,
```python
##quickstart script
from instapy.unfollow_util import get_relationship_counts
#some code

followers_count, following_count = get_relationship_counts(session.browser, insta_username, session.logger)
```
> If there is something I missed, please notify.