### PR TITLE
Added a "Required Tag" feature

### DIFF
--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -143,6 +143,7 @@ class InstaPy:
         self.smart_hashtags = []
 
         self.dont_like = ['sex', 'nsfw']
+        self.required_tag = []
         self.ignore_if_contains = []
         self.ignore_users = []
 
@@ -425,6 +426,22 @@ class InstaPy:
             self.aborting = True
 
         self.dont_like = tags or []
+
+        return self
+
+    def set_required_tag(self, tags=None):
+        """Changes the possible restriction tags, if the image does not contain
+         one or more of these tags, the image won't be liked but user 
+         still might be unfollowed. Useful when paired with geo-locoation features"""
+        if self.aborting:
+            return self
+
+        if not isinstance(tags, list):
+            self.logger.warning('Unable to use your set_required_tag '
+                                'configuration!')
+            self.aborting = True
+
+        self.required_tag = tags or []
 
         return self
 
@@ -830,6 +847,7 @@ class InstaPy:
                         check_link(self.browser,
                                    link,
                                    self.dont_like,
+                                   self.required_tag,
                                    self.ignore_if_contains,
                                    self.logger)
                     )
@@ -1007,6 +1025,7 @@ class InstaPy:
                         check_link(self.browser,
                                    link,
                                    self.dont_like,
+                                   self.required_tag,
                                    self.ignore_if_contains,
                                    self.logger)
                     )
@@ -1183,6 +1202,7 @@ class InstaPy:
                         check_link(self.browser,
                                    link,
                                    self.dont_like,
+                                   self.required_tag,
                                    self.ignore_if_contains,
                                    self.logger)
                     )
@@ -1423,6 +1443,7 @@ class InstaPy:
                         check_link(self.browser,
                                    link,
                                    self.dont_like,
+                                   self.required_tag,
                                    self.ignore_if_contains,
                                    self.logger)
                     )
@@ -1598,6 +1619,7 @@ class InstaPy:
                         check_link(self.browser,
                                    link,
                                    self.dont_like,
+                                   self.required_tag,
                                    self.ignore_if_contains,
                                    self.logger)
                     )
@@ -2357,6 +2379,7 @@ class InstaPy:
                                 check_link(self.browser,
                                            link,
                                            self.dont_like,
+                                           self.required_tag,
                                            self.ignore_if_contains,
                                            self.logger)
                             )
@@ -2764,6 +2787,7 @@ class InstaPy:
                         check_link(self.browser,
                                    link,
                                    self.dont_like,
+                                   self.required_tag,
                                    self.ignore_if_contains,
                                    self.logger)
                     )
@@ -2853,6 +2877,7 @@ class InstaPy:
                     check_link(self.browser,
                                url,
                                self.dont_like,
+                               self.required_tag,
                                self.ignore_if_contains,
                                self.logger)
                 )

--- a/instapy/like_util.py
+++ b/instapy/like_util.py
@@ -580,7 +580,7 @@ def check_link(browser, post_link, dont_like, required_tag, ignore_if_contains, 
                           (re.split(r'\W+', required_tags_regex))[3] if required_tags_regex.startswith('#[\\d\\w]+') else     # ']word'
                            (re.split(r'\W+', required_tags_regex))[1])                                                      # '#word'
                 has_required_tag = True
-        if !has_required_tag:
+        if  not has_required_tag:
             req_unit = 'Does not contain at least one required tag!'
             return True, user_name, is_video, req_unit, "Missing Req Tags"
 

