### PR TITLE
Add decision making in interaction

### DIFF
--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -1906,14 +1906,14 @@ class InstaPy:
             # decision making
             # static conditions
             not_dont_include = username not in self.dont_include
-            follow_restrected = follow_restriction("read", username,
+            follow_restricted = follow_restriction("read", username,
                                                     self.follow_times, self.logger)
             counter = 0
             while True:
                 following = (random.randint(0, 100) <= self.follow_percentage and
                              self.do_follow and
                              not_dont_include and
-                             not follow_restrected)
+                             not follow_restricted)
                 commenting = (random.randint(0, 100) <= self.comment_percentage and
                               self.do_comment and
                               not_dont_include)

--- a/instapy/util.py
+++ b/instapy/util.py
@@ -236,7 +236,7 @@ def add_user_to_blacklist(username, campaign, action, logger, logfolder):
                     'action': action
             })
     except Exception as err:
-        logger.error('blacklist dictWrite error {}'.format(err,))
+        logger.error('blacklist dictWrite error {}'.format(err))
 
     logger.info('--> {} added to blacklist for {} campaign (action: {})'
                 .format(username, campaign, action))


### PR DESCRIPTION
When interaction with a user start we shall:
* do at least one action follow/like/like+comment if validation is pass
* dont follow if one image in posts fail in check_image (optional* default is True)
* roll decision again in second post and beyond.
* fix: don't try to follow (again) when amount of posts is more than 1.
* save time by not checking the data bases over and over (static decisions)

Please verify logic.