### PR TITLE
Faster way to check if user is private

### DIFF
--- a/instapy/like_util.py
+++ b/instapy/like_util.py
@@ -324,7 +324,8 @@ def get_links_for_username(browser,
     abort = True
 
     try:
-	is_private = browser.execute_script("return window._sharedData.entry_data.ProfilePage[0].graphql.user.is_private")
+	is_private = browser.execute_script(
+		"return window._sharedData.entry_data.ProfilePage[0].graphql.user.is_private")
     except:
         logger.info('Interaction begin...')
     else:

--- a/instapy/like_util.py
+++ b/instapy/like_util.py
@@ -324,8 +324,7 @@ def get_links_for_username(browser,
     abort = True
 
     try:
-        is_private = body_elem.find_element_by_xpath(
-            '//h2[@class="_kcrwx"]')
+	is_private = browser.execute_script("return window._sharedData.entry_data.ProfilePage[0].graphql.user.is_private")
     except:
         logger.info('Interaction begin...')
     else:


### PR DESCRIPTION
Updated how we check if the user is private because it took 25 seconds with the find_element_by_xpath function.
It takes less than a second with this edit.