### PR TITLE
Add missing `update_activity()` lines to update server calls AND lots of Visual changes & Simplifications

### DIFF
--- a/instapy/commenters_util.py
+++ b/instapy/commenters_util.py
@@ -25,16 +25,19 @@ def check_exists_by_xpath(browser, xpath):
         return False
     return True
 
+
+
 def remove_duplicates_preserving_order(seq):
     seen = set()
     seen_add = seen.add
     return [x for x in seq if not (x in seen or seen_add(x))]
 
+
+
 def extract_post_info(browser):
     """Get the information from the current post"""
-                                              
     comments = []                                          
-  
+
     user_commented_list = []
     if browser.find_element_by_xpath("//div/ul"):
         comment_list = browser.find_element_by_xpath("//div/ul")
@@ -43,37 +46,39 @@ def extract_post_info(browser):
         if len(comments) > 1:
             # load hidden comments
             more_comments = 0
+
             while (" comments" in comments[1].text):
                 more_comments += 1
                 print ("loading more comments.")
                 load_more_comments_element = browser.find_element_by_xpath("//div/ul/li[2]/button")
-                browser.execute_script("arguments[0].click();", load_more_comments_element)
-                sleep(1)
+                click_element(browser, load_more_comments_element)
                 #comment_list = post.find_element_by_tag_name('ul')
                 comments = comment_list.find_elements_by_tag_name('li')
+
                 if more_comments > 10:
                     print ("Won't load more than that, moving on..")
                     break
-            
+
             #if post autor didnt write description, more comments text is in first comment
             if more_comments == 0:
                 while (" comments" in comments[0].text):
                     more_comments += 1
                     print ("loading more comments.")
                     load_more_comments_element = browser.find_element_by_xpath("//div/ul/li[1]/button")
-                    browser.execute_script("arguments[0].click();", load_more_comments_element)
-                    sleep(1)
+                    click_element(browser, load_more_comments_element)
                     #comment_list = post.find_element_by_tag_name('ul')
                     comments = comment_list.find_elements_by_tag_name('li')
+
                     if more_comments > 10:
                         print ("Won't load more than that, moving on..")
                         break
-                 
+
             #adding who commented into user_commented_list
             try:
                 for comm in comments:
                     user_commented = comm.find_element_by_tag_name('a').get_attribute("href").split('/')
                     user_commented_list.append(user_commented[3])
+
             except:
                 print ("cant get comments")
                 
@@ -81,6 +86,8 @@ def extract_post_info(browser):
     date_time = browser.find_element_by_tag_name('time').get_attribute("datetime")    
         
     return user_commented_list, date_time
+
+
 
 def extract_information(browser, username, daysold, max_pic):
   
@@ -91,6 +98,7 @@ def extract_information(browser, username, daysold, max_pic):
         num_of_posts = get_number_of_posts(browser)
         num_of_posts = (min (num_of_posts,max_pic))
         #we don't need to scroll more than is max number of posts we want to extract
+
     except:
         print ("\nError: Couldn't get user profile. Moving on..")
         return []
@@ -130,6 +138,7 @@ def extract_information(browser, username, daysold, max_pic):
                 print ("Cannot scroll, quitting..")
                 sleep(0.5)
                 break
+
             else:
                 print ("Scrolling profile ", len(links2), "/", num_of_posts)
                 
@@ -141,17 +150,22 @@ def extract_information(browser, username, daysold, max_pic):
 
                     print ("clicking on one photo..")
                     try:
-                        one_pic_elem = browser.find_element_by_xpath("//section/main/article/div[1]/div/div[10]/div[3]/a/div")
-                        browser.execute_script("arguments[0].click();", one_pic_elem)
+                        one_pic_elem = browser.find_element_by_xpath(
+                                    "//section/main/article/div[1]/div/div[10]/div[3]/a/div")
+                        click_element(browser, one_pic_elem)
+
                     except:
                         print ("Error: cant click on the photo..")
                         pass
+
                     sleep(1.5)
+
                     #following 6 lines give like to opened picture, to use our time effectively and look less suspicious
                     try:
                         like_element = browser.find_elements_by_xpath("//a[@role='button']/span[text()='Like']/..")
-                        browser.execute_script("arguments[0].click();", like_element[0])
+                        click_element(browser, like_element[0])
                         print ("clicking like..")
+
                     except:
                         pass
                     sleep(2)
