### PR TITLE
Fix issues out of inconsistent delays while after clicking the Unfollow button from the pop up dialog AND some others

### DIFF
--- a/instapy/commenters_util.py
+++ b/instapy/commenters_util.py
@@ -198,7 +198,7 @@ def extract_information(browser, username, daysold, max_pic):
         print ("\nScrapping link: ", link)
         
         try:
-            web_address_navigator(browser,link)
+            web_address_navigator(browser, link)
             user_commented_list, pic_date_time = extract_post_info(browser)     
             user_commented_total_list = user_commented_total_list + user_commented_list
 

--- a/instapy/unfollow_util.py
+++ b/instapy/unfollow_util.py
@@ -288,7 +288,7 @@ def unfollow(browser,
                     logger.warning("--> Unfollow quotient reached its peak!\t~leaving Unfollow-Users activity\n")
                     break
 
-                if sleep_counter >= sleep_after:
+                if sleep_counter >= sleep_after and sleep_delay not in [0, None]:
                     delay_random = random.randint(ceil(sleep_delay*0.85), ceil(sleep_delay*1.14))
                     logger.info("Unfollowed {} new users  ~sleeping about {}\n".format(sleep_counter,
                                     '{} seconds'.format(delay_random) if delay_random < 60 else
@@ -430,7 +430,8 @@ def unfollow(browser,
 
                 if (unfollowNum != 0 and
                         hasSlept is False and
-                            unfollowNum % 10 == 0):
+                            unfollowNum % 10 == 0 and
+                                sleep_delay not in [0, None]):
                     logger.info("sleeping for about {} min\n"
                                 .format(int(sleep_delay/60)))
                     sleep(sleep_delay)

--- a/instapy/unfollow_util.py
+++ b/instapy/unfollow_util.py
@@ -1177,9 +1177,9 @@ def confirm_unfollow(browser):
 
     while attempt<3:
         try:
+            attempt += 1
             button_xp = "//button[text()='Unfollow']"   # "//button[contains(text(), 'Unfollow')]"
             unfollow_button = browser.find_element_by_xpath(button_xp)
-            attempt += 1
 
             if unfollow_button.is_displayed():
                 click_element(browser, unfollow_button)


### PR DESCRIPTION
Hey guys

Here is the reasons for this PR,
+ 1st commit - https://github.com/timgrossmann/InstaPy/issues/2882#issuecomment-420370821
Well to say more words,
it happened cos the button accomplished its job after inconsistent time delays and there is a verification block which was misbehaving.
Now, `explicit_wait()` waits for enough time [default- 66 seconds] and releases back as the button has accomplished its job.
In case of it cannot accomplish its  job - it cannot unfollow; There it will timeout after the pre-defined delay [default- 66 seconds] and will reload page and try the same step again and in case of the second timeout, it will break the loop cos it is a sign of shadow ban.

>The usage of `explicit_wait()` is amazing 👈🏼 stability + performance + simplicity + speed

+ 2nd commit - https://github.com/timgrossmann/InstaPy/issues/2890#issuecomment-420382809

----

Cheers 😁
---------