### PR TITLE
Fix #2787, Do not like the post if ignore word is included in the caption

### DIFF
--- a/instapy/like_util.py
+++ b/instapy/like_util.py
@@ -483,7 +483,7 @@ def check_link(browser, post_link, dont_like, mandatory_words, ignore_if_contain
             return True, user_name, is_video, 'Mandatory words not fulfilled', "Not mandatory likes"
 
     if any((word in image_text for word in ignore_if_contains)):
-        return False, user_name, is_video, 'None', "Pass"
+        return True, user_name, is_video, 'None', "Pass"
 
     dont_like_regex = []
 


### PR DESCRIPTION
Here's a fix of https://github.com/timgrossmann/InstaPy/issues/2787.

But the real question is, how come nobody complained about this not working?