### PR TITLE
Single instance check

### DIFF
--- a/quickstart.py
+++ b/quickstart.py
@@ -2,6 +2,16 @@ import os
 import time
 from tempfile import gettempdir
 
+# Check that there is only one instance running
+import fcntl
+x = open('locked.txt', 'w+')
+
+try:
+    fcntl.flock(x, fcntl.LOCK_EX | fcntl.LOCK_NB)
+except:
+    print "There is another Instance alredy Running! Delete Locked.txt if this is not true!"
+    exit(0)
+	
 from selenium.common.exceptions import NoSuchElementException
 
 from instapy import InstaPy

--- a/quickstart.py
+++ b/quickstart.py
@@ -9,7 +9,7 @@ x = open('locked.txt', 'w+')
 try:
     fcntl.flock(x, fcntl.LOCK_EX | fcntl.LOCK_NB)
 except:
-    print "There is another Instance alredy Running! Delete Locked.txt if this is not true!"
+    print ("There is another Instance alredy Running! Delete Locked.txt if this is not true!")
     exit(0)
 	
 from selenium.common.exceptions import NoSuchElementException


### PR DESCRIPTION
As I see a lot of people locking for this, I've added a check that there is no other instance of quickstart.py running with a lock file.
I suppose is cross-platform, but for sure any posix will work.
