### PR TITLE
Log the userid when following other users

### DIFF
--- a/instapy/print_log_writer.py
+++ b/instapy/print_log_writer.py
@@ -57,13 +57,13 @@ def log_following_num(browser, username, logfolder):
     return following_num
 
 
-def log_followed_pool(login, followed, logger, logfolder, logtime):
+def log_followed_pool(login, followed, logger, logfolder, logtime, userid):
     """Prints and logs the followed to
     a seperate file"""
     try:
         with open('{0}{1}_followedPool.csv'.format(logfolder, login), 'a+') as followPool:
             with interruption_handler():
-                followPool.write('{} ~ {},\n'.format(logtime, followed))
+                followPool.write('{} ~ {} ~ {},\n'.format(logtime, followed,userid))
     except BaseException as e:
         logger.error("log_followed_pool error {}".format(str(e)))
 

--- a/instapy/unfollow_util.py
+++ b/instapy/unfollow_util.py
@@ -316,8 +316,7 @@ def unfollow(browser,
                                 ' now unfollowing: {}'
                                 .format(str(unfollowNum), amount, person.encode('utf-8')))
 
-                            delete_line_from_file('{0}{1}_followedPool.csv'.format(logfolder, username), person +
-                                              ",\n", logger)
+                            delete_line_from_file('{0}{1}_followedPool.csv'.format(logfolder, username), person, logger)
 
                             print('')
                             sleep(15)
@@ -349,7 +348,7 @@ def unfollow(browser,
                             .format(str(unfollowNum), person.encode('utf-8')))
 
                         delete_line_from_file('{0}{1}_followedPool.csv'.format(logfolder, username),
-                                              person + ",\n", logger)
+                                              person, logger)
 
                         print('')
                         sleep(2)
@@ -358,7 +357,7 @@ def unfollow(browser,
                     # if he is a white list user (set at init and not during run time)
                     if person in white_list:
                         delete_line_from_file('{0}{1}_followedPool.csv'.format(logfolder, username),
-                                              person + ",\n", logger)
+                                              person, logger)
                         list_type = 'whitelist'
                     else:
                         list_type = 'dont_include'
@@ -474,8 +473,7 @@ def unfollow(browser,
                         '--> Ongoing Unfollow {}/{}, now unfollowing: {}'
                         .format(str(unfollowNum), amount, person.encode('utf-8')))
 
-                    delete_line_from_file('{0}{1}_followedPool.csv'.format(logfolder, username), person +
-                                      ",\n", logger)
+                    delete_line_from_file('{0}{1}_followedPool.csv'.format(logfolder, username), person, logger)
 
                     print('')
                     sleep(15)
