### PR TITLE
Case insensitive ignore_if_contains

### DIFF
--- a/instapy/like_util.py
+++ b/instapy/like_util.py
@@ -479,7 +479,9 @@ def check_link(browser, post_link, dont_like, mandatory_words, ignore_if_contain
         if not all((word in image_text for word in mandatory_words)) :
             return True, user_name, is_video, 'Mandatory words not fulfilled', "Not mandatory likes"
 
-    if any((word in image_text for word in ignore_if_contains)):
+    image_text_lower = map(lambda x: x.lower(), image_text)
+    ignore_if_contains_lower = map(lambda x: x.lower(), ignore_if_contains)
+    if any((word in image_text_lower for word in ignore_if_contains_lower)):
         return False, user_name, is_video, 'None', "Pass"
 
     dont_like_regex = []


### PR DESCRIPTION
The ignore_if_contains() method was case sensitive. In my case, I wanted to ignore posts which contained "whatsapp" and realized that "WhatsApp", "whatsAPP", ... were not triggering the ignore.

This PR fixes this by comparing lowercased strings