### PR TITLE
Faster way to check if user is private

### DIFF
--- a/instapy/like_util.py
+++ b/instapy/like_util.py
@@ -10,9 +10,10 @@ from selenium.common.exceptions import WebDriverException
 from selenium.common.exceptions import NoSuchElementException
 
 from .time_util import sleep
-from .util import update_activity
 from .util import add_user_to_blacklist
 from .util import click_element
+from .util import is_private_profile
+from .util import update_activity
 from .util import web_adress_navigator
 
 
@@ -324,7 +325,7 @@ def get_links_for_username(browser,
     abort = True
 
     try:
-	is_private = browser.execute_script("return window._sharedData.entry_data.ProfilePage[0].graphql.user.is_private")
+        is_private = is_private_profile(browser, logger)
     except:
         logger.info('Interaction begin...')
     else:

--- a/instapy/like_util.py
+++ b/instapy/like_util.py
@@ -324,8 +324,7 @@ def get_links_for_username(browser,
     abort = True
 
     try:
-        is_private = body_elem.find_element_by_xpath(
-            '//h2[@class="_kcrwx"]')
+	is_private = browser.execute_script("return window._sharedData.entry_data.ProfilePage[0].graphql.user.is_private")
     except:
         logger.info('Interaction begin...')
     else:

--- a/instapy/util.py
+++ b/instapy/util.py
@@ -17,6 +17,20 @@ from .time_util import sleep
 from .time_util import sleep_actual
 
 
+def is_private_profile(browser, logger, following=True):
+    is_private = None
+    is_private = browser.execute_script(
+        "return window._sharedData.entry_data."
+        "ProfilePage[0].graphql.user.is_private")
+    # double check with xpath that should work only when we not follwoing a user
+    if is_private is True and not following:
+        logger.info("Is private account you're not following.")
+        body_elem = browser.find_element_by_tag_name('body')
+        is_private = body_elem.find_element_by_xpath(
+            '//h2[@class="_kcrwx"]')
+
+    return is_private
+
 def validate_username(browser,
                       username_or_link,
                       own_username,


### PR DESCRIPTION
Updated how we check if the user is private because it took 25 seconds with the find_element_by_xpath function.
It takes less than a second with this edit.

Work by @mehdichekori @sionking 