### PR TITLE
Multidimensional revisions & enhancements; Mainly- moved relationship bounds verification into `validate_username` definition AND redesigned `follow_user_followers` & follow_user_following` features to support relationship bounds verification & have on-the-go interactions

### DIFF
--- a/instapy/comment_util.py
+++ b/instapy/comment_util.py
@@ -51,7 +51,7 @@ def comment_image(browser, username, comments, blacklist, logger, logfolder):
             comment_input = get_comment_input(browser)
 
             browser.execute_script(
-                "arguments[0].value = '" + rand_comment + " ';", comment_input[0])
+                "arguments[0].value = arguments[1];", comment_input[0], rand_comment+' ')
             # An extra space is added here and then deleted.
             # This forces the input box to update the reactJS core
             comment_input[0].send_keys("\b")

--- a/instapy/like_util.py
+++ b/instapy/like_util.py
@@ -282,10 +282,24 @@ def get_links_for_username(browser,
 
     logger.info('Getting {} image list...'.format(username))
 
-    # Get  user profile page
-    browser.get('https://www.instagram.com/' + username)
-    # update server calls
-    update_activity()
+    user_link = "https://www.instagram.com/{}/".format(username)
+    sleep(1)
+    #Check URL of the webpage, if it already is user's profile page, then do not navigate to it again
+    try:
+        current_url = browser.current_url
+    except WebDriverException:
+        try:
+            current_url = browser.execute_script("return window.location.href")
+        except WebDriverException:
+            raise
+            current_url = None
+    
+    if current_url is None or current_url != user_link:
+        browser.get(user_link)
+        # update server calls
+        update_activity()
+        sleep(1)
+
 
     body_elem = browser.find_element_by_tag_name('body')
 

--- a/instapy/unfollow_util.py
+++ b/instapy/unfollow_util.py
@@ -264,7 +264,7 @@ def unfollow(browser,
                         sleep(2)
                         browser.get(url)
         except BaseException as e:
-            print(
+            logger.error(
                 "unable to get followers and following information \n", str(e))
 
         # make sure to unfollow users who don't follow back and don't
@@ -277,7 +277,7 @@ def unfollow(browser,
             hasSlept = False
             for person in unfollow_list:
                 if unfollowNum >= amount:
-                    print("--> Total unfollowNum reached it's amount "
+                    logger.info("--> Total unfollowNum reached it's amount "
                           "given {}".format(unfollowNum))
                     break
 
@@ -285,7 +285,7 @@ def unfollow(browser,
                    hasSlept is False and
                    unfollowNum % 10 == 0):
 
-                        print('sleeping for about {}min'
+                        logger.info('sleeping for about {}min'
                               .format(int(sleep_delay/60)))
                         sleep(sleep_delay)
                         hasSlept = True
@@ -298,7 +298,7 @@ def unfollow(browser,
                 if follow_button.text == 'Following':
                     unfollowNum += 1
                     click_element(browser, follow_button) # follow_button.click()
-                    print('--> Ongoing Unfollow ' + str(unfollowNum) +
+                    logger.info('--> Ongoing Unfollow ' + str(unfollowNum) +
                           ', now unfollowing: {}'
                           .format(person.encode('utf-8')))
                     sleep(15)
@@ -306,7 +306,7 @@ def unfollow(browser,
                         hasSlept = False
 
         except BaseException as e:
-            print("unfollow loop error \n", str(e))
+            logger.error("unfollow loop error \n", str(e))
 
     elif onlyNotFollowMe is not True:
         # unfollow from profile
@@ -419,18 +419,26 @@ def follow_user(browser, follow_restrict, login, user_name, blacklist, logger, l
         return 0
 
 
-def unfollow_user(browser, logger):
+def unfollow_user(browser, username, person, logger, logfolder):
     """Unfollows the user of the currently opened image"""
 
-    unfollow_button = browser.find_element_by_xpath(
-        "//*[contains(text(), 'Following')]")
+    try:
+        unfollow_button = browser.find_element_by_xpath(
+            "//*[text()='Following' or text()='Requested']")
+            #"//*[contains(text(), 'Following')]")  # or Requested
+    except NoSuchElementException:
+        logger.error("Could not locate \"Following\" or \"Requested\" button in order to unfollow '{}'!".format(person))
+        return 0
 
-    if unfollow_button.text == 'Following':
+    if unfollow_button.text in ['Following', 'Requested']:
         click_element(browser, unfollow_button) # unfollow_button.send_keys("\n")
+        logger.warning("--> Unfollowed '{}' due to Inappropriate Content".format(person))
 
+        delete_line_from_file('{0}{1}_followedPool.csv'.format(logfolder, username), person +
+                          ",\n", logger)
         update_activity('unfollows')
-        logger.warning('--> User unfollowed due to Inappropriate Content')
         sleep(3)
+
         return 1
 
 
@@ -442,9 +450,24 @@ def follow_given_user(browser,
                       logger,
                       logfolder):
     """Follows a given user."""
-    browser.get('https://www.instagram.com/' + acc_to_follow)
-    # update server calls
-    update_activity()
+    user_link = "https://www.instagram.com/{}/".format(acc_to_follow)
+    sleep(1)
+    #Check URL of the webpage, if it already is user's profile page, then do not navigate to it again
+    try:
+        current_url = browser.current_url
+    except WebDriverException:
+        try:
+            current_url = browser.execute_script("return window.location.href")
+        except WebDriverException:
+            raise
+            current_url = None
+    
+    if current_url is None or current_url != user_link:
+        browser.get(user_link)
+        # update server calls
+        update_activity()
+        sleep(1)
+
     logger.info('--> {} instagram account is opened...'.format(acc_to_follow))
 
     try:
@@ -472,55 +495,120 @@ def follow_given_user(browser,
         return 0
 
 
-def follow_through_dialog(browser,
+def get_users_through_dialog(browser,
+                          login,
                           user_name,
                           amount,
-                          dont_include,
-                          login,
-                          follow_restrict,
-                          allfollowing,
+                          users_count,
                           randomize,
-                          delay,
+                          dont_include,
+                          follow_restrict,
                           blacklist,
-                          logger,
-                          logfolder,
                           follow_times,
-                          callbacks=[]):
+                          logger,
+                          logfolder):
     sleep(2)
     person_followed = []
     real_amount = amount
     if randomize and amount >= 3:
         # expanding the popultaion for better sampling distribution
         amount = amount * 3
+        
+    if amount > int(users_count*0.85):   #taking 85 percent of possible amounts is a safe study
+        amount = int(users_count*0.85)
+    try_again = 0
+    sc_rolled = 0
 
     # find dialog box
     dialog = browser.find_element_by_xpath(
       "//div[text()='Followers' or text()='Following']/following-sibling::div")
-
-    # scroll down the page
-    scroll_bottom(browser, dialog, allfollowing)
 
     # get follow buttons. This approch will find the follow buttons and
     # ignore the Unfollow/Requested buttons.
     follow_buttons = dialog.find_elements_by_xpath(
         "//div/div/span/button[text()='Follow']")
 
-    person_list = []
     abort = False
+    person_list = []
     total_list = len(follow_buttons)
+    simulated_list = []
+    simulator_counter = 0
 
     # scroll down if the generated list of user to follow is not enough to
     # follow amount set
     while (total_list < amount) and not abort:
-        amount_left = amount - total_list
         before_scroll = total_list
-        scroll_bottom(browser, dialog, amount_left)
-        sleep(1)
+        for i in range(3):
+            scroll_bottom(browser, dialog, 2)
+            sc_rolled += 1
+            simulator_counter += 1
+            sleep(random.randint(1, 2))
+
         follow_buttons = dialog.find_elements_by_xpath(
             "//div/div/span/button[text()='Follow']")
         total_list = len(follow_buttons)
-        abort = (before_scroll == total_list)
 
+        abort = (before_scroll == total_list)
+        if abort:
+            if total_list < real_amount:
+                logger.info("Failed to load desired amount of users")
+        
+        if sc_rolled > 85:   #you may want to use up to 100
+            if total_list < amount:
+                logger.info("Too many requests sent!  attempt: {}  |  gathered links: {}   ~sleeping a bit  ".format(try_again+1, total_list))
+                sleep(random.randint(600, 655))
+                try_again += 1
+                sc_rolled = 0
+
+        # Will follow a little bit of users in order to simulate real interaction
+        if (simulator_counter > random.randint(5, 17) or
+                abort==True or
+                    total_list >= amount or
+                        sc_rolled==random.randint(3, 5)):
+
+            quick_amount = 1 if not total_list >= amount else random.randint(1, 4)
+
+            for i in range(0, quick_amount):
+                logger.info("Simulated follow : {}".format(len(simulated_list)+1))
+
+                quick_index = random.randint(0, len(follow_buttons))
+                quick_button = follow_buttons[quick_index]
+                quick_username = dialog_username_extractor(quick_button)
+                if quick_username[0] not in simulated_list:
+                    quick_follow = follow_through_dialog(browser,
+                                                         login,
+                                                         quick_username,
+                                                         quick_button,
+                                                         quick_amount,
+                                                         dont_include,
+                                                         follow_restrict,
+                                                         blacklist,
+                                                         follow_times,
+                                                         logger,
+                                                         logfolder)
+                    simulated_list.extend(quick_follow)
+
+            simulator_counter = 0
+
+    person_list = dialog_username_extractor(follow_buttons)
+    if randomize:
+        random.shuffle(person_list)
+
+    person_list = person_list[:(real_amount-len(simulated_list))]
+    for user in simulated_list:   #add simulated users to the `person_list` in random index
+        if user not in person_list:
+            person_list.insert(random.randint(0, len(person_list)), user)
+
+    return person_list, simulated_list
+
+
+def dialog_username_extractor(follow_buttons):
+    """ Extract username of a follow button from a dialog box """
+    
+    if not isinstance(follow_buttons, list):
+        follow_buttons = [follow_buttons]
+    
+    person_list = []
     for person in follow_buttons:
 
         if person and hasattr(person, 'text') and person.text:
@@ -530,50 +618,38 @@ def follow_through_dialog(browser,
             except IndexError:
                 pass  # Element list is too short to have a [1] element
 
-    if amount >= total_list:
-        amount = total_list
-        logger.warning("{} -> Less users to follow than requested."
-                       .format(user_name))
+    return person_list
 
-    # follow loop
+
+def follow_through_dialog(browser,
+                          login,
+                          person_list,
+                          buttons,
+                          amount,
+                          dont_include,
+                          follow_restrict,
+                          blacklist,
+                          follow_times,
+                          logger,
+                          logfolder):
+    """ Will follow username directly inside a dialog box """
+    if not isinstance(person_list, list):
+        person_list = [person_list]
+    
+    if not isinstance(buttons, list):
+        buttons = [buttons]
+    
+    person_followed = []
     try:
-        hasSlept = False
-        btnPerson = list(zip(follow_buttons, person_list))
-        if randomize:
-            sample = random.sample(range(0, len(follow_buttons)), real_amount)
-            finalBtnPerson = []
-            for num in sample:
-                finalBtnPerson.append(btnPerson[num])
-        else:
-            finalBtnPerson = btnPerson
-
-        followNum = 0
-
-        for button, person in finalBtnPerson:
-            if followNum >= real_amount:
-                logger.info("--> Total followNum reached: {}"
-                            .format(followNum))
-                break
-
-            if followNum != 0 and hasSlept is False and followNum % 10 == 0:
-                if delay < 60:
-                    logger.info('sleeping for about {} seconds'.format(delay))
-                else:
-                    logger.info(
-                        'sleeping for about {} minutes'.format(delay/60))
-                sleep(delay)
-                hasSlept = True
-                continue
-
+        for person, button in zip(person_list, buttons):
+            
             if (person not in dont_include and
                 follow_restrict.get(person, 0) < follow_times):
 
-                followNum += 1
                 # Register this session's followed user for further interaction
                 person_followed.append(person)
 
-
-                click_element(browser, button) # button.send_keys("\n")
+                click_element(browser, button)
                 logtime = datetime.now().strftime('%Y-%m-%d %H:%M')
                 log_followed_pool(login, person, logger, logfolder, logtime)
 
@@ -581,8 +657,7 @@ def follow_through_dialog(browser,
 
                 follow_restrict[person] = follow_restrict.get(person, 0) + 1
 
-                logger.info('--> Ongoing follow {}, now following: {}'
-                            .format(str(followNum), person.encode('utf-8')))
+                logger.info('--> Followed {}'.format(person.encode('utf-8')))
 
                 if blacklist['enabled'] is True:
                     action = 'followed'
@@ -590,27 +665,13 @@ def follow_through_dialog(browser,
                         browser, person, blacklist['campaign'], action, logger, logfolder
                     )
 
-                for callback in callbacks:
-                    callback(person.encode('utf-8'))
-                sleep(15)
-
-                # To only sleep once until there is the next follow
-                if hasSlept:
-                    hasSlept = False
-
-                continue
+                sleep(3)
 
             else:
-                if randomize:
-                    repickedNum = -1
-                    while repickedNum not in sample and repickedNum != -1:
-                        repickedNum = random.randint(0, len(btnPerson))
-                    sample.append(repickedNum)
-                    finalBtnPerson.append(btnPerson[repickedNum])
-                continue
-
+                logger.info("Not followed '{}'  ~inappropriate user".format(person))
+                
     except BaseException as e:
-        logger.error("follow loop error {}".format(str(e)))
+        logger.error("Error occured while following through dialog box:\n{}".format(str(e)))
 
     return person_followed
 
@@ -640,7 +701,7 @@ def get_given_user_followers(browser, user_name, amount, dont_include, login, ra
     # throw RuntimeWarning if we are 0 people following this user or
     # if its a private account
     try:
-        allfollowing = format_number(
+        allfollowers = format_number(
             browser.find_element_by_xpath("//li[2]/a/span").text)
     except NoSuchElementException:
         logger.warning('Can\'t interact with private account')
@@ -663,7 +724,7 @@ def get_given_user_followers(browser, user_name, amount, dont_include, login, ra
         "//div[text()='Followers']/following-sibling::div")
 
     # scroll down the page
-    scroll_bottom(browser, dialog, allfollowing)
+    scroll_bottom(browser, dialog, allfollowers)
 
     # get follow buttons. This approch will find the follow buttons and
     # ignore the Unfollow/Requested buttons.
@@ -760,23 +821,31 @@ def get_given_user_following(browser,
     return person_list
 
 
-def follow_given_user_followers(browser, user_name, amount, dont_include, login, follow_restrict,
-                                random, delay, blacklist, logger, logfolder, follow_times):
+def follow_given_user_followers(browser,
+                                login,
+                                user_name,
+                                amount,
+                                dont_include,
+                                randomize,
+                                follow_restrict,
+                                blacklist,
+                                follow_times,
+                                logger,
+                                logfolder):
     """
     For the given username, follow their followers.
 
     :param browser: webdriver instance
+    :param login:
     :param user_name: given username of account to follow
     :param amount: the number of followers to follow
     :param dont_include: ignore these usernames
-    :param login:
     :param follow_restrict:
     :param random: randomly select from users' followers
-    :param delay: the seconds to delay between each follow
     :param blacklist:
+    :param follow_times:
     :param logger: the logger instance
     :param logfolder: the logger folder
-    :param follow_times:
     :return: list of user's followers also followed
     """
     user_name = user_name.strip()
@@ -786,7 +855,7 @@ def follow_given_user_followers(browser, user_name, amount, dont_include, login,
 
     # check how many people are following this user.
     try:
-        user_followers_count = format_number(browser.find_element_by_xpath(
+        allfollowers = format_number(browser.find_element_by_xpath(
             '//li[2]/a/span').text)
     except NoSuchElementException:
         # todo check if private account?
@@ -794,12 +863,12 @@ def follow_given_user_followers(browser, user_name, amount, dont_include, login,
         return []
 
     # skip early for no followers
-    if not user_followers_count:
+    if not allfollowers:
         logger.info('{} has no followers'.format(user_name))
         return []
-    elif user_followers_count < amount:
+    elif allfollowers < amount:
         logger.warning('{} has less followers than given amount of {}'.format(
-            user_followers_count, amount))
+            allfollowers, amount))
 
     # locate element to user's followers
     try:
@@ -811,26 +880,25 @@ def follow_given_user_followers(browser, user_name, amount, dont_include, login,
         logger.error("following_link error {}".format(str(e)))
         return []
 
-    persons_followed = follow_through_dialog(browser, user_name, amount, dont_include, login,
-                                             follow_restrict, user_followers_count, random, delay,
-                                             blacklist, logger, logfolder, follow_times,
-                                             callbacks=[])
+    person_list, simulated_list = get_users_through_dialog(browser, login, user_name, amount,
+                                                 allfollowers, randomize, dont_include,
+                                                  follow_restrict, blacklist, follow_times,
+                                                   logger, logfolder)
 
-    return persons_followed
+    return person_list, simulated_list
 
 
 def follow_given_user_following(browser,
+                                login,
                                 user_name,
                                 amount,
                                 dont_include,
-                                login,
+                                randomize,
                                 follow_restrict,
-                                random,
-                                delay,
                                 blacklist,
+                                follow_times,
                                 logger,
-                                logfolder,
-                                follow_times):
+                                logfolder):
     user_name = user_name.strip()
 
     browser.get('https://www.instagram.com/' + user_name)
@@ -854,21 +922,12 @@ def follow_given_user_following(browser,
     except BaseException as e:
         logger.error("following_link error {}".format(str(e)))
 
-    personFollowed = follow_through_dialog(browser,
-                                           user_name,
-                                           amount,
-                                           dont_include,
-                                           login,
-                                           follow_restrict,
-                                           allfollowing,
-                                           random,
-                                           delay,
-                                           blacklist,
-                                           logger,
-                                           logfolder,
-                                           follow_times)
+    person_list, simulated_list = get_users_through_dialog(browser, login, user_name, amount,
+                                                 allfollowing, randomize, dont_include,
+                                                  follow_restrict, blacklist, follow_times,
+                                                   logger, logfolder)
 
-    return personFollowed
+    return person_list, simulated_list
 
 
 def dump_follow_restriction(followRes, logfolder):
@@ -892,58 +951,3 @@ def load_follow_restriction(logfolder):
     with open(filename) as followResFile:
         return json.load(followResFile)
 
-
-def get_relationship_counts(browser, username, logger):
-    """ Gets the followers & following counts of a given user """
-    userlink = 'https://www.instagram.com/' + username
-    browser.get(userlink)
-
-    # update server calls
-    update_activity()
-    sleep(1)
-
-    try:
-        followers_count = format_number(browser.find_element_by_xpath("//a[contains"
-                                "(@href,'followers')]/span").text)
-    except NoSuchElementException:
-        try:
-            followers_count = browser.execute_script(
-                "return window._sharedData.entry_data."
-                "ProfilePage[0].graphql.user.edge_followed_by.count")
-        except WebDriverException:
-            try:
-                browser.execute_script("location.reload()")
-                followers_count = browser.execute_script(
-                    "return window._sharedData.entry_data."
-                    "ProfilePage[0].graphql.user.edge_followed_by.count")
-            except WebDriverException:
-                try:
-                    followers_count = format_number(browser.find_element_by_xpath(
-                                    "//li[2]/a/span[contains(@class, '_fd86t')]").text)
-                except NoSuchElementException:
-                    logger.info("Error occured during getting the followers count of '{}'\n".format(username))
-                    followers_count = None
-
-    try:
-        following_count = format_number(browser.find_element_by_xpath("//a[contains"
-                                "(@href,'following')]/span").text)
-    except NoSuchElementException:
-        try:
-            following_count = browser.execute_script(
-                "return window._sharedData.entry_data."
-                "ProfilePage[0].graphql.user.edge_follow.count")
-        except WebDriverException:
-            try:
-                browser.execute_script("location.reload()")
-                following_count = browser.execute_script(
-                    "return window._sharedData.entry_data."
-                    "ProfilePage[0].graphql.user.edge_follow.count")
-            except WebDriverException:
-                try:
-                    following_count = format_number(browser.find_element_by_xpath(
-                                        "//li[3]/a/span[contains(@class, '_fd86t')]").text)
-                except NoSuchElementException:
-                    logger.info("\nError occured during getting the following count of '{}'\n".format(username))
-                    following_count = None
-    
-    return followers_count, following_count

--- a/instapy/util.py
+++ b/instapy/util.py
@@ -45,8 +45,9 @@ def validate_username(browser,
                         "return window._sharedData.entry_data."
                         "PostPage[0].graphql.shortcode_media.owner.username")
             except WebDriverException:
-                logger.error("Username validation failed! ~cannot get the post owner's username\n")
-                return True
+                logger.error("Username validation failed! ~cannot get the post owner's username")
+                return False, \
+                        "---> Sorry, this page isn't available! ~link is broken, or page is removed\n"
     else:
         username = username_or_link   # if there is no `/` in `username_or_link`, then it is a `username`
 


### PR DESCRIPTION
As of @DimIsaev's second request at #1858,
**Added** **relationship bounds** _verification_ support to `follow_user_follower` & `follow_user_followers` which _costed_ the **redesign** of `follow_through_dialog` definition.
* **Now**, it gets the list of usernames in the desired amount from the dialog box and then does the rest of the procedure through `follow_by_list`.
**It has** several **benefits**:
**1**. having **relationship bounds** _verification_
**2**. having **on-the-go** interactions (_if enabled_) **rather** than following **all of the** users **and then** _starting_ interactions
**3**. **more reliable** and **efficient** control **over sleep delay**, now it takes **a break time** **per** _overall follows_ in the called feature, **rather than** break times **per user**
* **Also**, enhanced the **process of** getting _links of usernames_, **now** it will **scroll as required** and **will get links regardless of the amount** (_used_ the previously **shared** method at https://github.com/timgrossmann/InstaPy/issues/1548#issuecomment-372803884)

* **For relationship bounds** _verification_ to be _used for other features_, I **did pull** it _into a new_ definition, actually, it's **more friendly** and already **existing** definition- `validate_username`, and did some **other improves** in it, too.
* Now, `check_link` definition _does_ **only its job**- checking the links **only**, _rather than_ checking links and _verifying users_.
* Also, at `check_link`, `validate_username` and `get_relationship_counts`, added **a new layer** of **current URL** checking, which is helpful:
**1**. if the **current URL** is the same with _to be_ navigated, it **will not navigate** to it again (_saving server requests_)
**2**. if the URLs **are different**, then it **will navigate** to the required URL.
_**it is very helpful** at certain **situations**, e.g. if **relationship bounds** _verification_ is **disabled**, check_link **does not need to** navigate to the _post page_ **again**, **OR** if **relationship bounds** _verification_ is **enabled**, `follow_given_user` does **not need to** navigate to the _profile page_ **again**, cos it **already navigated** in `get_relationship_counts`_

* **Also, moved** `get_relationship_counts` from `unfollow_util.py` to `util.py` **to avoid circular dependant imports** and **it is more** like a _general utility_ to be _there_.

* **Interesting thing**: added **simulated follows**- after changing the _mechanism_ of following through dialog to following on-by-one **separately**, I realized **it would be** pretty _non-humanly_ activity if you just scroll a huge list **and do** nothing, that's why _I did add_ a **simulated following** _mechanism_, which will follow a bit of users (_max of ~4 per 100_) in _random intervals_ during the scrolling until getting _sufficient amount_ of links and it will pass those simulatedly followed users to main processer and _if any of those_ users is **not valid**, it **will unfollow** them (**simulated** users are _added_ to the main list **in random** order) immediately.
**I think** this idea of **simulated actions** _should be_ applied to other features, **as well**, _cos_ scrolling a list (_even a huge list_) and **doing nothing** seems pretty _weird_ _to be smartly handled_.

* **Enhanced** `unfollow_users` function a bit and added missing **capability** to remove unfollowed user from followed pool CSV file (_if exists_).

* **Prior break time** handling in `follow_user_followers` & `follow_user_following` based on 10 follows is **now replaced** with smarter randomized **range** of `[7, 14)` and sleep delay is **also gonna** be randomized **between** `85` & `100` percents of user-provided or default (`600`) time and these values are gonna change **periodically**.

* **Alongside**, `follow_user_followers` and `follow_user_following`, I've also added **relationship bounds** _verification_ support for `follow_by_list` feature.
* Also some modifications is **done in syntax** for more **generalized** structure and **good** looking _output_.

The **enhancements done** for `follow_user_followers` were also **recently requested** by @OGHARRY (_**relationship bounds** _verification_ support_) in #2003 and by @FranklinClinton (_**relationship bounds** _verification_ support_ and _on-the-go_ interactions) in #2009
> **I** have tested several times, if there are still, some **logical** or **mechanical** errors, please **notify**!