@@ -162,7 +176,7 @@ def extract_information(browser, username, daysold, max_pic):
                     
                     print ("closing overlay")
                     close_overlay = browser.find_element_by_xpath("//div/div[@role='dialog']")
-                    browser.execute_script("arguments[0].click();", close_overlay)
+                    click_element(browser, close_overlay)
                     
                     print ("date of this picture was:", date_of_pic)
 
@@ -170,6 +184,7 @@ def extract_information(browser, username, daysold, max_pic):
                         print ("\nFinished scrolling, too old photos")
                         sleep(3)
                         break
+
                     else:
                         print ("\nPhotos seems to be fresh, continuing scrolling")
                         sleep(2)
@@ -236,6 +251,8 @@ def extract_information(browser, username, daysold, max_pic):
     print (user_commented_list, "\n")
     return user_commented_list
 
+
+
 def users_liked (browser, photo_url, amount=100):
     photo_likers = []
     try:
@@ -246,7 +263,9 @@ def users_liked (browser, photo_url, amount=100):
         print('Could not get information from post: ' + photo_url,' nothing to return')
             
     return photo_likers
-    
+
+
+
 def likers_from_photo(browser, amount=20):                                       
 
     user_liked_list = []
@@ -282,23 +301,30 @@ def likers_from_photo(browser, amount=20):
         follow_buttons = []
         browser.execute_script(
                 "arguments[0].scrollTop = arguments[0].scrollHeight", dialog)
+        update_activity()
         sleep(1)
+
         follow_buttons = dialog.find_elements_by_xpath(
             "//div/div/button[text()='Follow']")
+
         while (len(follow_buttons) != previous_len) and (len(follow_buttons)<amount):
             if previous_len+10 >= amount:
                 print ("Scrolling finished")
                 sleep(1)
                 break
+
             previous_len = len(follow_buttons)
             browser.execute_script(
                 "arguments[0].scrollTop = arguments[0].scrollHeight", dialog)
+            update_activity()
             sleep(1)
+
             follow_buttons = dialog.find_elements_by_xpath(
             "//div/div/button[text()='Follow']")
             print ("Scrolling down... ",previous_len,"->", len(follow_buttons) ," / ",amount) 
 
         person_list = []
+
         for person in follow_buttons:
             username_url = person.find_element_by_xpath("../../../*").find_element_by_tag_name("a").get_attribute('href')
             username = username_url_to_username(username_url)
@@ -306,21 +332,24 @@ def likers_from_photo(browser, amount=20):
         
         random.shuffle(person_list)     
         sleep(1)
+
         try:
             close = browser.find_element_by_xpath("//span[text()='Close']")
             click_element(browser, close)
             print ("Like window closed")
+
         except:
             pass
                
-        print ("\nGot ",len(person_list)," likers shuffled randomly, who you can follow:\n", person_list, "\n")
+        print("Got {} likers shuffled randomly whom you can follow:\n{}\n".format(len(person_list), person_list))
         return person_list
 
-    except Exception as e:
-        print ("Some problem")
-        print (e)
+    except Exception as exc:
+        print ("Some problem occred!\n\t{}".format(str(exc).encode("utf-8")))
         return []              
-        
+
+
+
 def get_photo_urls_from_profile (browser, username, links_to_return_amount=1, randomize=True):
     #try:   
     #input can be both username or user profile url

--- a/instapy/feed_util.py
+++ b/instapy/feed_util.py
@@ -1,5 +1,6 @@
+""" Module that handles the like features """
+from .util import update_activity
 
-"""Module that handles the like features"""
 from selenium.common.exceptions import NoSuchElementException
 
 
@@ -27,6 +28,7 @@ def get_like_on_feed(browser, amount):
         abort = False
         try:
             like_buttons = browser.find_elements_by_class_name(LIKE_TAG_CLASS)
+
         except NoSuchElementException:
             print('Unale to find the like buttons, Aborting')
             abort = True
@@ -36,11 +38,17 @@ def get_like_on_feed(browser, amount):
 
         for button in like_buttons:
             likes_performed += 1
+
             if not (likes_performed <= amount):
                 print('Performed the required number of likes')
                 break
             yield button
 
         print('---> Total Likes uptil now ->', likes_performed)
+
         browser.execute_script(
             "window.scrollTo(0, document.body.scrollHeight);")
+        update_activity()
+
+
+

