### PR TITLE
Prevent UnicodeDecodeError when inappropiate words found.

### DIFF
--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -1027,7 +1027,7 @@ class InstaPy:
                             already_liked += 1
                     else:
                         self.logger.info(
-                            '--> Image not liked: {}'.format(reason.encode('utf-8')))
+                            '--> Image not liked: {}'.format(reason))
                         inap_img += 1
                 except NoSuchElementException as err:
                     self.logger.error('Invalid Page: {}'.format(err))


### PR DESCRIPTION
Prevent bot error when inappropiate words found: "UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2 in position 43: ordinal not in range(128)"