### PR TITLE
Fix MoveTargetOutOfBoundsException on Legacy Firefox

### DIFF
--- a/examples/firefox_patcher.py
+++ b/examples/firefox_patcher.py
@@ -1,0 +1,31 @@
+
+from instapy import InstaPy
+from instapy.monkey_patcher import patch_all
+
+#
+# use_firefox=True : Switches the browser from Chrome to Firefox/Geckodriver
+#                    which might be better on ARM based systems
+#                    The default value is False
+#
+# page_delay=25 : Tells the WebDriver to poll the DOM for a certain amount of time
+#                 when trying to find any element (or elements) not immediately available.
+#                 The default setting is 25.
+#
+# set_switch_language(False) : Firefox on english operating systems already defaults to english.
+#                              Set to True if the language seen in the login page is anything but English.
+#                              The default value is True
+#
+
+# Patch ActionChain to reslove MoveTargetOutOfBoundsException issue ref: #803
+patch_all()
+
+
+InstaPy(username='test', password='test', use_firefox=True, page_delay=25)\
+    .set_switch_language(False)\
+    .login()\
+    .set_do_comment(True, percentage=10) \
+    .set_comments(['Cool!', 'Awesome!', 'Nice!']) \
+    .set_dont_include(['friend1', 'friend2', 'friend3']) \
+    .set_dont_like(['food', 'girl', 'hot']) \
+    .like_by_tags(['dog', '#cat'], amount=2) \
+    .end()

--- a/instapy/monkey_patcher.py
+++ b/instapy/monkey_patcher.py
@@ -1,0 +1,18 @@
+from selenium.webdriver.common.action_chains import ActionChains
+
+
+def patch_move_to_element():
+    """Patch move_to_element method in Class ActionChain"""
+    ref_move_to_element = ActionChains.move_to_element
+
+    def override_move_to_element(self, to_element):
+        if "firefox" in self._driver.name:
+            to_element.location_once_scrolled_into_view
+        return self.__move_to_element(to_element)
+
+    setattr(ActionChains, "__move_to_element", ref_move_to_element)
+    setattr(ActionChains, "move_to_element", override_move_to_element)
+
+
+def patch_all():
+    patch_move_to_element()


### PR DESCRIPTION
I'm use InstaPy in raspberry pi and cannot move to newer version of firefox.
I found some bug about MoveTargetOutOfBound if use method move_to_element in ActionChain class
in it like bug in selenium.
bug suggest to fix with manual move to element with alternative way and to something with it. 
I use
Raspberry pi 2
Selenium: 3.4.3
Geckodriver: 0.17.0
Firefox-esr: 52.9.0esr-1~deb9u1

Relate issue: #596 #803 #2591

Solution:
I wrote patch to move to target element before call real method.
I don't call patch in part of InstaPy code to prevent people who use old selenium or geckodrive but I also add example feel free to use.