### PR TITLE
Unfollow list returned

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,8 @@ logs/
 # pytest
 .pytest_cache/
 tests/logs
+unfollow.py
+meinerttt.py
+master.py
+follow.py
+myLogs/ 

--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,6 @@ meinerttt.py
 master.py
 follow.py
 myLogs/ 
+all_unfollowers.py
+nonfollower_clean.py
+test.py

--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,4 @@ myLogs/
 all_unfollowers.py
 nonfollower_clean.py
 test.py
+

--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -129,6 +129,7 @@ class InstaPy:
         self.commented = 0
         self.followed_by = 0
         self.unfollowNumber = 0
+        self.unfollow_list = []
         self.not_valid_users = 0
 
         self.follow_times = 1
@@ -2266,7 +2267,7 @@ class InstaPy:
                                                                  self.logfolder)
 
         try:
-            unfollowNumber = unfollow(self.browser,
+            unfollowNumber, unfollow_list = unfollow(self.browser,
                                       self.username,
                                       amount,
                                       customList,
@@ -2281,6 +2282,7 @@ class InstaPy:
                                       sleep_delay,
                                       self.logger,
                                       self.logfolder)
+            self.unfollow_list = unfollow_list
             self.logger.info(
                 "--> Total people unfollowed : {}\n".format(unfollowNumber))
             self.unfollowNumber += unfollowNumber

--- a/instapy/unfollow_util.py
+++ b/instapy/unfollow_util.py
@@ -147,10 +147,10 @@ def unfollow(browser,
 
     if allfollowing is None:
         logger.warning("Unable to find the count of users followed  ~leaving unfollow feature")
-        return 0
+        return 0, []
     elif allfollowing == 0:
         logger.warning("There are 0 people to unfollow  ~leaving unfollow feature")
-        return 0
+        return 0, []
 
     if amount > allfollowing:
         logger.info("There are less users to unfollow than you have requested:  "
@@ -190,7 +190,7 @@ def unfollow(browser,
 
             elif unfollow_track != "all":
                 logger.info("Unfollow track is not specified! ~choose \"all\" or \"nonfollowers\"")
-                return 0
+                return 0, []
 
         #re-generate unfollow list according to the `unfollow_after` parameter for `customList` and `nonFollowers` technics
         if customList == True or nonFollowers == True:
@@ -214,7 +214,7 @@ def unfollow(browser,
 
         if len(unfollow_list) < 1:
             logger.info("There are no any users available to unfollow")
-            return 0
+            return 0, []
 
         #choose the desired order of the elements
         if style == "LIFO":
@@ -341,10 +341,15 @@ def unfollow(browser,
                     logger.info("Not unfollowing '{}'!  ~user is in the list {}\n".format(person, list_type))
                     continue
 
+
+
         except BaseException as e:
             logger.error("Unfollow loop error:  {}\n".format(str(e)))
 
     elif allFollowing == True:
+
+        unfollow_list = []
+
         logger.info("Unfollowing the users you are following")
         # unfollow from profile
         try:
@@ -356,7 +361,7 @@ def unfollow(browser,
             update_activity()
         except BaseException as e:
             logger.error("following_link error {}".format(str(e)))
-            return 0
+            return 0, []
 
         #scroll down the page to get sufficient amount of usernames
         get_users_through_dialog(browser, None, username, amount,
@@ -386,6 +391,9 @@ def unfollow(browser,
         not_found = []
 
         for button, person in user_info:
+            unfollow_list.append(person)
+
+        for button, person in user_info:
             if person not in automatedFollowedPool["all"]:
                 not_found.append(person)
             elif (person in automatedFollowedPool["all"] and
@@ -399,7 +407,7 @@ def unfollow(browser,
 
         if len(user_info) < 1:
             logger.info("There are no any users to unfollow")
-            return 0
+            return 0, []
         elif len(user_info) < amount:
             logger.info("Could not grab requested amount of usernames to unfollow:  "
                 "{}/{}  ~using available amount".format(len(user_info), amount))
@@ -471,7 +479,7 @@ def unfollow(browser,
     else:
         logger.info("Please select a proper unfollow method!  ~leaving unfollow activity\n")
 
-    return unfollowNum
+    return unfollowNum, unfollow_list
 
 
 def follow_user(browser, login, user_name, blacklist, logger, logfolder):


### PR DESCRIPTION
Made the unfollow method return the list of users attempting to unfollow. Usefull to conflude if all possible users have been unfollowed or the job needs to be restarted. E.g. by comparing len(unfollow_list) with unfollowNumber