### PR TITLE
Fix for the most nasty bug off #2563

### DIFF
--- a/instapy/database_engine.py
+++ b/instapy/database_engine.py
@@ -11,7 +11,7 @@ def get_db(make=False):
     logger = Settings.logger
     credentials = Settings.profile
     # get existing profile credentials
-    id, name = credentials.values()
+    id, name = credentials["id"], credentials["name"]
     # make sure the address points to a database file
     if not address.endswith(".db"):
         slash = "\\" if "\\" in address else "/"


### PR DESCRIPTION
Having my **InstaPy** not affected any bit by that, it took lots of time thinking about the heart of this issue,
```erlang

Heeh! Error occured while getting a DB profile for 'None':
	b'NOT NULL constraint failed: profiles.name'

```

And **solved** it 🤝🏼 with the invaluable collaboration and help of @Mehran 💪🏼 WHERE shared the VPS console to troubleshoot the issue and funnily in the first attempt found the cause of it!  
>It's the problem issued in a few **Issues** and discussed in #2578 thread.

**The thing is** before _python_ `3.6`, dictionary order was arbitrary. It means that the dictionaries don't have an order for those versions.  
------------------------------------------------------------------------------------------------------------
#### There **was a line of code** I wrote which relied on a dictionary order and it was what _misbehaving_!
```erlang
profile = {"id":None, "name":None}
```
**And** as we know that **the order of the elements** of `profile` dictionary will be random on versions before _python_ `3.6`, it will cause troubles, **cos** of  this:
```python
id, name = profile.values()
```
_At this place, **sometimes**, `profile` dictionary's keys' order become `{"name", "id"}` instead of expected `{"id", "name"}`._
And the reason it worked sometimes and did **not work other times** is that _randomness_ of the order!
---------------------------------------------------------------------------------------------------------------
Well, we can use `OrderedDict` from `collections` module for _python_ before `3.6` **BUT** let's not touch this dictionary orders again, it is a so nasty data type! 😝

Thanks again, @Mehran to help me find out this 🙋🏼‍♂️  
  




Cheers 😁