### PR TITLE
Pick unfollowers error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,9 @@ logs/
 # pytest
 .pytest_cache/
 tests/logs
+unfollow.py
+meinerttt.py
+master.py
+follow.py
+
+myLogs/

--- a/.gitignore
+++ b/.gitignore
@@ -107,9 +107,3 @@ logs/
 # pytest
 .pytest_cache/
 tests/logs
-unfollow.py
-meinerttt.py
-master.py
-follow.py
-
-myLogs/

--- a/instapy/relationship_tools.py
+++ b/instapy/relationship_tools.py
@@ -863,9 +863,12 @@ def load_followers_data(username, compare_by, compare_track, logger, logfolder):
             structured_entries = {"years":{entry_year:{"months":{entry_month:{"days":{entry_day:{"entries":[entry]}}}}}}}
             continue
 
-        existing_years = list(year for year, month in structured_entries["years"].items())
-        existing_months = list(month for month, day in structured_entries["years"][entry_year]["months"].items())
-        existing_days = list(day for day, entry in structured_entries["years"][entry_year]["months"][entry_month]["days"].items())
+        try:
+            existing_years = list(year for year, month in structured_entries["years"].items())
+            existing_months = list(month for month, day in structured_entries["years"][entry_year]["months"].items())
+            existing_days = list(day for day, entry in structured_entries["years"][entry_year]["months"][entry_month]["days"].items())
+        except Exception as e:
+            print('Error: {0}'.format(e))
         
         if entry_year not in existing_years:
             structured_entries["years"][entry_year] = {"months":{entry_month:{"days":{entry_day:{"entries":[entry]}}}}}


### PR DESCRIPTION
An exception was thrown each time I ran this.

    all_unfollowers, active_unfollowers = session.pick_unfollowers(username="xxxxxx", compare_by="earliest", compare_track="first", live_match=True, store_locally=True, print_out=True)