### PR TITLE
Set headless_browser default value to True

### DIFF
--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -85,7 +85,7 @@ class InstaPy:
                  browser_profile_path=None,
                  page_delay=25,
                  show_logs=True,
-                 headless_browser=False,
+                 headless_browser=True,
                  proxy_address=None,
                  proxy_chrome_extension=None,
                  proxy_port=None,


### PR DESCRIPTION
Fixes issue `instapy.instapy.InstaPyError: ensure chromedriver is installed`(#2592 and similar)