@@ -557,8 +555,7 @@ def unfollow_user(browser, username, person, relationship_data, logger, logfolde
         click_element(browser, unfollow_button) # unfollow_button.send_keys("\n")
         logger.warning("--> Unfollowed '{}' due to Inappropriate Content".format(person))
 
-        delete_line_from_file('{0}{1}_followedPool.csv'.format(logfolder, username), person +
-                          ",\n", logger)
+        delete_line_from_file('{0}{1}_followedPool.csv'.format(logfolder, username), person, logger)
 
         if person in relationship_data[username]["all_following"]:
             relationship_data[username]["all_following"].remove(person)

--- a/instapy/unfollow_util.py
+++ b/instapy/unfollow_util.py
@@ -91,7 +91,7 @@ def get_following_status(browser, person, logger):
     except:
         logger.error(
             '--> Unfollow error with {},'
-            ' maybe no longer exists...'
+            ' maybe no longer exists....'
                 .format(person.encode('utf-8')))
 
     return following, follow_button
@@ -236,6 +236,7 @@ def unfollow(browser,
         try:
             sleep_counter = 0
             sleep_after = random.randint(8, 12)
+            index = 0
 
             for person in unfollow_list:
                 if unfollowNum >= amount:
@@ -255,27 +256,25 @@ def unfollow(browser,
                     pass
 
                 if person not in dont_include:
-                    browser.get('https://www.instagram.com/' + person)
                     sleep(2)
-
                     try:
+                        browser.get('https://www.instagram.com/' + person)
                         following, follow_button = get_following_status(browser, person, logger)
                     except:
                         logger.warning(
                             '--> Unfollow error with {},'
                             ' maybe username has changed...'
                                 .format(person.encode('utf-8')))
-                        try:
-                            browser.get('https://www.instagram.com/web/friendships/{}/follow/'.format(person.userid))
-                            sleep(2)
-                            following, follow_button = get_following_status(browser, person, logger)
-                        except:
-                            logger.error(
-                                '--> Unfollow error with {},'
-                                ' maybe no longer exists...'
-                                    .format(person.encode('utf-8')))
-                            continue
-
+                        pass
+                    try:
+                        browser.get('https://www.instagram.com/web/friendships/{}/follow/'.format(unfollowid_list[index]))
+                        following, follow_button = get_following_status(browser, person, logger)
+                    except:
+                        logger.error(
+                            '--> Unfollow error with {},'
+                            ' maybe no longer exists...'
+                                .format(person.encode('utf-8')))
+                        continue
 
                     if following:
                         # click the button
@@ -354,8 +353,8 @@ def unfollow(browser,
                     else:
                         list_type = 'dont_include'
                     logger.info("Not unfollowing '{}'!  ~user is in the list {}\n".format(person, list_type))
+                    index += 1
                     continue
-
         except BaseException as e:
             logger.error("Unfollow loop error:  {}\n".format(str(e)))
 
@@ -506,7 +505,7 @@ def follow_user(browser, login, user_name, blacklist, logger, logfolder):
                 "arguments[0].style.opacity = 1", follow_button)
             click_element(browser, follow_button) # follow_button.click()
         update_activity('follows')
-        userid = browser.execute_script("return window._sharedData.entry_data.ProfilePage[0].graphql.user.id")
+        userid = browser.execute_script("return window._sharedData.entry_data.PostPage[0].graphql.shortcode_media.owner.id")
 
         logger.info('--> Now following')
         logtime = datetime.now().strftime('%Y-%m-%d %H:%M')
@@ -584,6 +583,7 @@ def follow_given_user(browser,
         logger.info('---> Now following: {}'.format(acc_to_follow))
         logtime = datetime.now().strftime('%Y-%m-%d %H:%M')
         userid = browser.execute_script("return window._sharedData.entry_data.ProfilePage[0].graphql.user.id")
+        #userid = browser.execute_script("return window._sharedData.entry_data.PostPage[0].graphql.shortcode_media.owner.id")
         log_followed_pool(login, acc_to_follow, logger, logfolder, logtime, userid)
         follow_restriction("write", acc_to_follow, None, logger)
 

--- a/instapy/unfollow_util.py
+++ b/instapy/unfollow_util.py
@@ -261,7 +261,7 @@ def unfollow(browser,
                         browser.get('https://www.instagram.com/' + person)
                         following, follow_button = get_following_status(browser, person, logger)
                     except:
-                        logger.warning(
+                        logger.error(
                             '--> Unfollow error with {},'
                             ' maybe username has changed...'
                                 .format(person.encode('utf-8')))

--- a/instapy/unfollow_util.py
+++ b/instapy/unfollow_util.py
@@ -770,7 +770,7 @@ def follow_through_dialog(browser,
                 click_element(browser, button)
                 sleep(1)
 
-                browser.get('https://www.instagram.com/' + username)
+                browser.get('https://www.instagram.com/' + person)
                 userid = browser.execute_script("return window._sharedData.entry_data.ProfilePage[0].graphql.user.id")
                 
                 logtime = datetime.now().strftime('%Y-%m-%d %H:%M')

--- a/instapy/util.py
+++ b/instapy/util.py
@@ -384,7 +384,7 @@ def delete_line_from_file(filepath, lineToDelete, logger):
 
         f = open(file_path_Temp, "w")
         for line in lines:
-            if not line.endswith(lineToDelete):
+            if (line.find(lineToDelete) < 0):
                 f.write(line)
             else:
                 logger.info("\tRemoved '{}' from followedPool.csv file".format(line.split(',\n')[0]))

--- a/quickstart.py
+++ b/quickstart.py
@@ -6,8 +6,8 @@ from selenium.common.exceptions import NoSuchElementException
 
 from instapy import InstaPy
 
-insta_username = ''
-insta_password = ''
+insta_username = 'comeshareit'
+insta_password = 'WATWATWAT'
 
 # set headless_browser=True if you want to run InstaPy on a server
 

--- a/quickstart.py
+++ b/quickstart.py
@@ -6,8 +6,8 @@ from selenium.common.exceptions import NoSuchElementException
 
 from instapy import InstaPy
 
-insta_username = 'comeshareit'
-insta_password = 'WATWATWAT'
+insta_username = ''
+insta_password = ''
 
 # set headless_browser=True if you want to run InstaPy on a server
 


### PR DESCRIPTION
I have thought of implement this for awhile now,  Especially after got more than 100+ user that stuck in my following list that not able to unfollow (most likely they have changed their username)

Finally I was able to implement it after I got back from a long business trip. 

here are the changes:

Inside the `USERNAME_followedPool.csv` instead of only logging the username as it was (today) e.g.
```
2018-08-21 16:04 ~ javaabcdefg
```

It now become something like this 
```
2018-08-21 16:04 ~ javaabcdefg ~ 1234567890
```

**During unfollow procedure, if the instapy not able to load the following user profile by the `name` it will try use the `userid` that was logged to get to the profile page.** Which means, whatever the username change into, we should always able to find the user and to unfollow it. (unless the user is been deleted/bloced/banned, i'm not sure how does Instagram gonna treat on that situation, assume it will be automatially removed from your following list) 

please point out if anything I might have missed and happy contributing. 