### PR TITLE
Delete user from followedPool if no longer exists (account suspended / removed / name changed)

### DIFF
--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -1027,7 +1027,7 @@ class InstaPy:
                             already_liked += 1
                     else:
                         self.logger.info(
-                            '--> Image not liked: {}'.format(reason.encode('utf-8')))
+                            '--> Image not liked: {}'.format(reason))
                         inap_img += 1
                 except NoSuchElementException as err:
                     self.logger.error('Invalid Page: {}'.format(err))
@@ -1209,7 +1209,7 @@ class InstaPy:
                             already_liked += 1
                     else:
                         self.logger.info(
-                            '--> Image not liked: {}'.format(reason.encode('utf-8')))
+                            '--> Image not liked: {}'.format(reason))
                         inap_img += 1
                 except NoSuchElementException as err:
                     self.logger.error('Invalid Page: {}'.format(err))
@@ -1398,7 +1398,7 @@ class InstaPy:
 
                     else:
                         self.logger.info(
-                            '--> Image not liked: {}'.format(reason.encode('utf-8')))
+                            '--> Image not liked: {}'.format(reason))
                         inap_img += 1
                 except NoSuchElementException as err:
                     self.logger.error('Invalid Page: {}'.format(err))
@@ -1581,7 +1581,7 @@ class InstaPy:
 
                     else:
                         self.logger.info(
-                            '--> Image not liked: {}'.format(reason.encode('utf-8')))
+                            '--> Image not liked: {}'.format(reason))
                         inap_img += 1
                 except NoSuchElementException as err:
                     self.logger.info('Invalid Page: {}'.format(err))
@@ -2034,7 +2034,7 @@ class InstaPy:
                                     already_liked += 1
                             else:
                                 self.logger.info(
-                                    '--> Image not liked: {}'.format(reason.encode('utf-8')))
+                                    '--> Image not liked: {}'.format(reason))
                                 inap_img += 1
                                 if reason == 'Inappropriate' and unfollow:
                                     unfollow_user(self.browser, self.logger)

--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -1027,7 +1027,7 @@ class InstaPy:
                             already_liked += 1
                     else:
                         self.logger.info(
-                            '--> Image not liked: {}'.format(reason.encode('utf-8')))
+                            '--> Image not liked: {}'.format(reason))
                         inap_img += 1
                 except NoSuchElementException as err:
                     self.logger.error('Invalid Page: {}'.format(err))

--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -1027,7 +1027,7 @@ class InstaPy:
                             already_liked += 1
                     else:
                         self.logger.info(
-                            '--> Image not liked: {}'.format(reason))
+                            '--> Image not liked: {}'.format(reason.encode('utf-8')))
                         inap_img += 1
                 except NoSuchElementException as err:
                     self.logger.error('Invalid Page: {}'.format(err))

--- a/instapy/unfollow_util.py
+++ b/instapy/unfollow_util.py
@@ -258,6 +258,8 @@ def unfollow(browser,
                             '--> Unfollow error with {},'
                             ' maybe no longer exists...'
                                 .format(person.encode('utf-8')))
+                        delete_line_from_file('{0}{1}_followedPool.csv'.format(logfolder, username), person + ",\n", logger)
+
                         continue
 
                     if following:


### PR DESCRIPTION
[Discussed here: #2359] Delete user if followed with InstaPy, and when trying to unfollow it doesn't exist and remains in the followedPool.
Removed some unnecessary encodes (tested for weeks with no issues).