### PR TITLE
Bug Fix: make sure `unfollow_list` is always a list (rather than a `dict_keys` object)

### DIFF
--- a/instapy/unfollow_util.py
+++ b/instapy/unfollow_util.py
@@ -204,7 +204,7 @@ def unfollow(browser,
 
         elif InstapyFollowed == True:
             logger.info("Unfollowing the users followed by InstaPy\n")
-            unfollow_list = automatedFollowedPool["eligible"].keys()
+            unfollow_list = list(automatedFollowedPool["eligible"].keys())
 
         elif nonFollowers == True:
             logger.info("Unfollowing the users who do not follow back\n")


### PR DESCRIPTION
Problem is when shuffling COS `random.shuffle` cannot work with `dict_keys` objects
For example in my python 3,
```python
zx = {1:2, 3:4}
sl = zx.keys()   # sl is dict_keys([1, 3])
ld = list(zx.keys())   # ld is [1,3]
```

Hint: There is no problem while iterating over `dict_keys` objetcs

_It happened specially after I refactored `set_automated_followed_pool`_

Still wonders how I did not notice bug this before 🤔 until running a test for #2882

------

Cheers 😁
-----