### PR TITLE
Fixes for the #2563

### DIFF
--- a/instapy/database_engine.py
+++ b/instapy/database_engine.py
@@ -1,4 +1,3 @@
-import time
 import os
 import sqlite3
 

--- a/instapy/database_engine.py
+++ b/instapy/database_engine.py
@@ -13,9 +13,16 @@ def get_db(make=False):
     credentials = Settings.profile
     # get existing profile credentials
     id, name = credentials.values()
-    # make sure the location points to a database file
+    # make sure the address points to a database file
     if not address.endswith(".db"):
-        address += "instapy.db" if address.endswith(("\\", "/")) else "/instapy.db"
+        slash = "\\" if "\\" in address else "/"
+        address = address if address.endswith(slash) else address+slash
+        address += "instapy.db"
+        Settings.database_location = address
+    # make the given path if not exists
+    db_dir = os.path.dirname(address)
+    if not os.path.exists(db_dir):
+        os.makedirs(db_dir)
 
     make = True if not os.path.isfile(address) else make
 
@@ -24,7 +31,7 @@ def get_db(make=False):
             conn = sqlite3.connect(address)
             with conn:
                 conn.row_factory = sqlite3.Row
-                cur = conn.cursor()        
+                cur = conn.cursor()
 
                 #get 'profiles' table ready
                 cur.execute("""

--- a/instapy/settings.py
+++ b/instapy/settings.py
@@ -13,4 +13,4 @@ class Settings:
     loggers = {}
     logger = None
     # Set current profile credentials for DB operations
-    profile = {"id":None, "name":None}   
+    profile = {"id":None, "name":None}

--- a/instapy/util.py
+++ b/instapy/util.py
@@ -668,7 +668,6 @@ def dump_record_activity(profile_name, logger, logfolder):
             data = cur.fetchall()
 
         if data:
-            data = dict(data)
             record_data = {}
 
             # get the existing data
@@ -681,11 +680,11 @@ def dump_record_activity(profile_name, logger, logfolder):
 
             # pack the new data
             for day in data:
-                record_data[day["created"]] = {"likes":day["likes"],
-                                                 "comments":day["comments"],
-                                                  "follows":day["follows"],
-                                                   "unfollows":day["unfollows"],
-                                                    "server_calls":day["server_calls"]}
+                record_data[day[-1]] = {"likes":day[1],
+                                         "comments":day[2],
+                                          "follows":day[3],
+                                           "unfollows":day[4],
+                                            "server_calls":day[5]}
             current_data[profile_name] = record_data
 
             # dump the fresh record data to a local human readable JSON


### PR DESCRIPTION
Hey guys, I've included a few issues from people after #2563 and the solutions for them.  

**1**. I didn't know that `git` doesn't like empty folders where it removed the **db** folder after **instapy.db** pre-loaded file was removed.  
+ Added a smart layer to make the **path** in the given or default database location **if not exists**  

>  Other options are adding some small info file so that it is not empty to be removed by `git` OR add that file to `.gitkeep`, etc. But these options will work only for default **db** folder, so I chose a solution which will also work for custom locations off `Settings` class, too.

_Affected users **were** WHO cloned/downloaded the repo after #2563. But e.g. users who just pulled #2563 as an update could not face that issue, cos `git` keeps that **db** folder for them._ 

**2**. There is an issue with fetching the data from a DB and making a good dictionary from it while dumping **record activity** data. I have forgotten about `fetchall` vs `fetchone`, so it's my mistake and is fixed.  
>Actually the new code for it was the old code I used while testing, but before pushed #2563, I did that replacement (_for the sake of readability_) and thought it will work 100% 😂 which lead to this issue.

_I have really tested each bit of that PR but some unexpected issues pops up all the time and I'm still here to fix if any._

Cheers 😁