--- a/instapy/like_util.py
+++ b/instapy/like_util.py
@@ -431,13 +431,14 @@ def get_links_for_username(browser,
     return links[:amount]
 
 
-def check_link(browser, post_link, dont_like, ignore_if_contains, logger):
+def check_link(browser, post_link, dont_like, required_tag, ignore_if_contains, logger):
     """
     Check the given link if it is appropriate
 
     :param browser: The selenium webdriver instance
     :param link:
     :param dont_like: hashtags of inappropriate phrases
+    :param required_tag: hastags that post *must* contain (useful for Geolocation)
     :param ignore_if_contains:
 
     :param logger: the logger instance
@@ -541,6 +542,19 @@ def check_link(browser, post_link, dont_like, ignore_if_contains, logger):
             dont_like_regex.append(
                 "#[\d\w]*" + dont_likes + "[\d\w]*([^\d\w]|$)")
 
+    required_tag_regex = []
+    
+    for req_tags in required_tag:
+        if req_tags.startswith("#"):
+            required_tag_regex.append(req_tags + "([^\d\w]|$)")
+        elif req_tags.startswith("["):
+            required_tag_regex.append("#" + req_tags[1:] + "[\d\w]+([^\d\w]|$)")
+        elif req_tags.startswith("]"):
+            required_tag_regex.append("#[\d\w]+" + req_tags[1:] + "([^\d\w]|$)")
+        else:
+            required_tag_regex.append(
+                "#[\d\w]*" + req_tags + "[\d\w]*([^\d\w]|$)")
+
     for dont_likes_regex in dont_like_regex:
         quash = re.search(dont_likes_regex, image_text, re.IGNORECASE)
         if quash:
@@ -553,6 +567,22 @@ def check_link(browser, post_link, dont_like, ignore_if_contains, logger):
                 quashed if iffy == quashed else
                 '" in "'.join([str(iffy), str(quashed)]))
             return True, user_name, is_video, inapp_unit, "Undesired word"
+        
+    if len(required_tag) > 0:
+        has_required_tag = False
+        
+        for required_tags_regex in required_tag_regex:
+            quash = re.search(required_tags_regex, image_text, re.IGNORECASE)
+            if quash:
+                quashed = (((quash.group(0)).split('#')[1]).split(' ')[0]).split('\n')[0].encode('utf-8')   # dismiss possible space and newlines
+                iffy = ((re.split(r'\W+', required_tags_regex))[3] if required_tags_regex.endswith('*([^\\d\\w]|$)') else   # 'word' without format
+                         (re.split(r'\W+', required_tags_regex))[1] if required_tags_regex.endswith('+([^\\d\\w]|$)') else   # '[word'
+                          (re.split(r'\W+', required_tags_regex))[3] if required_tags_regex.startswith('#[\\d\\w]+') else     # ']word'
+                           (re.split(r'\W+', required_tags_regex))[1])                                                      # '#word'
+                has_required_tag = True
+        if !has_required_tag:
+            req_unit = 'Does not contain at least one required tag!'
+            return True, user_name, is_video, req_unit, "Missing Req Tags"
 
     return False, user_name, is_video, 'None', "Success"
 

--- a/tests/test_like_util.py
+++ b/tests/test_like_util.py
@@ -13,6 +13,6 @@ class TestCheckLink:
             [{'media': {'is_video': False, 'owner': {'username': 'john'}, 'caption': '#f\xf6o'}}],
             '']
         inappropriate, user_name, is_video, reason = check_link(
-            browser, MagicMock(), ['#f'], MagicMock(), MagicMock(), MagicMock(),
+            browser, MagicMock(), ['#f'], [], MagicMock(), MagicMock(), MagicMock(),
             None, None, MagicMock())
         assert inappropriate is True


### PR DESCRIPTION
Adds the ability to set one or more tags that must appear in a post to be like-able (via check_links function in like_util). Originally created for a friend that wants to use like_by_location features as well as narrowing the pool of potential posts with required tags. The list of tags is boolean OR, so if any one tag matches, then it passes the filter.

Usage example:

` session.set_required_tag(['river', '#cityofbridges'])`
` session.like_by_locations(['213470852/pittsburgh-pennsylvania/'], amount=200, media='Photo')`

I'm going to have a hearty laugh if there was already an easier way to do this.