--- a/instapy/like_util.py
+++ b/instapy/like_util.py
@@ -31,6 +31,7 @@ def get_links_from_feed(browser, amount, num_of_search, logger):
     for i in range(num_of_search + 1):
         browser.execute_script(
             "window.scrollTo(0, document.body.scrollHeight);")
+        update_activity()
         sleep(2)
 
     # get links
@@ -98,12 +99,16 @@ def get_links_for_location(browser,
         possible_posts = browser.execute_script(
             "return window._sharedData.entry_data."
             "LocationsPage[0].graphql.location.edge_location_to_media.count")
+
     except WebDriverException:
         logger.info("Failed to get the amount of possible posts in '{}' location".format(location))
         possible_posts = None
 
-    logger.info("desired amount: {}  |  top posts [{}]: {}  |  possible posts: {}".format(amount,
-                                      ('enabled' if not skip_top_posts else 'disabled'), len(top_posts), possible_posts))
+    logger.info("desired amount: {}  |  top posts [{}]: {}  |  possible posts: {}".format(
+                    amount,
+                    "enabled" if not skip_top_posts else "disabled",
+                    len(top_posts),
+                    possible_posts))
 
     if possible_posts is not None:
         possible_posts = possible_posts if not skip_top_posts else possible_posts-len(top_posts)
@@ -123,13 +128,14 @@ def get_links_for_location(browser,
                 logger.info("Scrolled too much! ~ sleeping a bit :>")
                 sleep(600)
                 sc_rolled = 0
+
             for i in range(3):
                 browser.execute_script(
                     "window.scrollTo(0, document.body.scrollHeight);")
-                sc_rolled += 1
                 update_activity()
-                sleep(
-                    nap)  # if not slept, and internet speed is low, instagram will only scroll one time, instead of many times you sent scroll command...
+                sc_rolled += 1
+                sleep(nap)  # if not slept, and internet speed is low, instagram will only scroll one time, instead of many times you sent scroll command...
+
             sleep(3)
             links.extend(get_links(browser, location, logger, media, main_elem))
 
@@ -140,19 +146,24 @@ def get_links_for_location(browser,
                 if i not in s:
                     s.add(i)
                     links.append(i)
+
             if len(links) == filtered_links:
                 try_again += 1
                 nap = 3 if try_again == 1 else 5
                 logger.info("Insufficient amount of links ~ trying again: {}".format(try_again))
                 sleep(3)
+
                 if try_again > 2:  # you can try again as much as you want by changing this number
                     if put_sleep < 1 and filtered_links <= 21:
                         logger.info("Cor! Did you send too many requests? ~ let's rest some")
                         sleep(600)
                         put_sleep += 1
+
                         browser.execute_script("location.reload()")
+                        update_activity()
                         try_again = 0
                         sleep(10)
+
                         main_elem = (browser.find_element_by_xpath('//main/article/div[1]') if not link_elems else
                                      browser.find_element_by_xpath('//main/article/div[2]') if skip_top_posts else
                                      browser.find_element_by_tag_name('main'))
@@ -217,21 +228,27 @@ def get_links_for_tag(browser,
         possible_posts = browser.execute_script(
             "return window._sharedData.entry_data."
             "TagPage[0].graphql.hashtag.edge_hashtag_to_media.count")
+
     except WebDriverException:
         try:
             possible_posts = (browser.find_element_by_xpath(
                                 "//span[contains(@class, 'g47SY')]").text)
             if possible_posts:
                 possible_posts = format_number(possible_posts)
+
             else:
                 logger.info("Failed to get the amount of possible posts in '{}' tag  ~empty string".format(tag))
                 possible_posts = None
+
         except NoSuchElementException:
             logger.info("Failed to get the amount of possible posts in {} tag".format(tag))
             possible_posts = None
 
-    logger.info("desired amount: {}  |  top posts [{}]: {}  |  possible posts: {}".format(amount,
-                                      ('enabled' if not skip_top_posts else 'disabled'), len(top_posts), possible_posts))
+    logger.info("desired amount: {}  |  top posts [{}]: {}  |  possible posts: {}".format(
+                    amount,
+                    "enabled" if not skip_top_posts else "disabled",
+                    len(top_posts),
+                    possible_posts))
 
     if possible_posts is not None:
         possible_posts = possible_posts if not skip_top_posts else possible_posts-len(top_posts)
@@ -251,12 +268,14 @@ def get_links_for_tag(browser,
                 logger.info("Scrolled too much! ~ sleeping a bit :>")
                 sleep(600)
                 sc_rolled = 0
+
             for i in range(3):
                 browser.execute_script(
                     "window.scrollTo(0, document.body.scrollHeight);")
-                sc_rolled += 1
                 update_activity()
+                sc_rolled += 1
                 sleep(nap)   #if not slept, and internet speed is low, instagram will only scroll one time, instead of many times you sent scoll command...
+
             sleep(3)
             links.extend(get_links(browser, tag, logger, media, main_elem))
 
@@ -267,19 +286,24 @@ def get_links_for_tag(browser,
                 if i not in s:
                     s.add(i)
                     links.append(i)
+
             if len(links) == filtered_links:
                 try_again += 1
                 nap = 3 if try_again==1 else 5
                 logger.info("Insufficient amount of links ~ trying again: {}".format(try_again))
                 sleep(3)
+
                 if try_again > 2:   #you can try again as much as you want by changing this number
                     if put_sleep < 1 and filtered_links <= 21 :
                         logger.info("Cor! Did you send too many requests? ~ let's rest some")
                         sleep(600)
                         put_sleep += 1
+
                         browser.execute_script("location.reload()")
+                        update_activity()
                         try_again = 0
                         sleep(10)
+
                         main_elem = (browser.find_element_by_xpath('//main/article/div[1]') if not link_elems else
                                       browser.find_element_by_xpath('//main/article/div[2]') if skip_top_posts else
                                        browser.find_element_by_tag_name('main'))
@@ -407,11 +431,15 @@ def check_link(browser, post_link, dont_like, mandatory_words, ignore_if_contain
     try:
         post_page = browser.execute_script(
             "return window._sharedData.entry_data.PostPage")
+
     except WebDriverException:   #handle the possible `entry_data` error
         try:
             browser.execute_script("location.reload()")
+            update_activity()
+
             post_page = browser.execute_script(
             "return window._sharedData.entry_data.PostPage")
+
         except WebDriverException:
             post_page = None
 
@@ -428,28 +456,35 @@ def check_link(browser, post_link, dont_like, mandatory_words, ignore_if_contain
         image_text = media['edge_media_to_caption']['edges']
         image_text = image_text[0]['node']['text'] if image_text else None
         owner_comments = browser.execute_script('''
-      latest_comments = window._sharedData.entry_data.PostPage[0].graphql.shortcode_media.edge_media_to_comment.edges;
-      if (latest_comments === undefined) latest_comments = Array();
-      owner_comments = latest_comments
-        .filter(item => item.node.owner.username == '{}')
-        .map(item => item.node.text)
-        .reduce((item, total) => item + '\\n' + total, '');
-      return owner_comments;
-    '''.format(user_name))
+            latest_comments = window._sharedData.entry_data.PostPage[0].graphql.shortcode_media.edge_media_to_comment.edges;
+            if (latest_comments === undefined) {
+                latest_comments = Array();
+                owner_comments = latest_comments
+                    .filter(item => item.node.owner.username == arguments[0])
+                    .map(item => item.node.text)
+                    .reduce((item, total) => item + '\\n' + total, '');
+                return owner_comments;}
+            else {
+                return null;}
+        ''', user_name)
+
     else:
         media = post_page[0]['media']
         is_video = media['is_video']
         user_name = media['owner']['username']
         image_text = media['caption']
         owner_comments = browser.execute_script('''
-      latest_comments = window._sharedData.entry_data.PostPage[0].media.comments.nodes;
-      if (latest_comments === undefined) latest_comments = Array();
-      owner_comments = latest_comments
-        .filter(item => item.user.username == '{}')
-        .map(item => item.text)
-        .reduce((item, total) => item + '\\n' + total, '');
-      return owner_comments;
-    '''.format(user_name))
+            latest_comments = window._sharedData.entry_data.PostPage[0].media.comments.nodes;
+            if (latest_comments === undefined) {
+                latest_comments = Array();
+                owner_comments = latest_comments
+                    .filter(item => item.user.username == arguments[0])
+                    .map(item => item.text)
+                    .reduce((item, total) => item + '\\n' + total, '');
+                return owner_comments;}
+            else {
+                return null;}
+        ''', user_name)
 
     if owner_comments == '':
         owner_comments = None
@@ -457,6 +492,7 @@ def check_link(browser, post_link, dont_like, mandatory_words, ignore_if_contain
     """Append owner comments to description as it might contain further tags"""
     if image_text is None:
         image_text = owner_comments
+
     elif owner_comments:
         image_text = image_text + '\n' + owner_comments
 
@@ -465,9 +501,11 @@ def check_link(browser, post_link, dont_like, mandatory_words, ignore_if_contain
         if graphql:
             image_text = media['edge_media_to_comment']['edges']
             image_text = image_text[0]['node']['text'] if image_text else None
+
         else:
             image_text = media['comments']['nodes']
             image_text = image_text[0]['text'] if image_text else None
+
     if image_text is None:
         image_text = "No description"
 
@@ -569,16 +607,19 @@ def get_tags(browser, url):
 
     graphql = browser.execute_script(
         "return ('graphql' in window._sharedData.entry_data.PostPage[0])")
+
     if graphql:
         image_text = browser.execute_script(
             "return window._sharedData.entry_data.PostPage[0].graphql."
             "shortcode_media.edge_media_to_caption.edges[0].node.text")
+
     else:
         image_text = browser.execute_script(
             "return window._sharedData.entry_data."
             "PostPage[0].media.caption.text")
 
     tags = findall(r'#\w*', image_text)
+
     return tags
 
 
@@ -607,21 +648,27 @@ def verify_liking(browser, max, min, logger):
             likes_count = browser.execute_script(
                 "return window._sharedData.entry_data."
                 "PostPage[0].graphql.shortcode_media.edge_media_preview_like.count")
+
         except WebDriverException:
             try:
                 browser.execute_script("location.reload()")
+                update_activity()
+
                 likes_count = browser.execute_script(
                     "return window._sharedData.entry_data."
                     "PostPage[0].graphql.shortcode_media.edge_media_preview_like.count")
+
             except WebDriverException:
                 try:
                     likes_count = (browser.find_element_by_css_selector(
                                         "section._1w76c._nlmjy > div > a > span").text)
+
                     if likes_count:
                         likes_count = format_number(likes_count)
                     else:
                         logger.info("Failed to check likes' count  ~empty string\n")
                         return True
+
                 except NoSuchElementException:
                     logger.info("Failed to check likes' count\n")
                     return True

--- a/instapy/login_util.py
+++ b/instapy/login_util.py
@@ -23,8 +23,15 @@ def bypass_suspicious_login(browser):
     # close sign up Instagram modal if available
     try:
         close_button = browser.find_element_by_xpath("[text()='Close']")
-        ActionChains(
-            browser).move_to_element(close_button).click().perform()
+
+        (ActionChains(browser)
+            .move_to_element(close_button)
+            .click()
+            .perform())
+
+        # update server calls
+        update_activity()
+
     except NoSuchElementException:
         pass
 
@@ -32,8 +39,15 @@ def bypass_suspicious_login(browser):
         # click on "This was me" button if challenge page was called
         this_was_me_button = browser.find_element_by_xpath(
             "//button[@name='choice'][text()='This Was Me']")
-        ActionChains(
-            browser).move_to_element(this_was_me_button).click().perform()
+
+        (ActionChains(browser)
+            .move_to_element(this_was_me_button)
+            .click()
+            .perform())
+
+        # update server calls
+        update_activity()
+
     except NoSuchElementException:
         # no verification needed
         pass
@@ -41,25 +55,32 @@ def bypass_suspicious_login(browser):
     try:
         user_email = browser.find_element_by_xpath(
             "//label[@for='choice_1']").text
+
     except NoSuchElementException:
         try:
             user_email = browser.find_element_by_xpath(
                 "//label[@class='_q0nt5']").text
+
         except:
             try:
                 user_email = browser.find_element_by_xpath(
                     "//label[@class='_q0nt5 _a7z3k']").text
+
             except:
                 print("Unable to locate email or phone button, maybe "
-                      "bypass_suspicious_login=True isn't needed anymore.")
+                        "bypass_suspicious_login=True isn't needed anymore.")
                 return False
 
     send_security_code_button = browser.find_element_by_xpath(
         "//button[text()='Send Security Code']")
+
     (ActionChains(browser)
-     .move_to_element(send_security_code_button)
-     .click()
-     .perform())
+        .move_to_element(send_security_code_button)
+        .click()
+        .perform())
+
+    # update server calls
+    update_activity()
 
     print('Instagram detected an unusual login attempt')
     print('A security code was sent to your {}'.format(user_email))
@@ -67,16 +88,27 @@ def bypass_suspicious_login(browser):
 
     security_code_field = browser.find_element_by_xpath((
         "//input[@id='security_code']"))
-    (ActionChains(browser)
-     .move_to_element(security_code_field)
-     .click().send_keys(security_code).perform())
-
-    submit_security_code_button = browser.find_element_by_xpath((
-        "//button[text()='Submit']"))
 
     (ActionChains(browser)
-     .move_to_element(submit_security_code_button)
-     .click().perform())
+        .move_to_element(security_code_field)
+        .click()
+        .send_keys(security_code)
+        .perform())
+
+    # update server calls for both 'click' and 'send_keys' actions
+    for i in range(2):
+        update_activity()
+
+    submit_security_code_button = browser.find_element_by_xpath(
+                                            "//button[text()='Submit']")
+
+    (ActionChains(browser)
+        .move_to_element(submit_security_code_button)
+        .click()
+        .perform())
+
+    # update server calls
+    update_activity()
 
     try:
         sleep(5)
@@ -84,12 +116,15 @@ def bypass_suspicious_login(browser):
         wrong_login = browser.find_element_by_xpath((
             "//p[text()='Please check the code we sent you and try "
             "again.']"))
+
         if wrong_login is not None:
             print(('Wrong security code! Please check the code Instagram'
                    'sent you and try again.'))
+
     except NoSuchElementException:
         # correct security code
         pass
+
 
 
 def login_user(browser,
@@ -140,14 +175,22 @@ def login_user(browser,
     # having the site on a different language
     # Might cause problems if the OS language is english
     if switch_language:
-        browser.find_element_by_xpath(
-          "//select[@class='hztqj']/option[text()='English']").click()
+        language_element_ENG = browser.find_element_by_xpath(
+          "//select[@class='hztqj']/option[text()='English']")
+        click_element(browser, language_element_ENG)
 
     # Check if the first div is 'Create an Account' or 'Log In'
     login_elem = browser.find_element_by_xpath(
         "//article/div/div/p/a[text()='Log in']")
+
     if login_elem is not None:
-        ActionChains(browser).move_to_element(login_elem).click().perform()
+        (ActionChains(browser)
+            .move_to_element(login_elem)
+            .click()
+            .perform())
+
+        # update server calls
+        update_activity()
 
     # Enter username and password and logs the user in
     # Sometimes the element name isn't 'Username' and 'Password'
@@ -163,8 +206,16 @@ def login_user(browser,
 
     input_username = browser.find_element_by_xpath(input_username_XP)
 
-    ActionChains(browser).move_to_element(input_username). \
-        click().send_keys(username).perform()
+    (ActionChains(browser)
+        .move_to_element(input_username)
+        .click()
+        .send_keys(username)
+        .perform())
+
+    # update server calls for both 'click' and 'send_keys' actions
+    for i in range(2):
+        update_activity()
+
     sleep(1)
 
     #  password
@@ -174,12 +225,23 @@ def login_user(browser,
     if not isinstance(password, str):
         password = str(password)
 
-    ActionChains(browser).move_to_element(input_password[0]). \
-        click().send_keys(password).perform()
+    (ActionChains(browser)
+        .move_to_element(input_password[0])
+        .click()
+        .send_keys(password)
+        .perform())
+
+    # update server calls for both 'click' and 'send_keys' actions
+    for i in range(2):
+        update_activity()
 
     login_button = browser.find_element_by_xpath(
         "//form/span/button[text()='Log in']")
-    ActionChains(browser).move_to_element(login_button).click().perform()
+
+    (ActionChains(browser)
+        .move_to_element(login_button)
+        .click()
+        .perform())
 
     # update server calls
     update_activity()

--- a/instapy/print_log_writer.py
+++ b/instapy/print_log_writer.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from .time_util import sleep
 from .util import interruption_handler
 from .util import web_address_navigator
+from .util import update_activity
 
 from selenium.common.exceptions import WebDriverException
 
@@ -20,13 +21,17 @@ def log_follower_num(browser, username, logfolder):
         followed_by = browser.execute_script(
             "return window._sharedData.""entry_data.ProfilePage[0]."
             "graphql.user.edge_followed_by.count")
+
     except WebDriverException:   #handle the possible `entry_data` error
         try:
             browser.execute_script("location.reload()")
+            update_activity()
+
             sleep(1)
             followed_by = browser.execute_script(
                 "return window._sharedData.""entry_data.ProfilePage[0]."
                 "graphql.user.edge_followed_by.count")
+
         except WebDriverException:
             followed_by = None
 
@@ -47,13 +52,17 @@ def log_following_num(browser, username, logfolder):
         following_num = browser.execute_script(
             "return window._sharedData.""entry_data.ProfilePage[0]."
             "graphql.user.edge_follow.count")
+
     except WebDriverException:
         try:
             browser.execute_script("location.reload()")
+            update_activity()
+
             sleep(10)
             following_num = browser.execute_script(
                 "return window._sharedData.""entry_data.ProfilePage[0]."
                 "graphql.user.edge_follow.count")
+
         except WebDriverException:
             following_num = None
 

--- a/instapy/relationship_tools.py
+++ b/instapy/relationship_tools.py
@@ -59,6 +59,7 @@ def get_followers(browser,
     user_data['id'] = browser.execute_script(
         "return window._sharedData.entry_data.ProfilePage[0]."
         "graphql.user.id")
+
     variables['id'] = user_data['id']
     variables['first'] = 50
 
@@ -76,8 +77,8 @@ def get_followers(browser,
             '{}&variables={}'
             .format(graphql_followers, str(json.dumps(variables)))
         )
-        sleep(2)
-        browser.get(url)
+        web_address_navigator(browser, url)
+
         """ Get stored graphql queries data to be used """
         try:
             filename = '{}graphql_queries.json'.format(logfolder)
@@ -160,9 +161,10 @@ def get_followers(browser,
                     .format(
                         graphql_followers, str(json.dumps(variables)))
                 )
-                sleep(2)
-                browser.get(url)
+
+                web_address_navigator(browser, url)
                 sc_rolled += 1
+
                 #dump the current graphql queries data
                 if local_read_failure != True:
                     try:
@@ -264,6 +266,7 @@ def get_following(browser,
     user_data['id'] = browser.execute_script(
         "return window._sharedData.entry_data.ProfilePage[0]."
         "graphql.user.id")
+
     variables['id'] = user_data['id']
     variables['first'] = 50
 
@@ -281,8 +284,8 @@ def get_following(browser,
             '{}&variables={}'
             .format(graphql_following, str(json.dumps(variables)))
         )
-        sleep(2)
-        browser.get(url)
+        web_address_navigator(browser, url)
+
         """ Get stored graphql queries data to be used """
         try:
             filename = '{}graphql_queries.json'.format(logfolder)
@@ -359,9 +362,10 @@ def get_following(browser,
                     .format(
                         graphql_following, str(json.dumps(variables)))
                 )
-                sleep(2)
-                browser.get(url)
+
+                web_address_navigator(browser, url)
                 sc_rolled += 1
+
                 #dumps the current graphql queries data
                 if local_read_failure != True:
                     try:

--- a/instapy/settings.py
+++ b/instapy/settings.py
@@ -14,19 +14,26 @@ class Settings:
     """ Globally accessible settings throughout whole project """
     log_location = os.path.join(BASE_DIR, 'logs')
     database_location = os.path.join(BASE_DIR, 'db', 'instapy.db')
+
+    # chromedriver-specific settings
+    chromedriver_min_version = 2.36
+
     specific_chromedriver = "chromedriver_{}".format(OS_ENV)
     chromedriver_location = os.path.join(BASE_DIR, "assets", specific_chromedriver)
+
     if not os.path.exists(chromedriver_location):
         chromedriver_location = os.path.join(BASE_DIR, 'assets', 'chromedriver')
 
-    chromedriver_min_version = 2.36
     # set a logger cache outside the InstaPy object to avoid re-instantiation issues
     loggers = {}
     logger = None
+
     # set current profile credentials for DB operations
     profile = {"id":None, "name":None}
+
     # hold live Quota Supervisor configuration for global usage
     QS_config = {}
+
     # specify either connected locally or through a proxy
     connection_type = None
 

--- a/instapy/unfollow_util.py
+++ b/instapy/unfollow_util.py
@@ -108,6 +108,8 @@ def get_following_status(browser, person, logger):
 
     if not follow_button:
         browser.execute_script("location.reload()")
+        update_activity()
+
         follow_button = explicit_wait(browser, "VOEL", [follow_button_XP, "XPath"], logger)
 
         if not follow_button:
@@ -514,6 +516,8 @@ def follow_user(browser, track, login, user_name, button, blacklist, logger, log
                                        "arguments[0].style.width = '10px'; "
                                        "arguments[0].style.opacity = 1",
                                             follow_button)
+                # update server calls
+                update_activity()
 
                 click_element(browser, follow_button)
 
@@ -526,7 +530,9 @@ def follow_user(browser, track, login, user_name, button, blacklist, logger, log
                                                               logger)
             if not following:
                 browser.execute_script("location.reload()")
+                update_activity()
                 sleep(2)
+
                 following, follow_button = get_following_status(browser,
                                                                  user_name,
                                                                   logger)
@@ -828,26 +834,33 @@ def get_given_user_followers(browser,
     try:
         allfollowers = format_number(browser.find_element_by_xpath("//a[contains"
                                 "(@href,'followers')]/span").text)
+
     except NoSuchElementException:
         try:
             allfollowers = browser.execute_script(
                 "return window._sharedData.entry_data."
                 "ProfilePage[0].graphql.user.edge_followed_by.count")
+
         except WebDriverException:
             try:
                 browser.execute_script("location.reload()")
+                update_activity()
+
                 allfollowers = browser.execute_script(
                     "return window._sharedData.entry_data."
                     "ProfilePage[0].graphql.user.edge_followed_by.count")
+
             except WebDriverException:
                 try:
                     topCount_elements = browser.find_elements_by_xpath(
                         "//span[contains(@class,'g47SY')]")
+
                     if topCount_elements:
                         allfollowers = format_number(topCount_elements[1].text)
                     else:
                         logger.info("Failed to get followers count of '{}'  ~empty list".format(user_name))
                         allfollowers = None
+
                 except NoSuchElementException:
                     logger.error("Error occured during getting the followers count of '{}'\n".format(user_name))
                     return [], []
@@ -909,26 +922,33 @@ def get_given_user_following(browser,
     try:
         allfollowing = format_number(browser.find_element_by_xpath("//a[contains"
                                 "(@href,'following')]/span").text)
+
     except NoSuchElementException:
         try:
             allfollowing = browser.execute_script(
                 "return window._sharedData.entry_data."
                 "ProfilePage[0].graphql.user.edge_follow.count")
+
         except WebDriverException:
             try:
                 browser.execute_script("location.reload()")
+                update_activity()
+
                 allfollowing = browser.execute_script(
                     "return window._sharedData.entry_data."
                     "ProfilePage[0].graphql.user.edge_follow.count")
+
             except WebDriverException:
                 try:
                     topCount_elements = browser.find_elements_by_xpath(
                         "//span[contains(@class,'g47SY')]")
+
                     if topCount_elements:
                         allfollowing = format_number(topCount_elements[2].text)
                     else:
                         logger.info("Failed to get following count of '{}'  ~empty list".format(user_name))
                         allfollowing = None
+
                 except NoSuchElementException:
                     logger.error("\nError occured during getting the following count of '{}'\n".format(user_name))
                     return [], []
@@ -1126,6 +1146,7 @@ def unfollow_user(browser, track, username, person, person_id, button, relations
 
             if not button_change:
                 browser.execute_script("location.reload()")
+                update_activity()
                 sleep(2)
 
                 # double check the following state


### PR DESCRIPTION
#### Hi all!
Earlier there were no URGENT reason to have _server calls_ (_or other actions_) updated cos those data WAS NOT used anywhere except by the people who was reading the **instapy.db** file to analyze record activity statistics.

But after Quota Supervisor came out, now every action counts.
That's why _server calls_ must be recorded PROPERLY after each request to the server [mostly by `GET` navigation method, page _reload_, _click_ and _scroll_ actions]

##### **Note**: Unlike _server calls_, other actions- *likes*, *comments*, *follows*, *unfollows* has a unique engine and there is only one line to update their record 🕹

Having known that matter I have added all of the missing [required] lines of `update_activity()` which is updating _server calls_ record in the local DB to be used with QS and etc.

------

### EXTRA
While doing the job mentioned above, I also did other visual changes to increase readability, etc.
Also,
+ Replaced a few direct `GET` method navigation to `web_address_navigator()` JUST cos of handling a few situations like timeouts and also for simplifying navigation, etc.
+ Replaced some several various style of clicking with `click_element()` generalized super smart clicker
tool to solve possible problems and simplify the actions [to be duplicated].

------

Lastly, the only change that the user will notice is gonna be the accurate amount of _server calls_ recorded.
Now it will be much better for those who supervise hourly or daily _server calls_ with QS or anybody who uses that information for analytics, etc.

----

Cheers 😁
----