### PR TITLE
Prevent indexing error once `quick_username` comes out empty and other fix

### DIFF
--- a/instapy/like_util.py
+++ b/instapy/like_util.py
@@ -357,6 +357,8 @@ def get_links_for_username(browser,
 
     while len(links) < amount:
         initial_links = links
+        browser.execute_script(
+            "window.scrollTo(0, document.body.scrollHeight);")
         body_elem.send_keys(Keys.HOME)
         # update server calls after a scroll request
         update_activity()

--- a/instapy/unfollow_util.py
+++ b/instapy/unfollow_util.py
@@ -676,7 +676,8 @@ def get_users_through_dialog(browser,
                 quick_index = random.randint(0, len(buttons)-1)
                 quick_button = buttons[quick_index]
                 quick_username = dialog_username_extractor(quick_button)
-                if quick_username[0] not in simulated_list:
+
+                if quick_username and quick_username[0] not in simulated_list:
                     quick_follow = follow_through_dialog(browser,
                                                          login,
                                                          quick_username,


### PR DESCRIPTION
It popped up last weeks and was issued in a few **Issues** until solved at https://github.com/timgrossmann/InstaPy/issues/2555#issuecomment-410475845.

If you read that comment in #2555 you will understand why I did not include it in a PR yet.
Basically, I wanted to understand how that `quick_username` variable can be empty.

But having no any continuous feedback I still am unsure about it.
Yet, the change included in this PR is still operational and harmless and will prevent possible crashes at that point.

If you want to understand why it may return an empty list, have a read this comment by the author of previously called `follow_through_dialog` (@BernardoGO?).
There is a comment line in `dialog_username_extractor` of **unfollow_util.py** file which is used to extract the `quick_username` from `quick_button`.
```python
            except IndexError:
                pass  # Element list is too short to have a [1] element
```
Maybe some of you can understand how a valid (_I think_) button can can pop up `IndexError` at that stage and help me understand it 🤔

#### Again saying, the change in this PR solves the situation clearly and the rest is just my curiosity about the `IndexError` at that stage 😟
And after one more guy asked for help on that issue, I decided to PR it, finally.

-------

Cheers 😁
-------