### PR TITLE
Avoid stop of execution if there are too few images

### DIFF
--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -796,7 +796,6 @@ class InstaPy:
                                                skip_top_posts)
             except NoSuchElementException:
                 self.logger.warning('Too few images, skipping this location')
-                raise
                 continue
 
             for i, link in enumerate(links):


### PR DESCRIPTION
This raise will stop execution when there are few images than expected.
I don't understand why is there