### PR TITLE
ISSUE-2079: set custom BASE_DIR for instapy settings

### DIFF
--- a/instapy/settings.py
+++ b/instapy/settings.py
@@ -5,6 +5,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 
 class Settings:
+    BASE_DIR=os.environ.get('BASE_DIR', BASE_DIR)
     log_location = os.path.join(BASE_DIR, 'logs')
     database_location = os.path.join(BASE_DIR, 'db', 'instapy.db')
     chromedriver_location = os.path.join(BASE_DIR, 'assets', 'chromedriver')


### PR DESCRIPTION
if you install instapy through pip and don't have the ability or desire to edit settings.py directly you only need set environment var for `BASE_DIR` before running your instapy (you'll need copies of db and proper db structure in base_dir)