### PR TITLE
Fix: proxy_port default value is None instead of 0

### DIFF
--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -82,7 +82,7 @@ class InstaPy:
                  headless_browser=False,
                  proxy_address=None,
                  proxy_chrome_extension=None,
-                 proxy_port=0,
+                 proxy_port=None,
                  bypass_suspicious_attempt=False,
                  multi_logs=False):
 
@@ -241,7 +241,7 @@ class InstaPy:
             # this setting can improve pageload & save bandwidth
             firefox_profile.set_preference('permissions.default.image', 2)
 
-            if self.proxy_address and self.proxy_port > 0:
+            if self.proxy_address and self.proxy_port:
                 firefox_profile.set_preference('network.proxy.type', 1)
                 firefox_profile.set_preference('network.proxy.http',
                                                self.proxy_address)
@@ -274,7 +274,7 @@ class InstaPy:
                                             .format(user_agent=user_agent))
             capabilities = DesiredCapabilities.CHROME
             # Proxy for chrome
-            if self.proxy_address and self.proxy_port > 0:
+            if self.proxy_address and self.proxy_port:
                 prox = Proxy()
                 proxy = ":".join([self.proxy_address, self.proxy_port])
                 prox.proxy_type = ProxyType.MANUAL


### PR DESCRIPTION
Although there is already [PR to fix such issue](https://github.com/timgrossmann/InstaPy/pull/2711) (and I am sorry for duplicate, initially I just fixed it for myself), it's incomplete and I think that changing port argument type from int to string is not a correct way to solve the problem (it may require changes for existing projects).
