### PR TITLE
Fix slicing issue off #2563 (hit py2)

### DIFF
--- a/instapy/unfollow_util.py
+++ b/instapy/unfollow_util.py
@@ -976,7 +976,7 @@ def dump_follow_restriction(profile_name, logger, logfolder):
                 current_data = {}
 
             # pack the new data
-            follow_data = dict(user_data[1:3] for user_data in data or [])
+            follow_data = {user_data[1]: user_data[2] for user_data in data or []}
             current_data[profile_name] = follow_data
 
             # dump the fresh follow data to a local human readable JSON


### PR DESCRIPTION
Highlighted, troubleshooted and solved at  #2589.

Shortly, I will say that it is a runtime error happened for some old python versions (_like 2.7_) where **slicing** the elements of a fetched _sqlite3_ `Row` _list_ is not yet implemented.  
Please see #2589 for more technical details.

>Earlier I've mostly used **replit** to test some little code off py2 portability but this time having a DB situation made me finally install python `2` on local system 😀 and now looking forward to install a good _tester_.   

_Special thanks to @bianpratama to post a good feedback in order to understand the cause of this **little** error._


Cheers 😁