### PR TITLE
Skip Private/Business/No Profile Pic, Min/Max posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ Table of Contents
   * [Unfollowing](#unfollowing)
   * [Don't unfollow active users](#dont-unfollow-active-users)
   * [Interactions based on the number of followers and/or following a user has](#interactions-based-on-the-number-of-followers-andor-following-a-user-has)
-  * [Skipping user for number of posts boundaries, private account, no profile picture, business account](#skipping-user-for-number-of-posts-boundaries-private-account-no-profile-picture-business-account)
+  * [Interactions based on the number of posts a user has](#interactions-based-on-the-number-of-posts-a-user-has)
+  * [Skipping user for private account, no profile picture, business account](#skipping-user-for-private-account-no-profile-picture-business-account)
   * [Liking based on the number of existing likes a post has](#liking-based-on-the-number-of-existing-likes-a-post-has)
   * [Commenting based on the number of existing comments a post has](#commenting-based-on-the-number-of-existing-comments-a-post-has)
   * [Commenting based on madatory words in the description or first comment](#commenting-based-on-madatory-words-in-the-description-or-first-comment)
@@ -519,7 +520,7 @@ _here the unfollow method- **alFollowing** is used_
 session.set_dont_unfollow_active_users(enabled=True, posts=5)
 ```
 
-### Interactions based on the number of followers and/or following a user has
+### Interactions based on the number of followers and/or following a user has 
 
 ##### This is used to check the number of _followers_ and/or _following_ a user has and if these numbers _either_ **exceed** the number set OR **does not pass** the number set OR if **their ratio does not reach** desired potency ratio then no further interaction happens
 ```python
@@ -529,7 +530,9 @@ session.set_relationship_bounds(enabled=True,
 				   max_followers=8500,
 				    max_following=4490,
 				     min_followers=100,
-				      min_following=56)
+				      min_following=56,
+				       min_posts=10,
+                                        max_posts=1000)
 ```
 Use `enabled=True` to **activate** this feature, and `enabled=False` to **deactivate** it, _any time_  
 `delimit_by_numbers` is used to **activate** & **deactivate** the usage of max & min values  
@@ -543,7 +546,6 @@ _**find** desired_ `potency_ratio` _with this formula_: `potency_ratio` == **fol
 _**find** desired_ `potency_ratio` _with this formula_: `potency_ratio` == **following count** / **followers count**  (_use desired counts_)
 >_**e.g.**_, target user has _`2000` followers_ & _`3000` following_ and you set `potency_ratio = -1.7`.  
 **Now** it _will **not** interact_ with this user, **cos** the user's **relationship ratio** is `3000/2000==1.5` and `1.5` is **below** _desired_ `potency_ratio` _of `1.7`_ (_**note that**, negative `-` sign is only used to determine your style, nothing more_)
-
 
 ###### There are **3** **COMBINATIONS** _available_ to use:
 * **1**. You can use `potency_ratio` **or not** (**e.g.**, `potency_ratio=None`, `delimit_by_numbers=True`) - _will decide only by your **pre-defined** max & min values regardless of the_ `potency_ratio`
@@ -564,12 +566,8 @@ session.set_relationship_bounds (enabled=True, potency_ratio=2.35, delimit_by_nu
 ```python
 session.set_relationship_bounds (enabled=True, potency_ratio=-1.44, delimit_by_numbers=True, max_followers=52639, max_following=None, min_followers=None, min_following=2240)
 ```
-
-
-### Skipping user for number of posts boundaries, private account, no profile picture, business account
-
+### Interactions based on the number of posts a user has
 #### This is used to check number of posts of a user and skip if they aren't in the boundaries provided
-
 ```python
 session.set_relationship_bounds(min_posts=10,
                                  max_posts=1000)
@@ -584,6 +582,9 @@ session.set_relationship_bounds(max_posts=1000)
 ```
 
 Will skip only users that have more than 1000 posts in their feed
+
+
+### Skipping user for private account, no profile picture, business account
 
 #### This is used to skip users with certain condition
 ```python
@@ -653,8 +654,7 @@ session.set_skip_users(skip_private=True,
 This will skip all business accounts except the ones that have a category that matches one item in the list of _dont_skip_business_categories_
 **N.B.** If both _dont_skip_business_categories_ and _skip_business_categories_, InstaPy will skip only business accounts in the list given from _skip_business_categories_.
 		       
-		      
-
+> [A list of all availlable business categories can be found here](./assets/business_categories.md)
 
 ### Liking based on the number of existing likes a post has
 

--- a/README.md
+++ b/README.md
@@ -569,7 +569,9 @@ session.set_relationship_bounds (enabled=True, potency_ratio=-1.44, delimit_by_n
 ### Skipping user for number of posts boundaries, private account, no profile picture, business account
 
 #### This is used to check number of posts of a user and skip if they aren't in the boundaries provided
-```session.set_relationship_bounds(min_posts=10,
+
+```python
+session.set_relationship_bounds(min_posts=10,
                                  max_posts=1000)
 ```
 Users that have more than 1000 posts or less than 10 will be discarded
@@ -577,14 +579,16 @@ Users that have more than 1000 posts or less than 10 will be discarded
 **N.B.:** It is up to the user to check that `min_posts <= max_posts`
 
 You can also set only one parameter at a time:
-```session.set_relationship_bounds(max_posts=1000)```
+```python
+session.set_relationship_bounds(max_posts=1000)```
 
 Will skip only users that have more than 1000 posts in their feed
 
 #### This is used to skip users with certain condition
 ##### Skip private account
 **This is done by default**
-```set_skip_users(skip_private=True,
+```python
+session.set_skip_users(skip_private=True,
                        skip_no_profile_pic=False,
                        skip_business=False,
                        skip_business_categories=[],
@@ -594,21 +598,24 @@ Will skip users that have private account, even if are followed by running accou
 
 ##### Skip users that don't have profile picture
 
-```set_skip_users(skip_private=True,
+```python
+session.set_skip_users(skip_private=True,
                        skip_no_profile_pic=True)
 ```
 Will skip users that haven't uploaded yet a profile picture
 
 ##### Skip users that have business account
 
-```set_skip_users(skip_private=True,
+```python
+session.set_skip_users(skip_private=True,
                        skip_no_profile_pic=True,
 		       skip_business=True)
 ```
 This will skip all users that have business account activated.
 
 ###### Skip only users that have certain business account
-```set_skip_users(skip_private=True,
+```python
+session.set_skip_users(skip_private=True,
                        skip_no_profile_pic=True,
 		       skip_business=True,
 		       skip_business_categories=['Creators & Celebrities'])
@@ -616,7 +623,8 @@ This will skip all users that have business account activated.
 This will skip all business accounts that have category in given list
 **N.B.** In _skip_business_categories_ you can add more than one category
 ###### Skip all business accounts, except from list given
-```set_skip_users(skip_private=True,
+```python
+session.set_skip_users(skip_private=True,
                        skip_no_profile_pic=True,
 		       skip_business=True,
 		       dont_skip_business_categories=['Creators & Celebrities'])

--- a/README.md
+++ b/README.md
@@ -568,52 +568,52 @@ session.set_relationship_bounds (enabled=True, potency_ratio=-1.44, delimit_by_n
 ### Skipping user for number of posts boundaries, private account, no profile picture, business account
 
 #### This is used to check number of posts of a user and skip if they aren't in the boundaries provided
-`session.set_relationship_bounds(min_posts=10,
-                                 max_posts=1000)`
+```session.set_relationship_bounds(min_posts=10,
+                                 max_posts=1000)```
 Users that have more than 1000 posts or less than 10 will be discarded
 
 **N.B.:** It is up to the user to check that `min_posts <= max_posts`
 
 You can also set only one parameter at a time:
-`session.set_relationship_bounds(max_posts=1000)`
+```session.set_relationship_bounds(max_posts=1000)```
 
 Will skip only users that have more than 1000 posts in their feed
 
 #### This is used to skip users with certain condition
 ##### Skip private account
 **This is done by default**
-`set_skip_users(skip_private=True,
+```set_skip_users(skip_private=True,
                        skip_no_profile_pic=False,
                        skip_business=False,
                        skip_business_categories=[],
-                       dont_skip_business_categories=[])`
+                       dont_skip_business_categories=[])```
 Will skip users that have private account, even if are followed by running account
 
 ##### Skip users that don't have profile picture
 
-`set_skip_users(skip_private=True,
-                       skip_no_profile_pic=True)`
+```set_skip_users(skip_private=True,
+                       skip_no_profile_pic=True)```
 Will skip users that haven't uploaded yet a profile picture
 
 ##### Skip users that have business account
 
-`set_skip_users(skip_private=True,
+```set_skip_users(skip_private=True,
                        skip_no_profile_pic=True,
-		       skip_business=True)`
+		       skip_business=True)```
 This will skip all users that have business account activated.
 
 ###### Skip only users that have certain business account
-`set_skip_users(skip_private=True,
+```set_skip_users(skip_private=True,
                        skip_no_profile_pic=True,
 		       skip_business=True,
-		       skip_business_categories=['Creators & Celebrities'])`
+		       skip_business_categories=['Creators & Celebrities'])```
 This will skip all business accounts that have category in given list
 **N.B.** In _skip_business_categories_ you can add more than one category
 ###### Skip all business accounts, except from list given
-`set_skip_users(skip_private=True,
+```set_skip_users(skip_private=True,
                        skip_no_profile_pic=True,
 		       skip_business=True,
-		       dont_skip_business_categories=['Creators & Celebrities'])`
+		       dont_skip_business_categories=['Creators & Celebrities'])```
 This will skip all business accounts except the ones that have a category that matches one item in the list of _dont_skip_business_categories_
 **N.B.** If both _dont_skip_business_categories_ and _skip_business_categories_, InstaPy will skip only business accounts in the list given from _skip_business_categories_.
 		       

--- a/README.md
+++ b/README.md
@@ -576,7 +576,7 @@ session.set_relationship_bounds(min_posts=10,
 ```
 Users that have more than 1000 posts or less than 10 will be discarded
 
-**N.B.:** It is up to the user to check that `min_posts <= max_posts`
+**N.B.:** It is up to the user to check that `min_posts < max_posts`
 
 You can also set only one parameter at a time:
 ```python

--- a/README.md
+++ b/README.md
@@ -632,7 +632,7 @@ You can set a percentage of skipping:
     _business_percentage_= 100 always skip business users
     _business_percentage_= 0 never skip business users (so set _skip_business_=False)
 
-*N.B.:* This _business_percentage_ parameter works only if no _skip_business_categories_ or _dont_skip_business_categories_ are provided!
+**N.B.:** This _business_percentage_ parameter works only if no _skip_business_categories_ or _dont_skip_business_categories_ are provided!
 
 ###### Skip only users that have certain business account
 ```python

--- a/README.md
+++ b/README.md
@@ -586,33 +586,53 @@ session.set_relationship_bounds(max_posts=1000)
 Will skip only users that have more than 1000 posts in their feed
 
 #### This is used to skip users with certain condition
+```python
+session.set_skip_users(skip_private=True,
+                       private_percentage=100,
+                       skip_no_profile_pic=False,
+                       no_profile_pic_percentage=100,
+                       skip_business=False,
+                       business_percentage=100,
+                       skip_business_categories=[],
+                       dont_skip_business_categories=[])
+```
 ##### Skip private account
 **This is done by default**
 ```python
 session.set_skip_users(skip_private=True,
-                       skip_no_profile_pic=False,
-                       skip_business=False,
-                       skip_business_categories=[],
-                       dont_skip_business_categories=[])
+                       private_percentage=100)
 ```
-Will skip users that have private account, even if are followed by running account
+Will skip users that have private account, even if are followed by running account.
+You can set a percentage of skipping:
+    _private_percentage_= 100 always skip private users
+    _private_percentage_= 0 never skip private users (so set skip_private=False)
 
 ##### Skip users that don't have profile picture
 
 ```python
 session.set_skip_users(skip_private=True,
-                       skip_no_profile_pic=True)
+                       skip_no_profile_pic=True,
+                       no_profile_pic_percentage=100)
 ```
 Will skip users that haven't uploaded yet a profile picture
+You can set a percentage of skipping:
+    _no_profile_pic_percentage_= 100 always skip users without profile picture
+    _no_profile_pic_percentage_= 0 never skip users without profile picture (so set _skip_no_profile_pic_=False)
 
 ##### Skip users that have business account
 
 ```python
 session.set_skip_users(skip_private=True,
                        skip_no_profile_pic=True,
-		       skip_business=True)
+		               skip_business=True,
+		               business_percentage=100)
 ```
 This will skip all users that have business account activated.
+You can set a percentage of skipping:
+    _business_percentage_= 100 always skip business users
+    _business_percentage_= 0 never skip business users (so set _skip_business_=False)
+
+*N.B.:* This _business_percentage_ parameter works only if no _skip_business_categories_ or _dont_skip_business_categories_ are provided!
 
 ###### Skip only users that have certain business account
 ```python

--- a/README.md
+++ b/README.md
@@ -580,7 +580,8 @@ Users that have more than 1000 posts or less than 10 will be discarded
 
 You can also set only one parameter at a time:
 ```python
-session.set_relationship_bounds(max_posts=1000)```
+session.set_relationship_bounds(max_posts=1000)
+```
 
 Will skip only users that have more than 1000 posts in their feed
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Table of Contents
   * [Unfollowing](#unfollowing)
   * [Don't unfollow active users](#dont-unfollow-active-users)
   * [Interactions based on the number of followers and/or following a user has](#interactions-based-on-the-number-of-followers-andor-following-a-user-has)
+  * [Skipping user for number of posts boundaries, private account, no profile picture, business account](#skipping-user-for-number-of-posts-boundaries-private-account-no-profile-picture-business-account)
   * [Liking based on the number of existing likes a post has](#liking-based-on-the-number-of-existing-likes-a-post-has)
   * [Commenting based on the number of existing comments a post has](#commenting-based-on-the-number-of-existing-comments-a-post-has)
   * [Commenting based on madatory words in the description or first comment](#commenting-based-on-madatory-words-in-the-description-or-first-comment)
@@ -564,12 +565,13 @@ session.set_relationship_bounds (enabled=True, potency_ratio=2.35, delimit_by_nu
 session.set_relationship_bounds (enabled=True, potency_ratio=-1.44, delimit_by_numbers=True, max_followers=52639, max_following=None, min_followers=None, min_following=2240)
 ```
 
-@GabrieleCalarota
+
 ### Skipping user for number of posts boundaries, private account, no profile picture, business account
 
 #### This is used to check number of posts of a user and skip if they aren't in the boundaries provided
 ```session.set_relationship_bounds(min_posts=10,
-                                 max_posts=1000)```
+                                 max_posts=1000)
+```
 Users that have more than 1000 posts or less than 10 will be discarded
 
 **N.B.:** It is up to the user to check that `min_posts <= max_posts`
@@ -586,34 +588,39 @@ Will skip only users that have more than 1000 posts in their feed
                        skip_no_profile_pic=False,
                        skip_business=False,
                        skip_business_categories=[],
-                       dont_skip_business_categories=[])```
+                       dont_skip_business_categories=[])
+```
 Will skip users that have private account, even if are followed by running account
 
 ##### Skip users that don't have profile picture
 
 ```set_skip_users(skip_private=True,
-                       skip_no_profile_pic=True)```
+                       skip_no_profile_pic=True)
+```
 Will skip users that haven't uploaded yet a profile picture
 
 ##### Skip users that have business account
 
 ```set_skip_users(skip_private=True,
                        skip_no_profile_pic=True,
-		       skip_business=True)```
+		       skip_business=True)
+```
 This will skip all users that have business account activated.
 
 ###### Skip only users that have certain business account
 ```set_skip_users(skip_private=True,
                        skip_no_profile_pic=True,
 		       skip_business=True,
-		       skip_business_categories=['Creators & Celebrities'])```
+		       skip_business_categories=['Creators & Celebrities'])
+```
 This will skip all business accounts that have category in given list
 **N.B.** In _skip_business_categories_ you can add more than one category
 ###### Skip all business accounts, except from list given
 ```set_skip_users(skip_private=True,
                        skip_no_profile_pic=True,
 		       skip_business=True,
-		       dont_skip_business_categories=['Creators & Celebrities'])```
+		       dont_skip_business_categories=['Creators & Celebrities'])
+```
 This will skip all business accounts except the ones that have a category that matches one item in the list of _dont_skip_business_categories_
 **N.B.** If both _dont_skip_business_categories_ and _skip_business_categories_, InstaPy will skip only business accounts in the list given from _skip_business_categories_.
 		       

--- a/README.md
+++ b/README.md
@@ -562,8 +562,62 @@ session.set_relationship_bounds (enabled=True, potency_ratio=2.35, delimit_by_nu
 > **All** of the **4** max & min values are _able to **freely** operate_, **e.g.**, you may want to _**only** delimit_ `max_followers` and `min_following` (**e.g.**, `max_followers=52639`, `max_following=None`, `min_followers=None`, `min_following=2240`)
 ```python
 session.set_relationship_bounds (enabled=True, potency_ratio=-1.44, delimit_by_numbers=True, max_followers=52639, max_following=None, min_followers=None, min_following=2240)
-```  
+```
 
+@GabrieleCalarota
+### Skipping user for number of posts boundaries, private account, no profile picture, business account
+
+#### This is used to check number of posts of a user and skip if they aren't in the boundaries provided
+`session.set_relationship_bounds(min_posts=10,
+                                 max_posts=1000)`
+Users that have more than 1000 posts or less than 10 will be discarded
+
+**N.B.:** It is up to the user to check that `min_posts <= max_posts`
+
+You can also set only one parameter at a time:
+`session.set_relationship_bounds(max_posts=1000)`
+
+Will skip only users that have more than 1000 posts in their feed
+
+#### This is used to skip users with certain condition
+##### Skip private account
+**This is done by default**
+`set_skip_users(skip_private=True,
+                       skip_no_profile_pic=False,
+                       skip_business=False,
+                       skip_business_categories=[],
+                       dont_skip_business_categories=[])`
+Will skip users that have private account, even if are followed by running account
+
+##### Skip users that don't have profile picture
+
+`set_skip_users(skip_private=True,
+                       skip_no_profile_pic=True)`
+Will skip users that haven't uploaded yet a profile picture
+
+##### Skip users that have business account
+
+`set_skip_users(skip_private=True,
+                       skip_no_profile_pic=True,
+		       skip_business=True)`
+This will skip all users that have business account activated.
+
+###### Skip only users that have certain business account
+`set_skip_users(skip_private=True,
+                       skip_no_profile_pic=True,
+		       skip_business=True,
+		       skip_business_categories=['Creators & Celebrities'])`
+This will skip all business accounts that have category in given list
+**N.B.** In _skip_business_categories_ you can add more than one category
+###### Skip all business accounts, except from list given
+`set_skip_users(skip_private=True,
+                       skip_no_profile_pic=True,
+		       skip_business=True,
+		       dont_skip_business_categories=['Creators & Celebrities'])`
+This will skip all business accounts except the ones that have a category that matches one item in the list of _dont_skip_business_categories_
+**N.B.** If both _dont_skip_business_categories_ and _skip_business_categories_, InstaPy will skip only business accounts in the list given from _skip_business_categories_.
+		       
+		      
 
 
 ### Liking based on the number of existing likes a post has

--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -91,6 +91,7 @@ class InstaPy:
                  bypass_suspicious_attempt=False,
                  multi_logs=True):
 
+
         if nogui:
             self.display = Display(visible=0, size=(800, 600))
             self.display.start()
@@ -193,6 +194,9 @@ class InstaPy:
         self.skip_business = False
         self.skip_no_profile_pic = False
         self.skip_private = True
+        self.skip_business_percentage = 100
+        self.skip_no_profile_pic_percentage = 100
+        self.skip_private_percentage = 100
 
         self.relationship_data = {username: {"all_following": [], "all_followers": []}}
 
@@ -873,8 +877,11 @@ class InstaPy:
                                                         self.min_posts,
                                                         self.max_posts,
                                                         self.skip_private,
+                                                        self.skip_private_percentage,
                                                         self.skip_no_profile_pic,
+                                                        self.skip_no_profile_pic_percentage,
                                                         self.skip_business,
+                                                        self.skip_business_percentage,
                                                         self.skip_business_categories,
                                                         self.dont_skip_business_categories,
                                                         self.logger)
@@ -992,14 +999,20 @@ class InstaPy:
 
     def set_skip_users(self,
                        skip_private=True,
+                       private_percentage=100,
                        skip_no_profile_pic=False,
+                       no_profile_pic_percentage=100,
                        skip_business=False,
+                       business_percentage=100,
                        skip_business_categories=[],
                        dont_skip_business_categories=[]):
 
         self.skip_business = skip_business
         self.skip_private = skip_private
         self.skip_no_profile_pic = skip_no_profile_pic
+        self.skip_business_percentage = business_percentage
+        self.skip_no_profile_pic_percentage = no_profile_pic_percentage
+        self.skip_private_percentage = private_percentage
         if skip_business:
             self.skip_business_categories = skip_business_categories
             if len(skip_business_categories) == 0:
@@ -1124,8 +1137,11 @@ class InstaPy:
                                                                 self.min_posts,
                                                                 self.max_posts,
                                                                 self.skip_private,
+                                                                self.skip_private_percentage,
                                                                 self.skip_no_profile_pic,
+                                                                self.skip_no_profile_pic_percentage,
                                                                 self.skip_business,
+                                                                self.skip_business_percentage,
                                                                 self.skip_business_categories,
                                                                 self.dont_skip_business_categories,
                                                                 self.logger)
@@ -1336,8 +1352,11 @@ class InstaPy:
                                                                 self.min_posts,
                                                                 self.max_posts,
                                                                 self.skip_private,
+                                                                self.skip_private_percentage,
                                                                 self.skip_no_profile_pic,
+                                                                self.skip_no_profile_pic_percentage,
                                                                 self.skip_business,
+                                                                self.skip_business_percentage,
                                                                 self.skip_business_categories,
                                                                 self.dont_skip_business_categories,
                                                                 self.logger)
@@ -1553,8 +1572,11 @@ class InstaPy:
                                                                 self.min_posts,
                                                                 self.max_posts,
                                                                 self.skip_private,
+                                                                self.skip_private_percentage,
                                                                 self.skip_no_profile_pic,
+                                                                self.skip_no_profile_pic_percentage,
                                                                 self.skip_business,
+                                                                self.skip_business_percentage,
                                                                 self.skip_business_categories,
                                                                 self.dont_skip_business_categories,
                                                                 self.logger)
@@ -1747,8 +1769,11 @@ class InstaPy:
                                                     self.min_posts,
                                                     self.max_posts,
                                                     self.skip_private,
+                                                    self.skip_private_percentage,
                                                     self.skip_no_profile_pic,
+                                                    self.skip_no_profile_pic_percentage,
                                                     self.skip_business,
+                                                    self.skip_business_percentage,
                                                     self.skip_business_categories,
                                                     self.dont_skip_business_categories,
                                                     self.logger)
@@ -1985,8 +2010,11 @@ class InstaPy:
                                                         self.min_posts,
                                                         self.max_posts,
                                                         self.skip_private,
+                                                        self.skip_private_percentage,
                                                         self.skip_no_profile_pic,
+                                                        self.skip_no_profile_pic_percentage,
                                                         self.skip_business,
+                                                        self.skip_business_percentage,
                                                         self.skip_business_categories,
                                                         self.dont_skip_business_categories,
                                                         self.logger)
@@ -2327,8 +2355,11 @@ class InstaPy:
                                                         self.min_posts,
                                                         self.max_posts,
                                                         self.skip_private,
+                                                        self.skip_private_percentage,
                                                         self.skip_no_profile_pic,
+                                                        self.skip_no_profile_pic_percentage,
                                                         self.skip_business,
+                                                        self.skip_business_percentage,
                                                         self.skip_business_categories,
                                                         self.dont_skip_business_categories,
                                                         self.logger)
@@ -2489,8 +2520,11 @@ class InstaPy:
                                                         self.min_posts,
                                                         self.max_posts,
                                                         self.skip_private,
+                                                        self.skip_private_percentage,
                                                         self.skip_no_profile_pic,
+                                                        self.skip_no_profile_pic_percentage,
                                                         self.skip_business,
+                                                        self.skip_business_percentage,
                                                         self.skip_business_categories,
                                                         self.dont_skip_business_categories,
                                                         self.logger)
@@ -2654,8 +2688,11 @@ class InstaPy:
                                                         self.min_posts,
                                                         self.max_posts,
                                                         self.skip_private,
+                                                        self.skip_private_percentage,
                                                         self.skip_no_profile_pic,
+                                                        self.skip_no_profile_pic_percentage,
                                                         self.skip_business,
+                                                        self.skip_business_percentage,
                                                         self.skip_business_categories,
                                                         self.dont_skip_business_categories,
                                                         self.logger)
@@ -2830,8 +2867,11 @@ class InstaPy:
                                                         self.min_posts,
                                                         self.max_posts,
                                                         self.skip_private,
+                                                        self.skip_private_percentage,
                                                         self.skip_no_profile_pic,
+                                                        self.skip_no_profile_pic_percentage,
                                                         self.skip_business,
+                                                        self.skip_business_percentage,
                                                         self.skip_business_categories,
                                                         self.dont_skip_business_categories,
                                                         self.logger)
@@ -3090,8 +3130,11 @@ class InstaPy:
                                                                         self.min_posts,
                                                                         self.max_posts,
                                                                         self.skip_private,
+                                                                        self.skip_private_percentage,
                                                                         self.skip_no_profile_pic,
+                                                                        self.skip_no_profile_pic_percentage,
                                                                         self.skip_business,
+                                                                        self.skip_business_percentage,
                                                                         self.skip_business_categories,
                                                                         self.dont_skip_business_categories,
                                                                         self.logger)
@@ -3552,8 +3595,11 @@ class InstaPy:
                                                                 self.min_posts,
                                                                 self.max_posts,
                                                                 self.skip_private,
+                                                                self.skip_private_percentage,
                                                                 self.skip_no_profile_pic,
+                                                                self.skip_no_profile_pic_percentage,
                                                                 self.skip_business,
+                                                                self.skip_business_percentage,
                                                                 self.skip_business_categories,
                                                                 self.dont_skip_business_categories,
                                                                 self.logger)
@@ -3667,8 +3713,11 @@ class InstaPy:
                                                             self.min_posts,
                                                             self.max_posts,
                                                             self.skip_private,
+                                                            self.skip_private_percentage,
                                                             self.skip_no_profile_pic,
+                                                            self.skip_no_profile_pic_percentage,
                                                             self.skip_business,
+                                                            self.skip_business_percentage,
                                                             self.skip_business_categories,
                                                             self.dont_skip_business_categories,
                                                             self.logger)

--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -66,12 +66,9 @@ from .database_engine import get_database
 from selenium.common.exceptions import NoSuchElementException, WebDriverException
 
 
-
-
 class InstaPyError(Exception):
     """General error for InstaPy exceptions"""
     pass
-
 
 
 class InstaPy:
@@ -149,7 +146,7 @@ class InstaPy:
         self.dont_include = set()
         self.white_list = set()
         self.blacklist = {'enabled': 'True', 'campaign': ''}
-        self.automatedFollowedPool = {"all":[], "eligible":[]}
+        self.automatedFollowedPool = {"all": [], "eligible": []}
         self.do_like = False
         self.like_percentage = 0
         self.smart_hashtags = []
@@ -189,16 +186,18 @@ class InstaPy:
         self.max_comments = 35
         self.min_comments = 0
         self.comments_mandatory_words = []
+        self.max_posts = None
+        self.min_posts = None
 
-        self.relationship_data = {username:{"all_following":[], "all_followers":[]}}
+        self.relationship_data = {username: {"all_following": [], "all_followers": []}}
 
         self.simulation = {"enabled": True, "percentage": 100}
 
         # use this variable to terminate the nested loops after quotient reaches
         self.quotient_breach = False
         # hold the consecutive jumps and set max of it used with QS to break loops
-        self.jumps = {"consequent":{"likes": 0, "comments":0, "follows":0, "unfollows":0},
-                      "limit":{"likes": 7, "comments":3, "follows":5, "unfollows":4}}
+        self.jumps = {"consequent": {"likes": 0, "comments": 0, "follows": 0, "unfollows": 0},
+                      "limit": {"likes": 7, "comments": 3, "follows": 5, "unfollows": 4}}
 
         # stores the features' name which are being used by other features
         self.internal_usage = {}
@@ -216,7 +215,6 @@ class InstaPy:
         if self.selenium_local_session == True:
             self.set_selenium_local_session()
 
-
     def get_instapy_logger(self, show_logs):
         """
         Handles the creation and retrieval of loggers to avoid re-instantiation.
@@ -232,7 +230,8 @@ class InstaPy:
             file_handler = logging.FileHandler('{}general.log'.format(self.logfolder))
             file_handler.setLevel(logging.DEBUG)
             extra = {"username": self.username}
-            logger_formatter = logging.Formatter('%(levelname)s [%(asctime)s] [%(username)s]  %(message)s', datefmt='%Y-%m-%d %H:%M:%S')
+            logger_formatter = logging.Formatter('%(levelname)s [%(asctime)s] [%(username)s]  %(message)s',
+                                                 datefmt='%Y-%m-%d %H:%M:%S')
             file_handler.setFormatter(logger_formatter)
             logger.addHandler(file_handler)
 
@@ -282,7 +281,7 @@ class InstaPy:
         else:
             chromedriver_location = Settings.chromedriver_location
             chrome_options = Options()
-            #chrome_options.add_argument("--disable-infobars")
+            # chrome_options.add_argument("--disable-infobars")
             chrome_options.add_argument("--mute-audio")
             chrome_options.add_argument('--dns-prefetch-disable')
             chrome_options.add_argument('--lang=en-US')
@@ -293,10 +292,10 @@ class InstaPy:
             if self.headless_browser:
                 chrome_options.add_argument('--headless')
                 chrome_options.add_argument('--no-sandbox')
-                
+
                 if self.disable_image_load:
                     chrome_options.add_argument('--blink-settings=imagesEnabled=false')
-                
+
                 # Replaces browser User Agent from "HeadlessChrome".
                 user_agent = "Chrome"
                 chrome_options.add_argument('user-agent={user_agent}'
@@ -322,10 +321,10 @@ class InstaPy:
             chrome_prefs = {
                 'intl.accept_languages': 'en-US'
             }
-            
+
             if self.disable_image_load:
                 chrome_prefs['profile.managed_default_content_settings.images'] = 2
-            
+
             chrome_options.add_experimental_option('prefs', chrome_prefs)
             try:
                 self.browser = webdriver.Chrome(chromedriver_location,
@@ -350,7 +349,6 @@ class InstaPy:
         print('')
 
         return self
-
 
     def set_selenium_remote_session(self, selenium_url=''):
         """Starts remote session for a selenium server.
@@ -542,7 +540,7 @@ class InstaPy:
         if self.aborting:
             return self
 
-        #if os.name == 'nt':
+        # if os.name == 'nt':
         #    raise InstaPyError('Clarifai is not supported on Windows')
 
         self.use_clarifai = enabled
@@ -609,9 +607,7 @@ class InstaPy:
             self.clarifai_img_tags.append((tags, comment, comments))
             self.clarifai_img_tags_skip = tags_skip
 
-
         return self
-
 
     def follow_commenters(self, usernames, amount=10, daysold=365, max_pic=50, sleep_delay=600, interact=False):
         """ Follows users' commenters """
@@ -633,41 +629,50 @@ class InstaPy:
         commented_init = self.commented
         inap_img_init = self.inap_img
 
-        relax_point = random.randint(7, 14)   # you can use some plain value `10` instead of this quitely randomized score
+        relax_point = random.randint(7,
+                                     14)  # you can use some plain value `10` instead of this quitely randomized score
         self.quotient_breach = False
 
         for username in usernames:
             if self.quotient_breach:
                 break
 
-            self.logger.info("Following commenters of '{}' from {} pictures in last {} days...\nScrapping wall..".format(username, max_pic, daysold))
+            self.logger.info(
+                "Following commenters of '{}' from {} pictures in last {} days...\nScrapping wall..".format(username,
+                                                                                                            max_pic,
+                                                                                                            daysold))
             commenters = extract_information(self.browser, username, daysold, max_pic)
 
-            if len(commenters)>0:
+            if len(commenters) > 0:
                 self.logger.info("Going to follow top {} users.\n".format(amount))
                 sleep(1)
                 # This way of iterating will prevent sleep interference between functions
                 random.shuffle(commenters)
-                for commenter in commenters[:amount] :
+                for commenter in commenters[:amount]:
                     if self.quotient_breach:
-                        self.logger.warning("--> Follow quotient reached its peak!\t~leaving Follow-Commenters activity\n")
+                        self.logger.warning(
+                            "--> Follow quotient reached its peak!\t~leaving Follow-Commenters activity\n")
                         break
 
                     with self.feature_in_feature("follow_by_list", True):
                         followed = self.follow_by_list(commenter,
-                                                        self.follow_times,
-                                                         sleep_delay,
-                                                          interact)
+                                                       self.follow_times,
+                                                       sleep_delay,
+                                                       interact)
                     if followed > 0:
                         followed_all += 1
                         followed_new += 1
                         self.logger.info("Total Follow: {}\n".format(str(followed_all)))
                         # Take a break after a good following
                         if followed_new >= relax_point:
-                            delay_random = random.randint(ceil(sleep_delay*0.85), ceil(sleep_delay*1.14))
+                            delay_random = random.randint(ceil(sleep_delay * 0.85), ceil(sleep_delay * 1.14))
                             self.logger.info('------=>  Followed {} new users ~sleeping about {}'.format(followed_new,
-                                                                        '{} seconds'.format(delay_random) if delay_random < 60 else
-                                                                        '{} minutes'.format(float("{0:.2f}".format(delay_random/60)))))
+                                                                                                         '{} seconds'.format(
+                                                                                                             delay_random) if delay_random < 60 else
+                                                                                                         '{} minutes'.format(
+                                                                                                             float(
+                                                                                                                 "{0:.2f}".format(
+                                                                                                                     delay_random / 60)))))
                             sleep(delay_random)
                             relax_point = random.randint(7, 14)
                             followed_new = 0
@@ -686,7 +691,7 @@ class InstaPy:
         liked = (self.liked_img - liked_init)
         already_liked = (self.already_liked - already_liked_init)
         commented = (self.commented - commented_init)
-        inap_img = (self.inap_img- inap_img_init)
+        inap_img = (self.inap_img - inap_img_init)
 
         # print results
         self.logger.info("Followed: {}".format(followed_all))
@@ -703,9 +708,8 @@ class InstaPy:
 
         return self
 
-
-
-    def follow_likers (self, usernames, photos_grab_amount=3, follow_likers_per_photo=3, randomize=True, sleep_delay=600, interact=False):
+    def follow_likers(self, usernames, photos_grab_amount=3, follow_likers_per_photo=3, randomize=True, sleep_delay=600,
+                      interact=False):
         """ Follows users' likers """
 
         message = "Starting to follow likers.."
@@ -714,7 +718,7 @@ class InstaPy:
         if not isinstance(usernames, list):
             usernames = [usernames]
 
-        if photos_grab_amount>12:
+        if photos_grab_amount > 12:
             self.logger.info("Sorry, you can only grab likers from first 12 photos for given username now.\n")
             photos_grab_amount = 12
 
@@ -729,7 +733,8 @@ class InstaPy:
         commented_init = self.commented
         inap_img_init = self.inap_img
 
-        relax_point = random.randint(7, 14)   # you can use some plain value `10` instead of this quitely randomized score
+        relax_point = random.randint(7,
+                                     14)  # you can use some plain value `10` instead of this quitely randomized score
         self.quotient_breach = False
 
         for username in usernames:
@@ -749,29 +754,33 @@ class InstaPy:
                 # This way of iterating will prevent sleep interference between functions
                 random.shuffle(likers)
 
-                for liker in likers[:follow_likers_per_photo] :
+                for liker in likers[:follow_likers_per_photo]:
                     if self.quotient_breach:
                         self.logger.warning("--> Follow quotient reached its peak!\t~leaving Follow-Likers activity\n")
                         break
 
                     with self.feature_in_feature("follow_by_list", True):
                         followed = self.follow_by_list(liker,
-                                                        self.follow_times,
-                                                         sleep_delay,
-                                                          interact)
+                                                       self.follow_times,
+                                                       sleep_delay,
+                                                       interact)
                     if followed > 0:
                         followed_all += 1
                         followed_new += 1
                         self.logger.info("Total Follow: {}\n".format(str(followed_all)))
                         # Take a break after a good following
                         if followed_new >= relax_point:
-                            delay_random = random.randint(ceil(sleep_delay*0.85), ceil(sleep_delay*1.14))
+                            delay_random = random.randint(ceil(sleep_delay * 0.85), ceil(sleep_delay * 1.14))
                             self.logger.info('------=>  Followed {} new users ~sleeping about {}'.format(followed_new,
-                                                                        '{} seconds'.format(delay_random) if delay_random < 60 else
-                                                                        '{} minutes'.format(float("{0:.2f}".format(delay_random/60)))))
+                                                                                                         '{} seconds'.format(
+                                                                                                             delay_random) if delay_random < 60 else
+                                                                                                         '{} minutes'.format(
+                                                                                                             float(
+                                                                                                                 "{0:.2f}".format(
+                                                                                                                     delay_random / 60)))))
                             sleep(delay_random)
                             relax_point = random.randint(7, 14)
-                            followed_new=0
+                            followed_new = 0
                             pass
 
         self.logger.info("Finished following Likers!\n")
@@ -782,7 +791,7 @@ class InstaPy:
         liked = (self.liked_img - liked_init)
         already_liked = (self.already_liked - already_liked_init)
         commented = (self.commented - commented_init)
-        inap_img = (self.inap_img- inap_img_init)
+        inap_img = (self.inap_img - inap_img_init)
 
         # print results
         self.logger.info("Followed: {}".format(followed_all))
@@ -799,8 +808,6 @@ class InstaPy:
 
         return self
 
-
-
     def follow_by_list(self, followlist, times=1, sleep_delay=600, interact=False):
         """Allows to follow by any scrapped list"""
         if not isinstance(followlist, list):
@@ -808,7 +815,7 @@ class InstaPy:
 
         if self.aborting:
             self.logger.info(">>> self aborting prevented")
-            #return self
+            # return self
 
         # standalone means this feature is started by the user
         standalone = True if "follow_by_list" not in self.internal_usage.keys() else False
@@ -828,7 +835,8 @@ class InstaPy:
         commented_init = self.commented
         inap_img_init = self.inap_img
 
-        relax_point = random.randint(7, 14)   # you can use some plain value `10` instead of this quitely randomized score
+        relax_point = random.randint(7,
+                                     14)  # you can use some plain value `10` instead of this quitely randomized score
         self.quotient_breach = False
 
         for acc_to_follow in followlist:
@@ -847,17 +855,19 @@ class InstaPy:
             if not users_validated:
                 # Verify if the user should be followed
                 validation, details = validate_username(self.browser,
-                                               acc_to_follow,
-                                               self.username,
-                                               self.ignore_users,
-                                               self.blacklist,
-                                               self.potency_ratio,
-                                               self.delimit_by_numbers,
-                                               self.max_followers,
-                                               self.max_following,
-                                               self.min_followers,
-                                               self.min_following,
-                                               self.logger)
+                                                        acc_to_follow,
+                                                        self.username,
+                                                        self.ignore_users,
+                                                        self.blacklist,
+                                                        self.potency_ratio,
+                                                        self.delimit_by_numbers,
+                                                        self.max_followers,
+                                                        self.max_following,
+                                                        self.min_followers,
+                                                        self.min_following,
+                                                        self.min_posts,
+                                                        self.max_posts,
+                                                        self.logger)
                 if validation != True or acc_to_follow == self.username:
                     self.logger.info("--> Not a valid user: {}\n".format(details))
                     not_valid_users += 1
@@ -865,10 +875,13 @@ class InstaPy:
 
             # Take a break after a good following
             if followed_new >= relax_point:
-                delay_random = random.randint(ceil(sleep_delay*0.85), ceil(sleep_delay*1.14))
+                delay_random = random.randint(ceil(sleep_delay * 0.85), ceil(sleep_delay * 1.14))
                 self.logger.info("Followed {} new users  ~sleeping about {}\n".format(followed_new,
-                                                            '{} seconds'.format(delay_random) if delay_random < 60 else
-                                                            '{} minutes'.format(float("{0:.2f}".format(delay_random/60)))))
+                                                                                      '{} seconds'.format(
+                                                                                          delay_random) if delay_random < 60 else
+                                                                                      '{} minutes'.format(float(
+                                                                                          "{0:.2f}".format(
+                                                                                              delay_random / 60)))))
                 sleep(delay_random)
                 followed_new = 0
                 relax_point = random.randint(7, 14)
@@ -876,13 +889,13 @@ class InstaPy:
 
             if not follow_restriction("read", acc_to_follow, self.follow_times, self.logger):
                 follow_state, msg = follow_user(self.browser,
-                                        "profile",
-                                         self.username,
-                                          acc_to_follow,
-                                           None,
-                                            self.blacklist,
-                                             self.logger,
-                                              self.logfolder)
+                                                "profile",
+                                                self.username,
+                                                acc_to_follow,
+                                                None,
+                                                self.blacklist,
+                                                self.logger,
+                                                self.logfolder)
                 sleep(random.randint(1, 3))
 
                 if follow_state == True:
@@ -891,21 +904,21 @@ class InstaPy:
                     # reset jump counter after a successful follow
                     self.jumps["consequent"]["follows"] = 0
 
-                    if standalone:   # print only for external usage (internal callers have their printers)
+                    if standalone:  # print only for external usage (internal callers have their printers)
                         self.logger.info("Total Follow: {}\n".format(str(followed_all)))
 
                     # Check if interaction is expected
                     if interact and self.do_like:
                         do_interact = random.randint(0, 100) <= self.user_interact_percentage
                         # Do interactions if any
-                        if do_interact and self.user_interact_amount>0:
-                            original_do_follow = self.do_follow   # store the original value of `self.do_follow`
-                            self.do_follow = False   # disable following temporarily cos the user is already followed above
+                        if do_interact and self.user_interact_amount > 0:
+                            original_do_follow = self.do_follow  # store the original value of `self.do_follow`
+                            self.do_follow = False  # disable following temporarily cos the user is already followed above
                             self.interact_by_users(acc_to_follow,
-                                                    self.user_interact_amount,
-                                                     self.user_interact_random,
-                                                      self.user_interact_media)
-                            self.do_follow = original_do_follow   # revert back original `self.do_follow` value (either it was `False` or `True`)
+                                                   self.user_interact_amount,
+                                                   self.user_interact_random,
+                                                   self.user_interact_media)
+                            self.do_follow = original_do_follow  # revert back original `self.do_follow` value (either it was `False` or `True`)
 
                 elif msg == "already followed":
                     already_followed += 1
@@ -916,7 +929,7 @@ class InstaPy:
 
                 sleep(1)
 
-        if standalone:   # print only for external usage (internal callers have their printers)
+        if standalone:  # print only for external usage (internal callers have their printers)
             self.logger.info("Finished following by List!\n")
             # print summary
             self.logger.info("Followed: {}".format(followed_all))
@@ -929,7 +942,7 @@ class InstaPy:
                 liked = (self.liked_img - liked_init)
                 already_liked = (self.already_liked - already_liked_init)
                 commented = (self.commented - commented_init)
-                inap_img = (self.inap_img- inap_img_init)
+                inap_img = (self.inap_img - inap_img_init)
 
                 # print the summary out of interactions
                 self.logger.info("Liked: {}".format(liked))
@@ -944,19 +957,19 @@ class InstaPy:
 
         return followed_all
 
-
-
-    def set_relationship_bounds (self,
-                                  enabled=None,
-                                   potency_ratio=None,
-                                    delimit_by_numbers=None,
-                                     max_followers=None,
-                                      max_following=None,
-                                       min_followers=None,
-                                        min_following=None):
+    def set_relationship_bounds(self,
+                                enabled=None,
+                                potency_ratio=None,
+                                delimit_by_numbers=None,
+                                min_posts=None,
+                                max_posts=None,
+                                max_followers=None,
+                                max_following=None,
+                                min_followers=None,
+                                min_following=None):
         """Sets the potency ratio and limits to the provide an efficient activity between the targeted masses"""
-        self.potency_ratio = potency_ratio if enabled==True else None
-        self.delimit_by_numbers = delimit_by_numbers if enabled==True else None
+        self.potency_ratio = potency_ratio if enabled == True else None
+        self.delimit_by_numbers = delimit_by_numbers if enabled == True else None
 
         self.max_followers = max_followers
         self.min_followers = min_followers
@@ -964,32 +977,30 @@ class InstaPy:
         self.max_following = max_following
         self.min_following = min_following
 
-
+        self.min_posts = min_posts
+        self.max_posts = max_posts
 
     def set_delimit_liking(self,
-                            enabled=None,
-                             max=None,
-                              min=None):
+                           enabled=None,
+                           max=None,
+                           min=None):
 
-        self.delimit_liking = True if enabled==True else False
+        self.delimit_liking = True if enabled == True else False
         self.max_likes = max
         self.min_likes = min
 
-
-
     def set_delimit_commenting(self,
-                                enabled=False,
-                                 max=None,
-                                  min=None,
-                                    comments_mandatory_words=[]):
+                               enabled=False,
+                               max=None,
+                               min=None,
+                               comments_mandatory_words=[]):
 
-        self.delimit_commenting = True if enabled==True else False
+        self.delimit_commenting = True if enabled == True else False
         self.max_comments = max
         self.min_comments = min
 
         # comment only when the image description contain at least one of those words
         self.comments_mandatory_words = comments_mandatory_words
-
 
     def set_simulation(self, enabled=True, percentage=100):
         """ Sets aside simulation parameters """
@@ -1001,9 +1012,7 @@ class InstaPy:
 
         else:
             percentage = 0 if percentage is None else percentage
-            self.simulation = {"enabled":True, "percentage":percentage}
-
-
+            self.simulation = {"enabled": True, "percentage": percentage}
 
     def like_by_locations(self,
                           locations=None,
@@ -1069,19 +1078,21 @@ class InstaPy:
                         self.liking_approved = verify_liking(self.browser, self.max_likes, self.min_likes, self.logger)
 
                     if not inappropriate and self.liking_approved:
-                        #validate user
+                        # validate user
                         validation, details = validate_username(self.browser,
-                                                       user_name,
-                                                       self.username,
-                                                       self.ignore_users,
-                                                       self.blacklist,
-                                                       self.potency_ratio,
-                                                       self.delimit_by_numbers,
-                                                       self.max_followers,
-                                                       self.max_following,
-                                                       self.min_followers,
-                                                       self.min_following,
-                                                       self.logger)
+                                                                user_name,
+                                                                self.username,
+                                                                self.ignore_users,
+                                                                self.blacklist,
+                                                                self.potency_ratio,
+                                                                self.delimit_by_numbers,
+                                                                self.max_followers,
+                                                                self.max_following,
+                                                                self.min_followers,
+                                                                self.min_following,
+                                                                self.min_posts,
+                                                                self.max_posts,
+                                                                self.logger)
                         if validation != True:
                             self.logger.info("--> Not a valid user: {}".format(details))
                             not_valid_users += 1
@@ -1089,12 +1100,12 @@ class InstaPy:
                         else:
                             web_address_navigator(self.browser, link)
 
-                        #try to like
+                        # try to like
                         like_state, msg = like_image(self.browser,
-                                           user_name,
-                                           self.blacklist,
-                                           self.logger,
-                                           self.logfolder)
+                                                     user_name,
+                                                     self.blacklist,
+                                                     self.logger,
+                                                     self.logfolder)
 
                         if like_state == True:
                             liked_img += 1
@@ -1125,8 +1136,8 @@ class InstaPy:
 
                             # comments
                             if (self.do_comment and
-                                user_name not in self.dont_include and
-                                checked_img and
+                                    user_name not in self.dont_include and
+                                    checked_img and
                                     commenting):
 
                                 if self.delimit_commenting:
@@ -1135,7 +1146,7 @@ class InstaPy:
                                                                              self.max_comments,
                                                                              self.min_comments,
                                                                              self.comments_mandatory_words,
-                                                                              self.logger)
+                                                                             self.logger)
                                 if self.commenting_approved:
                                     if temp_comments:
                                         # Use clarifai related comments only!
@@ -1147,11 +1158,11 @@ class InstaPy:
                                         comments = (self.comments +
                                                     self.photo_comments)
                                     comment_state, msg = comment_image(self.browser,
-                                                               user_name,
-                                                               comments,
-                                                               self.blacklist,
-                                                               self.logger,
-                                                               self.logfolder)
+                                                                       user_name,
+                                                                       comments,
+                                                                       self.blacklist,
+                                                                       self.logger,
+                                                                       self.logfolder)
                                     if comment_state == True:
                                         commented += 1
 
@@ -1164,20 +1175,20 @@ class InstaPy:
 
                             # following
                             if (self.do_follow and
-                                user_name not in self.dont_include and
-                                checked_img and
-                                following and
-                                not follow_restriction("read", user_name,
-                                 self.follow_times, self.logger)):
+                                    user_name not in self.dont_include and
+                                    checked_img and
+                                    following and
+                                    not follow_restriction("read", user_name,
+                                                           self.follow_times, self.logger)):
 
                                 follow_state, msg = follow_user(self.browser,
-                                                        "post",
-                                                        self.username,
-                                                        user_name,
-                                                        None,
-                                                        self.blacklist,
-                                                        self.logger,
-                                                        self.logfolder)
+                                                                "post",
+                                                                self.username,
+                                                                user_name,
+                                                                None,
+                                                                self.blacklist,
+                                                                self.logger,
+                                                                self.logfolder)
                                 if follow_state == True:
                                     followed += 1
 
@@ -1218,10 +1229,10 @@ class InstaPy:
         return self
 
     def comment_by_locations(self,
-                      locations=None,
-                      amount=50,
-                      media=None,
-                      skip_top_posts=True):
+                             locations=None,
+                             amount=50,
+                             media=None,
+                             skip_top_posts=True):
         """Likes (default) 50 images per given locations"""
         if self.aborting:
             return self
@@ -1255,7 +1266,8 @@ class InstaPy:
 
             for i, link in enumerate(links):
                 if self.jumps["consequent"]["comments"] >= self.jumps["limit"]["comments"]:
-                    self.logger.warning("--> Comment quotient reached its peak!\t~leaving Comment-By-Locations activity\n")
+                    self.logger.warning(
+                        "--> Comment quotient reached its peak!\t~leaving Comment-By-Locations activity\n")
                     self.quotient_breach = True
                     # reset jump counter after a breach report
                     self.jumps["consequent"]["comments"] = 0
@@ -1273,19 +1285,21 @@ class InstaPy:
                                    self.ignore_if_contains,
                                    self.logger))
                     if not inappropriate:
-                        #validate user
+                        # validate user
                         validation, details = validate_username(self.browser,
-                                                       user_name,
-                                                       self.username,
-                                                       self.ignore_users,
-                                                       self.blacklist,
-                                                       self.potency_ratio,
-                                                       self.delimit_by_numbers,
-                                                       self.max_followers,
-                                                       self.max_following,
-                                                       self.min_followers,
-                                                       self.min_following,
-                                                       self.logger)
+                                                                user_name,
+                                                                self.username,
+                                                                self.ignore_users,
+                                                                self.blacklist,
+                                                                self.potency_ratio,
+                                                                self.delimit_by_numbers,
+                                                                self.max_followers,
+                                                                self.max_following,
+                                                                self.min_followers,
+                                                                self.min_following,
+                                                                self.min_posts,
+                                                                self.max_posts,
+                                                                self.logger)
                         if validation != True:
                             self.logger.info(details)
                             not_valid_users += 1
@@ -1293,8 +1307,9 @@ class InstaPy:
                         else:
                             web_address_navigator(self.browser, link)
 
-                        #try to comment
-                        self.logger.info("--> Image not liked: Likes are disabled for the 'Comment-By-Locations' feature")
+                        # try to comment
+                        self.logger.info(
+                            "--> Image not liked: Likes are disabled for the 'Comment-By-Locations' feature")
 
                         checked_img = True
                         temp_comments = []
@@ -1322,16 +1337,16 @@ class InstaPy:
                                     'Image check error: {}'.format(err))
 
                         if (self.do_comment and
-                            user_name not in self.dont_include and
-                            checked_img):
+                                user_name not in self.dont_include and
+                                checked_img):
 
                             if self.delimit_commenting:
                                 (self.commenting_approved,
-                                  disapproval_reason) = verify_commenting(self.browser,
-                                                                           self.max_comments,
-                                                                           self.min_comments,
-                                                                           self.comments_mandatory_words,
-                                                                            self.logger)
+                                 disapproval_reason) = verify_commenting(self.browser,
+                                                                         self.max_comments,
+                                                                         self.min_comments,
+                                                                         self.comments_mandatory_words,
+                                                                         self.logger)
                             if self.commenting_approved:
                                 if temp_comments:
                                     # Use clarifai related comments only!
@@ -1344,11 +1359,11 @@ class InstaPy:
                                                 self.photo_comments)
 
                                 comment_state, msg = comment_image(self.browser,
-                                                                    user_name,
-                                                                     comments,
-                                                                      self.blacklist,
-                                                                       self.logger,
-                                                                       self.logfolder)
+                                                                   user_name,
+                                                                   comments,
+                                                                   self.blacklist,
+                                                                   self.logger,
+                                                                   self.logfolder)
                                 if comment_state == True:
                                     commented += 1
                                     # reset jump counter after a successful comment
@@ -1356,22 +1371,22 @@ class InstaPy:
 
                                     # try to follow
                                     if (self.do_follow and
-                                         user_name not in self.dont_include and
-                                          checked_img and
-                                           following and
+                                            user_name not in self.dont_include and
+                                            checked_img and
+                                            following and
                                             not follow_restriction("read",
-                                                                    user_name,
-                                                                     self.follow_times,
-                                                                      self.logger)):
+                                                                   user_name,
+                                                                   self.follow_times,
+                                                                   self.logger)):
 
                                         follow_state, msg = follow_user(self.browser,
-                                                                         "post",
-                                                                          self.username,
-                                                                          user_name,
-                                                                           None,
-                                                                            self.blacklist,
-                                                                             self.logger,
-                                                                             self.logfolder)
+                                                                        "post",
+                                                                        self.username,
+                                                                        user_name,
+                                                                        None,
+                                                                        self.blacklist,
+                                                                        self.logger,
+                                                                        self.logfolder)
                                         if follow_state == True:
                                             followed += 1
 
@@ -1408,8 +1423,6 @@ class InstaPy:
         self.not_valid_users += not_valid_users
 
         return self
-
-
 
     def like_by_tags(self,
                      tags=None,
@@ -1484,19 +1497,21 @@ class InstaPy:
                         self.liking_approved = verify_liking(self.browser, self.max_likes, self.min_likes, self.logger)
 
                     if not inappropriate and self.liking_approved:
-                        #validate user
+                        # validate user
                         validation, details = validate_username(self.browser,
-                                                       user_name,
-                                                       self.username,
-                                                       self.ignore_users,
-                                                       self.blacklist,
-                                                       self.potency_ratio,
-                                                       self.delimit_by_numbers,
-                                                       self.max_followers,
-                                                       self.max_following,
-                                                       self.min_followers,
-                                                       self.min_following,
-                                                       self.logger)
+                                                                user_name,
+                                                                self.username,
+                                                                self.ignore_users,
+                                                                self.blacklist,
+                                                                self.potency_ratio,
+                                                                self.delimit_by_numbers,
+                                                                self.max_followers,
+                                                                self.max_following,
+                                                                self.min_followers,
+                                                                self.min_following,
+                                                                self.min_posts,
+                                                                self.max_posts,
+                                                                self.logger)
                         if validation != True:
                             self.logger.info(details)
                             not_valid_users += 1
@@ -1504,12 +1519,12 @@ class InstaPy:
                         else:
                             web_address_navigator(self.browser, link)
 
-                        #try to like
+                        # try to like
                         like_state, msg = like_image(self.browser,
-                                           user_name,
-                                           self.blacklist,
-                                           self.logger,
-                                           self.logfolder)
+                                                     user_name,
+                                                     self.blacklist,
+                                                     self.logger,
+                                                     self.logfolder)
 
                         if like_state == True:
                             liked_img += 1
@@ -1540,8 +1555,8 @@ class InstaPy:
 
                             # comments
                             if (self.do_comment and
-                                user_name not in self.dont_include and
-                                checked_img and
+                                    user_name not in self.dont_include and
+                                    checked_img and
                                     commenting):
 
                                 if self.delimit_commenting:
@@ -1562,11 +1577,11 @@ class InstaPy:
                                         comments = (self.comments +
                                                     self.photo_comments)
                                     comment_state, msg = comment_image(self.browser,
-                                                               user_name,
-                                                               comments,
-                                                               self.blacklist,
-                                                               self.logger,
-                                                               self.logfolder)
+                                                                       user_name,
+                                                                       comments,
+                                                                       self.blacklist,
+                                                                       self.logger,
+                                                                       self.logfolder)
                                     if comment_state == True:
                                         commented += 1
 
@@ -1579,20 +1594,20 @@ class InstaPy:
 
                             # following
                             if (self.do_follow and
-                                user_name not in self.dont_include and
-                                checked_img and
-                                following and
-                                not follow_restriction("read", user_name,
-                                 self.follow_times, self.logger)):
+                                    user_name not in self.dont_include and
+                                    checked_img and
+                                    following and
+                                    not follow_restriction("read", user_name,
+                                                           self.follow_times, self.logger)):
 
                                 follow_state, msg = follow_user(self.browser,
-                                                        "post",
-                                                        self.username,
-                                                        user_name,
-                                                        None,
-                                                        self.blacklist,
-                                                        self.logger,
-                                                        self.logfolder)
+                                                                "post",
+                                                                self.username,
+                                                                user_name,
+                                                                None,
+                                                                self.blacklist,
+                                                                self.logger,
+                                                                self.logfolder)
                                 if follow_state == True:
                                     followed += 1
                             else:
@@ -1602,13 +1617,13 @@ class InstaPy:
                             # interactions (if any)
                             if interact:
                                 self.logger.info(
-                                      "--> User gonna be interacted: '{}'"
-                                       .format(user_name))
+                                    "--> User gonna be interacted: '{}'"
+                                        .format(user_name))
 
                                 self.like_by_users(user_name,
-                                                    self.user_interact_amount,
-                                                    self.user_interact_random,
-                                                    self.user_interact_media)
+                                                   self.user_interact_amount,
+                                                   self.user_interact_random,
+                                                   self.user_interact_media)
 
                         elif msg == "already liked":
                             already_liked += 1
@@ -1666,24 +1681,26 @@ class InstaPy:
                 break
 
             self.logger.info("Username [{}/{}]"
-                              .format(index + 1, len(usernames)))
+                             .format(index + 1, len(usernames)))
             self.logger.info("--> {}"
-                              .format(username.encode('utf-8')))
+                             .format(username.encode('utf-8')))
 
             following = random.randint(0, 100) <= self.follow_percentage
 
             validation, details = validate_username(self.browser,
-                                           username,
-                                           self.username,
-                                           self.ignore_users,
-                                           self.blacklist,
-                                           self.potency_ratio,
-                                           self.delimit_by_numbers,
-                                           self.max_followers,
-                                           self.max_following,
-                                           self.min_followers,
-                                           self.min_following,
-                                           self.logger)
+                                                    username,
+                                                    self.username,
+                                                    self.ignore_users,
+                                                    self.blacklist,
+                                                    self.potency_ratio,
+                                                    self.delimit_by_numbers,
+                                                    self.max_followers,
+                                                    self.max_following,
+                                                    self.min_followers,
+                                                    self.min_following,
+                                                    self.min_posts,
+                                                    self.max_posts,
+                                                    self.logger)
             if not validation:
                 self.logger.info("--> not a valid user: {}".format(details))
                 not_valid_users += 1
@@ -1703,20 +1720,20 @@ class InstaPy:
                 continue
 
             if (self.do_follow and
-                username not in self.dont_include and
-                following and
-                not follow_restriction("read",
-                                         username,
-                                          self.follow_times,
+                    username not in self.dont_include and
+                    following and
+                    not follow_restriction("read",
+                                           username,
+                                           self.follow_times,
                                            self.logger)):
                 follow_state, msg = follow_user(self.browser,
-                                        "profile",
-                                        self.username,
-                                        username,
-                                        None,
-                                        self.blacklist,
-                                        self.logger,
-                                        self.logfolder)
+                                                "profile",
+                                                self.username,
+                                                username,
+                                                None,
+                                                self.blacklist,
+                                                self.logger,
+                                                self.logfolder)
                 if follow_state == True:
                     followed += 1
             else:
@@ -1761,10 +1778,10 @@ class InstaPy:
 
                     if not inappropriate and self.liking_approved:
                         like_state, msg = like_image(self.browser,
-                                                      user_name,
-                                                       self.blacklist,
-                                                        self.logger,
-                                                        self.logfolder)
+                                                     user_name,
+                                                     self.blacklist,
+                                                     self.logger,
+                                                     self.logfolder)
                         if like_state == True:
                             total_liked_img += 1
                             liked_img += 1
@@ -1792,17 +1809,17 @@ class InstaPy:
                                         'Image check error: {}'.format(err))
 
                             if (self.do_comment and
-                                user_name not in self.dont_include and
-                                checked_img and
+                                    user_name not in self.dont_include and
+                                    checked_img and
                                     commenting):
 
                                 if self.delimit_commenting:
                                     (self.commenting_approved,
                                      disapproval_reason) = verify_commenting(
-                                                                self.browser,
-                                                                 self.max_comments,
-                                                                 self.min_comments,
-                                                                  self.logger)
+                                        self.browser,
+                                        self.max_comments,
+                                        self.min_comments,
+                                        self.logger)
                                 if self.commenting_approved:
                                     if temp_comments:
                                         # use clarifai related comments only!
@@ -1815,11 +1832,11 @@ class InstaPy:
                                                     self.photo_comments)
 
                                     comment_state, msg = comment_image(self.browser,
-                                                               user_name,
-                                                               comments,
-                                                               self.blacklist,
-                                                               self.logger,
-                                                               self.logfolder)
+                                                                       user_name,
+                                                                       comments,
+                                                                       self.blacklist,
+                                                                       self.logger,
+                                                                       self.logfolder)
                                     if comment_state == True:
                                         commented += 1
 
@@ -1865,8 +1882,6 @@ class InstaPy:
 
         return self
 
-
-
     def interact_by_users(self,
                           usernames,
                           amount=10,
@@ -1906,17 +1921,19 @@ class InstaPy:
 
             if not users_validated:
                 validation, details = validate_username(self.browser,
-                                               username,
-                                               self.username,
-                                               self.ignore_users,
-                                               self.blacklist,
-                                               self.potency_ratio,
-                                               self.delimit_by_numbers,
-                                               self.max_followers,
-                                               self.max_following,
-                                               self.min_followers,
-                                               self.min_following,
-                                               self.logger)
+                                                        username,
+                                                        self.username,
+                                                        self.ignore_users,
+                                                        self.blacklist,
+                                                        self.potency_ratio,
+                                                        self.delimit_by_numbers,
+                                                        self.max_followers,
+                                                        self.max_following,
+                                                        self.min_followers,
+                                                        self.min_following,
+                                                        self.min_posts,
+                                                        self.max_posts,
+                                                        self.logger)
                 if not validation:
                     self.logger.info("--> not a valid user: {}".format(details))
                     not_valid_users += 1
@@ -1926,7 +1943,7 @@ class InstaPy:
             # static conditions
             not_dont_include = username not in self.dont_include
             follow_restricted = follow_restriction("read", username,
-                                                    self.follow_times, self.logger)
+                                                   self.follow_times, self.logger)
             counter = 0
             while True:
                 following = (random.randint(0, 100) <= self.follow_percentage and
@@ -1944,7 +1961,8 @@ class InstaPy:
                 if commenting and not liking and amount == 1:
                     continue
                 if following or commenting or liking:
-                    self.logger.info('username actions: following={} commenting={} liking={}'.format(following, commenting, liking))
+                    self.logger.info(
+                        'username actions: following={} commenting={} liking={}'.format(following, commenting, liking))
                     break
                 # if for some reason we have no actions on this user
                 if counter > 5:
@@ -2000,19 +2018,20 @@ class InstaPy:
                         if i > 0:
                             liking = (random.randint(0, 100) <= self.like_percentage)
                             commenting = (random.randint(0, 100) <= self.comment_percentage and
-                                            self.do_comment and
-                                                not_dont_include)
+                                          self.do_comment and
+                                          not_dont_include)
 
                         # like
                         if self.do_like and liking and self.delimit_liking:
-                            self.liking_approved = verify_liking(self.browser, self.max_likes, self.min_likes, self.logger)
+                            self.liking_approved = verify_liking(self.browser, self.max_likes, self.min_likes,
+                                                                 self.logger)
 
                         if self.do_like and liking and self.liking_approved:
                             like_state, msg = like_image(self.browser,
-                                               user_name,
-                                               self.blacklist,
-                                               self.logger,
-                                               self.logfolder)
+                                                         user_name,
+                                                         self.blacklist,
+                                                         self.logger,
+                                                         self.logfolder)
                             if like_state == True:
                                 total_liked_img += 1
                                 liked_img += 1
@@ -2041,12 +2060,12 @@ class InstaPy:
 
                                     if self.delimit_commenting:
                                         (self.commenting_approved,
-                                          disapproval_reason) = verify_commenting(
-                                                                     self.browser,
-                                                                      self.max_comments,
-                                                                      self.min_comments,
-                                                                      self.comments_mandatory_words,
-                                                                       self.logger)
+                                         disapproval_reason) = verify_commenting(
+                                            self.browser,
+                                            self.max_comments,
+                                            self.min_comments,
+                                            self.comments_mandatory_words,
+                                            self.logger)
                                     if self.commenting_approved:
                                         if temp_comments:
                                             # use clarifai related comments only!
@@ -2061,11 +2080,11 @@ class InstaPy:
                                                         self.photo_comments)
 
                                         comment_state, msg = comment_image(self.browser,
-                                                                            user_name,
-                                                                             comments,
-                                                                              self.blacklist,
-                                                                               self.logger,
-                                                                               self.logfolder)
+                                                                           user_name,
+                                                                           comments,
+                                                                           self.blacklist,
+                                                                           self.logger,
+                                                                           self.logfolder)
                                         if comment_state == True:
                                             commented += 1
 
@@ -2119,9 +2138,9 @@ class InstaPy:
                                  "reached its end\n")
 
         # final words
-        interacted_media_size = (len(usernames)*amount - inap_img)
+        interacted_media_size = (len(usernames) * amount - inap_img)
         self.logger.info("Finished interacting on total of {} images from {} users! xD\n"
-                            .format(interacted_media_size, len(usernames)))
+                         .format(interacted_media_size, len(usernames)))
 
         # print results
         self.logger.info('Liked: {}'.format(total_liked_img))
@@ -2141,8 +2160,6 @@ class InstaPy:
         self.not_valid_users += not_valid_users
 
         return self
-
-
 
     def like_from_image(self, url, amount=50, media=None):
         """Gets the tags from an image and likes 50 images for each tag"""
@@ -2165,8 +2182,6 @@ class InstaPy:
 
         return self
 
-
-
     def interact_user_followers(self, usernames, amount=10, randomize=False):
 
         if self.aborting:
@@ -2177,7 +2192,8 @@ class InstaPy:
             return self
 
         elif self.user_interact_amount <= 0:
-            self.logger.info("Please choose an amount higher than zero in `set_user_interact` in order to do interactions.")
+            self.logger.info(
+                "Please choose an amount higher than zero in `set_user_interact` in order to do interactions.")
             return self
 
         if not isinstance(usernames, list):
@@ -2200,20 +2216,20 @@ class InstaPy:
             if self.quotient_breach:
                 break
 
-            self.logger.info("User '{}' [{}/{}]".format((user), index+1, len(usernames)))
+            self.logger.info("User '{}' [{}/{}]".format((user), index + 1, len(usernames)))
             try:
                 person_list, simulated_list = get_given_user_followers(self.browser,
-                                                                        self.username,
-                                                                        user,
-                                                                        amount,
-                                                                        self.dont_include,
-                                                                        randomize,
-                                                                        self.blacklist,
-                                                                        self.follow_times,
-                                                                        self.simulation,
-                                                                        self.jumps,
-                                                                        self.logger,
-                                                                        self.logfolder)
+                                                                       self.username,
+                                                                       user,
+                                                                       amount,
+                                                                       self.dont_include,
+                                                                       randomize,
+                                                                       self.blacklist,
+                                                                       self.follow_times,
+                                                                       self.simulation,
+                                                                       self.jumps,
+                                                                       self.logger,
+                                                                       self.logfolder)
             except (TypeError, RuntimeWarning) as err:
 
                 if isinstance(err, RuntimeWarning):
@@ -2228,29 +2244,33 @@ class InstaPy:
                     return self
 
             print('')
-            self.logger.info("Grabbed {} usernames from '{}'s `Followers` to do interaction.".format(len(person_list), user))
+            self.logger.info(
+                "Grabbed {} usernames from '{}'s `Followers` to do interaction.".format(len(person_list), user))
 
             interacted_personal = 0
 
             for index, person in enumerate(person_list):
                 if self.quotient_breach:
-                    self.logger.warning("--> Like quotient reached its peak!\t~leaving Interact-User-Followers activity\n")
+                    self.logger.warning(
+                        "--> Like quotient reached its peak!\t~leaving Interact-User-Followers activity\n")
                     break
 
-                self.logger.info("User '{}' [{}/{}]".format((person), index+1, len(person_list)))
+                self.logger.info("User '{}' [{}/{}]".format((person), index + 1, len(person_list)))
 
                 validation, details = validate_username(self.browser,
-                                                         person,
-                                                         self.username,
-                                                          self.ignore_users,
-                                                          self.blacklist,
-                                                           self.potency_ratio,
-                                                           self.delimit_by_numbers,
-                                                            self.max_followers,
-                                                            self.max_following,
-                                                            self.min_followers,
-                                                            self.min_following,
-                                                             self.logger)
+                                                        person,
+                                                        self.username,
+                                                        self.ignore_users,
+                                                        self.blacklist,
+                                                        self.potency_ratio,
+                                                        self.delimit_by_numbers,
+                                                        self.max_followers,
+                                                        self.max_following,
+                                                        self.min_followers,
+                                                        self.min_following,
+                                                        self.min_posts,
+                                                        self.max_posts,
+                                                        self.logger)
                 if validation != True:
                     self.logger.info(details)
                     not_valid_users += 1
@@ -2258,17 +2278,17 @@ class InstaPy:
                     if person in simulated_list:
                         self.logger.warning("--> Simulated Unfollow {}:"
                                             " unfollowing '{}' due to mismatching validation..."
-                                                .format(simulated_unfollow+1, person))
+                                            .format(simulated_unfollow + 1, person))
 
                         unfollow_state, msg = unfollow_user(self.browser,
-                                                             "profile",
-                                                              self.username,
-                                                              person,
-                                                               None,
-                                                                None,
-                                                                 self.relationship_data,
-                                                                  self.logger,
-                                                                  self.logfolder)
+                                                            "profile",
+                                                            self.username,
+                                                            person,
+                                                            None,
+                                                            None,
+                                                            self.relationship_data,
+                                                            self.logger,
+                                                            self.logfolder)
                         if unfollow_state == True:
                             simulated_unfollow += 1
 
@@ -2277,8 +2297,9 @@ class InstaPy:
                 # Do interactions if any
                 do_interact = random.randint(0, 100) <= self.user_interact_percentage
 
-                if do_interact==False:
-                    self.logger.info("Skipping user '{}' due to the interaction percentage of {}".format(person, self.user_interact_percentage))
+                if do_interact == False:
+                    self.logger.info("Skipping user '{}' due to the interaction percentage of {}".format(person,
+                                                                                                         self.user_interact_percentage))
                     continue
 
                 else:
@@ -2286,18 +2307,18 @@ class InstaPy:
                     interacted_personal += 1
 
                     self.logger.info("Interaction [{}/{}]  |  Total Interaction: {}"
-                            .format(interacted_personal, len(person_list), interacted_all))
+                                     .format(interacted_personal, len(person_list), interacted_all))
 
                     with self.feature_in_feature("interact_by_users", False):
                         self.interact_by_users(person,
-                                                self.user_interact_amount,
-                                                 self.user_interact_random,
-                                                  self.user_interact_media)
+                                               self.user_interact_amount,
+                                               self.user_interact_random,
+                                               self.user_interact_media)
                     sleep(1)
 
         # final words
         self.logger.info("Finished interacting {} people from {} users' `Followers`! xD\n"
-                            .format(interacted_all, len(usernames)))
+                         .format(interacted_all, len(usernames)))
 
         # find the feature-wide action sizes by taking a difference
         liked = (self.liked_img - liked_init)
@@ -2317,8 +2338,6 @@ class InstaPy:
         self.not_valid_users += not_valid_users
 
         return self
-
-
 
     def interact_user_following(self, usernames, amount=10, randomize=False):
 
@@ -2330,7 +2349,8 @@ class InstaPy:
             return self
 
         elif self.user_interact_amount <= 0:
-            self.logger.info("Please choose an amount higher than zero in `set_user_interact` in order to do interactions.")
+            self.logger.info(
+                "Please choose an amount higher than zero in `set_user_interact` in order to do interactions.")
             return self
 
         if not isinstance(usernames, list):
@@ -2353,20 +2373,20 @@ class InstaPy:
             if self.quotient_breach:
                 break
 
-            self.logger.info("User '{}' [{}/{}]".format((user), index+1, len(usernames)))
+            self.logger.info("User '{}' [{}/{}]".format((user), index + 1, len(usernames)))
             try:
                 person_list, simulated_list = get_given_user_following(self.browser,
-                                                                        self.username,
-                                                                        user,
-                                                                        amount,
-                                                                        self.dont_include,
-                                                                        randomize,
-                                                                        self.blacklist,
-                                                                        self.follow_times,
-                                                                        self.simulation,
-                                                                        self.jumps,
-                                                                        self.logger,
-                                                                        self.logfolder)
+                                                                       self.username,
+                                                                       user,
+                                                                       amount,
+                                                                       self.dont_include,
+                                                                       randomize,
+                                                                       self.blacklist,
+                                                                       self.follow_times,
+                                                                       self.simulation,
+                                                                       self.jumps,
+                                                                       self.logger,
+                                                                       self.logfolder)
             except (TypeError, RuntimeWarning) as err:
 
                 if isinstance(err, RuntimeWarning):
@@ -2381,29 +2401,33 @@ class InstaPy:
                     return self
 
             print('')
-            self.logger.info("Grabbed {} usernames from '{}'s `Following` to do interaction.".format(len(person_list), user))
+            self.logger.info(
+                "Grabbed {} usernames from '{}'s `Following` to do interaction.".format(len(person_list), user))
 
             interacted_personal = 0
 
             for index, person in enumerate(person_list):
                 if self.quotient_breach:
-                    self.logger.warning("--> Like quotient reached its peak!\t~leaving Interact-User-Following activity\n")
+                    self.logger.warning(
+                        "--> Like quotient reached its peak!\t~leaving Interact-User-Following activity\n")
                     break
 
-                self.logger.info("User '{}' [{}/{}]".format((person), index+1, len(person_list)))
+                self.logger.info("User '{}' [{}/{}]".format((person), index + 1, len(person_list)))
 
                 validation, details = validate_username(self.browser,
-                                                         person,
-                                                         self.username,
-                                                          self.ignore_users,
-                                                          self.blacklist,
-                                                           self.potency_ratio,
-                                                           self.delimit_by_numbers,
-                                                            self.max_followers,
-                                                            self.max_following,
-                                                            self.min_followers,
-                                                            self.min_following,
-                                                             self.logger)
+                                                        person,
+                                                        self.username,
+                                                        self.ignore_users,
+                                                        self.blacklist,
+                                                        self.potency_ratio,
+                                                        self.delimit_by_numbers,
+                                                        self.max_followers,
+                                                        self.max_following,
+                                                        self.min_followers,
+                                                        self.min_following,
+                                                        self.min_posts,
+                                                        self.max_posts,
+                                                        self.logger)
                 if validation != True:
                     self.logger.info(details)
                     not_valid_users += 1
@@ -2411,17 +2435,17 @@ class InstaPy:
                     if person in simulated_list:
                         self.logger.warning("--> Simulated Unfollow {}:"
                                             " unfollowing '{}' due to mismatching validation..."
-                                                .format(simulated_unfollow+1, person))
+                                            .format(simulated_unfollow + 1, person))
 
                         unfollow_state, msg = unfollow_user(self.browser,
-                                                             "profile",
-                                                              self.username,
-                                                              person,
-                                                               None,
-                                                                None,
-                                                                 self.relationship_data,
-                                                                  self.logger,
-                                                                  self.logfolder)
+                                                            "profile",
+                                                            self.username,
+                                                            person,
+                                                            None,
+                                                            None,
+                                                            self.relationship_data,
+                                                            self.logger,
+                                                            self.logfolder)
                         if unfollow_state == True:
                             simulated_unfollow += 1
 
@@ -2430,8 +2454,9 @@ class InstaPy:
                 # Do interactions if any
                 do_interact = random.randint(0, 100) <= self.user_interact_percentage
 
-                if do_interact==False:
-                    self.logger.info("Skipping user '{}' due to the interaction percentage of {}".format(person, self.user_interact_percentage))
+                if do_interact == False:
+                    self.logger.info("Skipping user '{}' due to the interaction percentage of {}".format(person,
+                                                                                                         self.user_interact_percentage))
                     continue
 
                 else:
@@ -2439,18 +2464,18 @@ class InstaPy:
                     interacted_personal += 1
 
                     self.logger.info("Interaction [{}/{}]  |  Total Interaction: {}"
-                            .format(interacted_personal, len(person_list), interacted_all))
+                                     .format(interacted_personal, len(person_list), interacted_all))
 
                     with self.feature_in_feature("interact_by_users", False):
                         self.interact_by_users(person,
-                                                self.user_interact_amount,
-                                                 self.user_interact_random,
-                                                  self.user_interact_media)
+                                               self.user_interact_amount,
+                                               self.user_interact_random,
+                                               self.user_interact_media)
                     sleep(1)
 
         # final words
         self.logger.info("Finished interacting {} people from {} users' `Following`! xD\n"
-                            .format(interacted_all, len(usernames)))
+                         .format(interacted_all, len(usernames)))
 
         # find the feature-wide action sizes by taking a difference
         liked = (self.liked_img - liked_init)
@@ -2470,8 +2495,6 @@ class InstaPy:
         self.not_valid_users += not_valid_users
 
         return self
-
-
 
     def follow_user_followers(self,
                               usernames,
@@ -2491,7 +2514,7 @@ class InstaPy:
         followed_new = 0
         not_valid_users = 0
 
-        relax_point = random.randint(7, 14)   # you can use some plain value `10` instead of this quite randomized score
+        relax_point = random.randint(7, 14)  # you can use some plain value `10` instead of this quite randomized score
 
         # hold the current global values for differentiating at the end
         already_followed_init = self.already_followed
@@ -2506,21 +2529,21 @@ class InstaPy:
             if self.quotient_breach:
                 break
 
-            self.logger.info("User '{}' [{}/{}]".format((user), index+1, len(usernames)))
+            self.logger.info("User '{}' [{}/{}]".format((user), index + 1, len(usernames)))
 
             try:
                 person_list, simulated_list = get_given_user_followers(self.browser,
-                                                                        self.username,
-                                                                        user,
-                                                                        amount,
-                                                                        self.dont_include,
-                                                                        randomize,
-                                                                        self.blacklist,
-                                                                        self.follow_times,
-                                                                        self.simulation,
-                                                                        self.jumps,
-                                                                        self.logger,
-                                                                        self.logfolder)
+                                                                       self.username,
+                                                                       user,
+                                                                       amount,
+                                                                       self.dont_include,
+                                                                       randomize,
+                                                                       self.blacklist,
+                                                                       self.follow_times,
+                                                                       self.simulation,
+                                                                       self.jumps,
+                                                                       self.logger,
+                                                                       self.logfolder)
 
             except (TypeError, RuntimeWarning) as err:
 
@@ -2536,30 +2559,35 @@ class InstaPy:
                     return self
 
             print('')
-            self.logger.info("Grabbed {} usernames from '{}'s `Followers` to do following\n".format(len(person_list), user))
+            self.logger.info(
+                "Grabbed {} usernames from '{}'s `Followers` to do following\n".format(len(person_list), user))
 
             followed_personal = 0
             simulated_unfollow = 0
 
             for index, person in enumerate(person_list):
                 if self.quotient_breach:
-                    self.logger.warning("--> Follow quotient reached its peak!\t~leaving Follow-User-Followers activity\n")
+                    self.logger.warning(
+                        "--> Follow quotient reached its peak!\t~leaving Follow-User-Followers activity\n")
                     break
 
-                self.logger.info("Ongoing Follow [{}/{}]: now following '{}'...".format(index+1, len(person_list), person))
+                self.logger.info(
+                    "Ongoing Follow [{}/{}]: now following '{}'...".format(index + 1, len(person_list), person))
 
                 validation, details = validate_username(self.browser,
-                                                         person,
-                                                         self.username,
-                                                          self.ignore_users,
-                                                          self.blacklist,
-                                                           self.potency_ratio,
-                                                           self.delimit_by_numbers,
-                                                            self.max_followers,
-                                                            self.max_following,
-                                                            self.min_followers,
-                                                            self.min_following,
-                                                             self.logger)
+                                                        person,
+                                                        self.username,
+                                                        self.ignore_users,
+                                                        self.blacklist,
+                                                        self.potency_ratio,
+                                                        self.delimit_by_numbers,
+                                                        self.max_followers,
+                                                        self.max_following,
+                                                        self.min_followers,
+                                                        self.min_following,
+                                                        self.min_posts,
+                                                        self.max_posts,
+                                                        self.logger)
                 if validation != True:
                     self.logger.info(details)
                     not_valid_users += 1
@@ -2567,17 +2595,17 @@ class InstaPy:
                     if person in simulated_list:
                         self.logger.warning("--> Simulated Unfollow {}:"
                                             " unfollowing '{}' due to mismatching validation...\n"
-                                                .format(simulated_unfollow+1, person))
+                                            .format(simulated_unfollow + 1, person))
 
                         unfollow_state, msg = unfollow_user(self.browser,
-                                                             "profile",
-                                                              self.username,
-                                                              person,
-                                                               None,
-                                                                None,
-                                                                 self.relationship_data,
-                                                                  self.logger,
-                                                                  self.logfolder)
+                                                            "profile",
+                                                            self.username,
+                                                            person,
+                                                            None,
+                                                            None,
+                                                            self.relationship_data,
+                                                            self.logger,
+                                                            self.logfolder)
                         if unfollow_state == True:
                             simulated_unfollow += 1
 
@@ -2586,9 +2614,9 @@ class InstaPy:
                 # go ahead and follow, then interact (if any)
                 with self.feature_in_feature("follow_by_list", False):
                     followed = self.follow_by_list(person,
-                                                    self.follow_times,
-                                                     sleep_delay,
-                                                      interact)
+                                                   self.follow_times,
+                                                   sleep_delay,
+                                                   interact)
                 sleep(1)
 
                 if followed > 0:
@@ -2600,21 +2628,24 @@ class InstaPy:
 
                 # take a break after a good following
                 if followed_new >= relax_point:
-                    delay_random = random.randint(ceil(sleep_delay*0.85), ceil(sleep_delay*1.14))
+                    delay_random = random.randint(ceil(sleep_delay * 0.85), ceil(sleep_delay * 1.14))
                     self.logger.info("------=>  Followed {} new users ~sleeping about {}\n".format(followed_new,
-                                                                '{} seconds'.format(delay_random) if delay_random < 60 else
-                                                                '{} minutes'.format(float("{0:.2f}".format(delay_random/60)))))
+                                                                                                   '{} seconds'.format(
+                                                                                                       delay_random) if delay_random < 60 else
+                                                                                                   '{} minutes'.format(
+                                                                                                       float(
+                                                                                                           "{0:.2f}".format(
+                                                                                                               delay_random / 60)))))
                     sleep(delay_random)
                     relax_point = random.randint(7, 14)
-                    followed_new=0
+                    followed_new = 0
 
         # final words
         self.logger.info("Finished following {} users' `Followers`! xD\n".format(len(usernames)))
 
-
         # find the feature-wide action sizes by taking a difference
         already_followed = (self.already_followed - already_followed_init)
-        inap_img = (self.inap_img- inap_img_init)
+        inap_img = (self.inap_img - inap_img_init)
         liked = (self.liked_img - liked_init)
         already_liked = (self.already_liked - already_liked_init)
         commented = (self.commented - commented_init)
@@ -2635,8 +2666,6 @@ class InstaPy:
         self.not_valid_users += not_valid_users
 
         return self
-
-
 
     def follow_user_following(self,
                               usernames,
@@ -2664,28 +2693,28 @@ class InstaPy:
         commented_init = self.commented
         inap_img_init = self.inap_img
 
-        relax_point = random.randint(7, 14)   # you can use some plain value `10` instead of this quite randomized score
+        relax_point = random.randint(7, 14)  # you can use some plain value `10` instead of this quite randomized score
         self.quotient_breach = False
 
         for index, user in enumerate(usernames):
             if self.quotient_breach:
                 break
 
-            self.logger.info("User '{}' [{}/{}]".format((user), index+1, len(usernames)))
+            self.logger.info("User '{}' [{}/{}]".format((user), index + 1, len(usernames)))
 
             try:
                 person_list, simulated_list = get_given_user_following(self.browser,
-                                                                        self.username,
-                                                                        user,
-                                                                        amount,
-                                                                        self.dont_include,
-                                                                        randomize,
-                                                                        self.blacklist,
-                                                                        self.follow_times,
-                                                                        self.simulation,
-                                                                        self.jumps,
-                                                                        self.logger,
-                                                                        self.logfolder)
+                                                                       self.username,
+                                                                       user,
+                                                                       amount,
+                                                                       self.dont_include,
+                                                                       randomize,
+                                                                       self.blacklist,
+                                                                       self.follow_times,
+                                                                       self.simulation,
+                                                                       self.jumps,
+                                                                       self.logger,
+                                                                       self.logfolder)
 
             except (TypeError, RuntimeWarning) as err:
 
@@ -2701,30 +2730,35 @@ class InstaPy:
                     return self
 
             print('')
-            self.logger.info("Grabbed {} usernames from '{}'s `Following` to do following\n".format(len(person_list), user))
+            self.logger.info(
+                "Grabbed {} usernames from '{}'s `Following` to do following\n".format(len(person_list), user))
 
             followed_personal = 0
             simulated_unfollow = 0
 
             for index, person in enumerate(person_list):
                 if self.quotient_breach:
-                    self.logger.warning("--> Follow quotient reached its peak!\t~leaving Follow-User-Following activity\n")
+                    self.logger.warning(
+                        "--> Follow quotient reached its peak!\t~leaving Follow-User-Following activity\n")
                     break
 
-                self.logger.info("Ongoing Follow [{}/{}]: now following '{}'...".format(index+1, len(person_list), person))
+                self.logger.info(
+                    "Ongoing Follow [{}/{}]: now following '{}'...".format(index + 1, len(person_list), person))
 
                 validation, details = validate_username(self.browser,
-                                                         person,
-                                                         self.username,
-                                                          self.ignore_users,
-                                                          self.blacklist,
-                                                           self.potency_ratio,
-                                                           self.delimit_by_numbers,
-                                                            self.max_followers,
-                                                            self.max_following,
-                                                            self.min_followers,
-                                                            self.min_following,
-                                                             self.logger)
+                                                        person,
+                                                        self.username,
+                                                        self.ignore_users,
+                                                        self.blacklist,
+                                                        self.potency_ratio,
+                                                        self.delimit_by_numbers,
+                                                        self.max_followers,
+                                                        self.max_following,
+                                                        self.min_followers,
+                                                        self.min_following,
+                                                        self.min_posts,
+                                                        self.max_posts,
+                                                        self.logger)
                 if validation != True:
                     self.logger.info(details)
                     not_valid_users += 1
@@ -2732,17 +2766,17 @@ class InstaPy:
                     if person in simulated_list:
                         self.logger.warning("--> Simulated Unfollow {}:"
                                             " unfollowing '{}' due to mismatching validation...\n"
-                                                .format(simulated_unfollow+1, person))
+                                            .format(simulated_unfollow + 1, person))
 
                         unfollow_state, msg = unfollow_user(self.browser,
-                                                             "profile",
-                                                              self.username,
-                                                              person,
-                                                               None,
-                                                                None,
-                                                                 self.relationship_data,
-                                                                  self.logger,
-                                                                  self.logfolder)
+                                                            "profile",
+                                                            self.username,
+                                                            person,
+                                                            None,
+                                                            None,
+                                                            self.relationship_data,
+                                                            self.logger,
+                                                            self.logfolder)
                         if unfollow_state == True:
                             simulated_unfollow += 1
 
@@ -2751,9 +2785,9 @@ class InstaPy:
                 # go ahead and follow, then interact (if any)
                 with self.feature_in_feature("follow_by_list", False):
                     followed = self.follow_by_list(person,
-                                                    self.follow_times,
-                                                     sleep_delay,
-                                                      interact)
+                                                   self.follow_times,
+                                                   sleep_delay,
+                                                   interact)
                 sleep(1)
 
                 if followed > 0:
@@ -2765,21 +2799,24 @@ class InstaPy:
 
                 # take a break after a good following
                 if followed_new >= relax_point:
-                    delay_random = random.randint(ceil(sleep_delay*0.85), ceil(sleep_delay*1.14))
+                    delay_random = random.randint(ceil(sleep_delay * 0.85), ceil(sleep_delay * 1.14))
                     self.logger.info("------=>  Followed {} new users ~sleeping about {}\n".format(followed_new,
-                                                                '{} seconds'.format(delay_random) if delay_random < 60 else
-                                                                '{} minutes'.format(float("{0:.2f}".format(delay_random/60)))))
+                                                                                                   '{} seconds'.format(
+                                                                                                       delay_random) if delay_random < 60 else
+                                                                                                   '{} minutes'.format(
+                                                                                                       float(
+                                                                                                           "{0:.2f}".format(
+                                                                                                               delay_random / 60)))))
                     sleep(delay_random)
                     relax_point = random.randint(7, 14)
-                    followed_new=0
-
+                    followed_new = 0
 
         # final words
         self.logger.info("Finished following {} users' `Following`! xD\n".format(len(usernames)))
 
         # find the feature-wide action sizes by taking a difference
         already_followed = (self.already_followed - already_followed_init)
-        inap_img = (self.inap_img- inap_img_init)
+        inap_img = (self.inap_img - inap_img_init)
         liked = (self.liked_img - liked_init)
         already_liked = (self.already_liked - already_liked_init)
         commented = (self.commented - commented_init)
@@ -2800,8 +2837,6 @@ class InstaPy:
         self.not_valid_users += not_valid_users
 
         return self
-
-
 
     def unfollow_users(self,
                        amount=10,
@@ -2832,21 +2867,21 @@ class InstaPy:
 
         try:
             unfollowed = unfollow(self.browser,
-                                      self.username,
-                                      amount,
-                                      customList,
-                                      InstapyFollowed,
-                                      nonFollowers,
-                                      allFollowing,
-                                      style,
-                                      self.automatedFollowedPool,
-                                      self.relationship_data,
-                                      self.dont_include,
-                                      self.white_list,
-                                      sleep_delay,
-                                      self.jumps,
-                                      self.logger,
-                                      self.logfolder)
+                                  self.username,
+                                  amount,
+                                  customList,
+                                  InstapyFollowed,
+                                  nonFollowers,
+                                  allFollowing,
+                                  style,
+                                  self.automatedFollowedPool,
+                                  self.relationship_data,
+                                  self.dont_include,
+                                  self.white_list,
+                                  sleep_delay,
+                                  self.jumps,
+                                  self.logger,
+                                  self.logfolder)
             self.logger.info(
                 "--> Total people unfollowed : {}\n".format(unfollowed))
             self.unfollowed += unfollowed
@@ -2863,8 +2898,6 @@ class InstaPy:
 
         return self
 
-
-
     def like_by_feed(self, **kwargs):
         """Like the users feed"""
         for i in self.like_by_feed_generator(**kwargs):
@@ -2872,13 +2905,11 @@ class InstaPy:
 
         return self
 
-
-
     def like_by_feed_generator(self,
-                                amount=50,
-                                 randomize=False,
-                                  unfollow=False,
-                                   interact=False):
+                               amount=50,
+                               randomize=False,
+                               unfollow=False,
+                               interact=False):
         """Like the users feed"""
 
         if self.aborting:
@@ -2964,22 +2995,25 @@ class InstaPy:
                             )
 
                             if not inappropriate and self.delimit_liking:
-                                self.liking_approved = verify_liking(self.browser, self.max_likes, self.min_likes, self.logger)
+                                self.liking_approved = verify_liking(self.browser, self.max_likes, self.min_likes,
+                                                                     self.logger)
 
                             if not inappropriate and self.liking_approved:
-                                #validate user
+                                # validate user
                                 validation, details = validate_username(self.browser,
-                                                               user_name,
-                                                               self.username,
-                                                               self.ignore_users,
-                                                               self.blacklist,
-                                                               self.potency_ratio,
-                                                               self.delimit_by_numbers,
-                                                               self.max_followers,
-                                                               self.max_following,
-                                                               self.min_followers,
-                                                               self.min_following,
-                                                               self.logger)
+                                                                        user_name,
+                                                                        self.username,
+                                                                        self.ignore_users,
+                                                                        self.blacklist,
+                                                                        self.potency_ratio,
+                                                                        self.delimit_by_numbers,
+                                                                        self.max_followers,
+                                                                        self.max_following,
+                                                                        self.min_followers,
+                                                                        self.min_following,
+                                                                        self.min_posts,
+                                                                        self.max_posts,
+                                                                        self.logger)
                                 if validation != True:
                                     self.logger.info(details)
                                     not_valid_users += 1
@@ -2987,12 +3021,12 @@ class InstaPy:
                                 else:
                                     web_address_navigator(self.browser, link)
 
-                                #try to like
+                                # try to like
                                 like_state, msg = like_image(self.browser,
-                                                   user_name,
-                                                   self.blacklist,
-                                                   self.logger,
-                                                   self.logfolder)
+                                                             user_name,
+                                                             self.blacklist,
+                                                             self.logger,
+                                                             self.logfolder)
 
                                 if like_state == True:
                                     liked_img += 1
@@ -3026,7 +3060,7 @@ class InstaPy:
 
                                     # commenting
                                     if (self.do_comment and
-                                        user_name not in self.dont_include and
+                                            user_name not in self.dont_include and
                                             checked_img and
                                             commenting):
                                         if self.delimit_commenting:
@@ -3035,7 +3069,7 @@ class InstaPy:
                                                                                      self.max_comments,
                                                                                      self.min_comments,
                                                                                      self.comments_mandatory_words,
-                                                                                      self.logger)
+                                                                                     self.logger)
 
                                         if self.commenting_approved:
                                             if temp_comments:
@@ -3044,19 +3078,19 @@ class InstaPy:
                                                 comments = temp_comments
                                             elif is_video:
                                                 comments = (
-                                                    self.comments +
-                                                    self.video_comments)
+                                                        self.comments +
+                                                        self.video_comments)
                                             else:
                                                 comments = (
-                                                    self.comments +
-                                                    self.photo_comments)
+                                                        self.comments +
+                                                        self.photo_comments)
                                             comment_state, msg = comment_image(
-                                                                    self.browser,
-                                                                    user_name,
-                                                                    comments,
-                                                                    self.blacklist,
-                                                                    self.logger,
-                                                                    self.logfolder)
+                                                self.browser,
+                                                user_name,
+                                                comments,
+                                                self.blacklist,
+                                                self.logger,
+                                                self.logfolder)
                                             if comment_state == True:
                                                 commented += 1
 
@@ -3069,20 +3103,20 @@ class InstaPy:
 
                                     # following
                                     if (self.do_follow and
-                                        user_name not in self.dont_include and
-                                        checked_img and
-                                        following and
-                                        not follow_restriction("read", user_name,
-                                         self.follow_times, self.logger)):
+                                            user_name not in self.dont_include and
+                                            checked_img and
+                                            following and
+                                            not follow_restriction("read", user_name,
+                                                                   self.follow_times, self.logger)):
                                         follow_state, msg = follow_user(
-                                                                self.browser,
-                                                                "post",
-                                                                self.username,
-                                                                user_name,
-                                                                None,
-                                                                self.blacklist,
-                                                                self.logger,
-                                                                self.logfolder)
+                                            self.browser,
+                                            "post",
+                                            self.username,
+                                            user_name,
+                                            None,
+                                            self.blacklist,
+                                            self.logger,
+                                            self.logfolder)
                                         if follow_state == True:
                                             followed += 1
                                     else:
@@ -3092,13 +3126,13 @@ class InstaPy:
                                     # interactions (if any)
                                     if interact:
                                         self.logger.info(
-                                              "--> User gonna be interacted: '{}'"
-                                               .format(user_name))
+                                            "--> User gonna be interacted: '{}'"
+                                                .format(user_name))
 
                                         self.like_by_users(user_name,
-                                                            self.user_interact_amount,
-                                                            self.user_interact_random,
-                                                            self.user_interact_media)
+                                                           self.user_interact_amount,
+                                                           self.user_interact_random,
+                                                           self.user_interact_media)
 
                                     yield self
 
@@ -3112,23 +3146,23 @@ class InstaPy:
                             elif inappropriate:
                                 inap_img += 1
                                 self.logger.info("--> Image not liked: {}"
-                                                    .format(reason.encode('utf-8')))
+                                                 .format(reason.encode('utf-8')))
 
                                 if "Inappropriate" in reason and unfollow:
                                     # example of unfollowing directly from a post page (faster)
                                     self.logger.warning("--> Ongoing Unfollow {}:"
                                                         " unfollowing '{}' due to inappropriate content..."
-                                                            .format(inap_unfollow+1, user_name))
+                                                        .format(inap_unfollow + 1, user_name))
 
                                     unfollow_state, msg = unfollow_user(self.browser,
-                                                                         "post",
-                                                                          self.username,
-                                                                          user_name,
-                                                                           None,
-                                                                            None,
-                                                                             self.relationship_data,
-                                                                              self.logger,
-                                                                               self.logfolder)
+                                                                        "post",
+                                                                        self.username,
+                                                                        user_name,
+                                                                        None,
+                                                                        None,
+                                                                        self.relationship_data,
+                                                                        self.logger,
+                                                                        self.logfolder)
                                     if unfollow_state == True:
                                         inap_unfollow += 1
 
@@ -3189,7 +3223,6 @@ class InstaPy:
         except:
             self.logger.info('Campaign {} first run'.format(campaign))
 
-
     def grab_followers(self, username=None, amount=None, live_match=False, store_locally=True):
         """ Gets and returns `followers` information of given user in desired amount, also, saves locally """
 
@@ -3197,7 +3230,8 @@ class InstaPy:
         highlight_print(self.username, message, "feature", "info", self.logger)
 
         if username is None:
-            self.logger.warning("Please provide a username to grab `Followers` data  ~e.g. your own username or somebody else's")
+            self.logger.warning(
+                "Please provide a username to grab `Followers` data  ~e.g. your own username or somebody else's")
             return self
         elif amount is None:
             self.logger.warning("Please put amount to grab `Followers` data")
@@ -3206,7 +3240,7 @@ class InstaPy:
             self.logger.info("Please provide a valid amount bigger than zero (0) to grab `Followers` data")
             return self
 
-        #Get `followers` data
+        # Get `followers` data
         grabbed_followers = get_followers(self.browser,
                                           username,
                                           amount,
@@ -3217,7 +3251,6 @@ class InstaPy:
                                           self.logfolder)
         return grabbed_followers
 
-
     def grab_following(self, username=None, amount=None, live_match=False, store_locally=True):
         """ Gets and returns `following` information of given user in desired amount, also, saves locally """
 
@@ -3225,7 +3258,8 @@ class InstaPy:
         highlight_print(self.username, message, "feature", "info", self.logger)
 
         if username is None:
-            self.logger.warning("Please provide a username to grab `Following` data  ~e.g. your own username or somebody else's")
+            self.logger.warning(
+                "Please provide a username to grab `Following` data  ~e.g. your own username or somebody else's")
             return self
         elif amount is None:
             self.logger.warning("Please put amount to grab `Following` data")
@@ -3234,7 +3268,7 @@ class InstaPy:
             self.logger.info("Please provide a valid amount bigger than zero (0) to grab `Following` data")
             return self
 
-        #Get `following` data
+        # Get `following` data
         grabbed_following = get_following(self.browser,
                                           username,
                                           amount,
@@ -3245,28 +3279,27 @@ class InstaPy:
                                           self.logfolder)
         return grabbed_following
 
-
-    def pick_unfollowers(self, username=None, compare_by="latest", compare_track="first", live_match=False, store_locally=True, print_out=True):
+    def pick_unfollowers(self, username=None, compare_by="latest", compare_track="first", live_match=False,
+                         store_locally=True, print_out=True):
         """ Compares the `followers` stored in a latest local copy against
         either lively generated data or previous local copy and returns absent followers """
 
         message = "Starting to pick Unfollowers of {}..".format(username)
         highlight_print(self.username, message, "feature", "info", self.logger)
 
-        #get all and active Unfollowers
+        # get all and active Unfollowers
         all_unfollowers, active_unfollowers = get_unfollowers(self.browser,
-                                                               username,
-                                                                compare_by,
-                                                                 compare_track,
-                                                                  self.relationship_data,
-                                                                   live_match,
-                                                                    store_locally,
-                                                                     print_out,
-                                                                      self.logger,
-                                                                       self.logfolder)
+                                                              username,
+                                                              compare_by,
+                                                              compare_track,
+                                                              self.relationship_data,
+                                                              live_match,
+                                                              store_locally,
+                                                              print_out,
+                                                              self.logger,
+                                                              self.logfolder)
 
         return all_unfollowers, active_unfollowers
-
 
     def pick_nonfollowers(self, username=None, live_match=False, store_locally=True):
         """ Returns Nonfollowers data of a given user """
@@ -3274,19 +3307,16 @@ class InstaPy:
         message = "Starting to pick Nonfollowers of {}..".format(username)
         highlight_print(self.username, message, "feature", "info", self.logger)
 
-        #get Nonfollowers
+        # get Nonfollowers
         nonfollowers = get_nonfollowers(self.browser,
-                                         username,
-                                          self.relationship_data,
-                                           live_match,
-                                            store_locally,
-                                             self.logger,
-                                              self.logfolder)
+                                        username,
+                                        self.relationship_data,
+                                        live_match,
+                                        store_locally,
+                                        self.logger,
+                                        self.logfolder)
 
         return nonfollowers
-
-
-
 
     def pick_fans(self, username=None, live_match=False, store_locally=True):
         """ Returns Fans data- all of the usernames who do follow
@@ -3295,17 +3325,16 @@ class InstaPy:
         message = "Starting to pick Fans of {}..".format(username)
         highlight_print(self.username, message, "feature", "info", self.logger)
 
-        #get Fans
+        # get Fans
         fans = get_fans(self.browser,
-                         username,
-                          self.relationship_data,
-                           live_match,
-                            store_locally,
-                             self.logger,
-                              self.logfolder)
+                        username,
+                        self.relationship_data,
+                        live_match,
+                        store_locally,
+                        self.logger,
+                        self.logfolder)
 
         return fans
-
 
     def pick_mutual_following(self, username=None, live_match=False, store_locally=True):
         """ Returns Mutual Following data- all of the usernames who do follow
@@ -3314,17 +3343,16 @@ class InstaPy:
         message = "Starting to pick Mutual Following of {}..".format(username)
         highlight_print(self.username, message, "feature", "info", self.logger)
 
-        #get Mutual Following
+        # get Mutual Following
         mutual_following = get_mutual_following(self.browser,
-                                                 username,
-                                                  self.relationship_data,
-                                                   live_match,
-                                                    store_locally,
-                                                     self.logger,
-                                                      self.logfolder)
+                                                username,
+                                                self.relationship_data,
+                                                live_match,
+                                                store_locally,
+                                                self.logger,
+                                                self.logfolder)
 
         return mutual_following
-
 
     def end(self):
         """Closes the current session"""
@@ -3335,7 +3363,7 @@ class InstaPy:
             except Exception as exc:
                 if isinstance(exc, WebDriverException):
                     self.logger.exception("Error occured while deleting cookies from web browser!\n\t{}"
-                                            .format(str(exc).encode("utf-8")))
+                                          .format(str(exc).encode("utf-8")))
 
             # close web browser
             try:
@@ -3343,7 +3371,7 @@ class InstaPy:
             except Exception as exc:
                 if isinstance(exc, WebDriverException):
                     self.logger.exception("Error occured while closing web browser!\n\t{}"
-                                            .format(str(exc).encode("utf-8")))
+                                          .format(str(exc).encode("utf-8")))
 
             # close virtual display
             if self.nogui:
@@ -3363,15 +3391,13 @@ class InstaPy:
             highlight_print(self.username, message, "end", "info", self.logger)
             print("\n\n")
 
-
-
     def follow_by_tags(self,
-                     tags=None,
-                     amount=50,
-                     skip_top_posts=True,
-                     use_smart_hashtags=False,
-                     randomize=False,
-                     media=None):
+                       tags=None,
+                       amount=50,
+                       skip_top_posts=True,
+                       use_smart_hashtags=False,
+                       randomize=False,
+                       media=None):
         if self.aborting:
             return self
 
@@ -3430,19 +3456,21 @@ class InstaPy:
                     )
 
                     if not inappropriate:
-                        #validate user
+                        # validate user
                         validation, details = validate_username(self.browser,
-                                                       user_name,
-                                                       self.username,
-                                                       self.ignore_users,
-                                                       self.blacklist,
-                                                       self.potency_ratio,
-                                                       self.delimit_by_numbers,
-                                                       self.max_followers,
-                                                       self.max_following,
-                                                       self.min_followers,
-                                                       self.min_following,
-                                                       self.logger)
+                                                                user_name,
+                                                                self.username,
+                                                                self.ignore_users,
+                                                                self.blacklist,
+                                                                self.potency_ratio,
+                                                                self.delimit_by_numbers,
+                                                                self.max_followers,
+                                                                self.max_following,
+                                                                self.min_followers,
+                                                                self.min_following,
+                                                                self.min_posts,
+                                                                self.max_posts,
+                                                                self.logger)
                         if validation != True:
                             self.logger.info(details)
                             not_valid_users += 1
@@ -3450,15 +3478,15 @@ class InstaPy:
                         else:
                             web_address_navigator(self.browser, link)
 
-                        #try to follow
+                        # try to follow
                         follow_state, msg = follow_user(self.browser,
-                                                "post",
-                                                self.username,
-                                                user_name,
-                                                None,
-                                                self.blacklist,
-                                                self.logger,
-                                                self.logfolder)
+                                                        "post",
+                                                        self.username,
+                                                        user_name,
+                                                        None,
+                                                        self.blacklist,
+                                                        self.logger,
+                                                        self.logfolder)
                         if follow_state == True:
                             followed += 1
                             # reset jump counter after a successful follow
@@ -3486,12 +3514,10 @@ class InstaPy:
 
         return self
 
-
-
     def interact_by_URL(self,
-                         urls=[],
-                          randomize=False,
-                           interact=False):
+                        urls=[],
+                        randomize=False,
+                        interact=False):
         """ Interact on posts at given URLs """
 
         if self.aborting:
@@ -3522,7 +3548,7 @@ class InstaPy:
                 break
 
             if "https://www.instagram.com/p/" not in url:
-                url = "https://www.instagram.com/p/"+url
+                url = "https://www.instagram.com/p/" + url
 
             self.logger.info('URL [{}/{}]'.format(index + 1, len(urls)))
             self.logger.info('--> {}'.format(url.encode('utf-8')))
@@ -3540,19 +3566,21 @@ class InstaPy:
                     self.liking_approved = verify_liking(self.browser, self.max_likes, self.min_likes, self.logger)
 
                 if not inappropriate and self.liking_approved:
-                    #validate user
+                    # validate user
                     validation, details = validate_username(self.browser,
-                                                   user_name,
-                                                   self.username,
-                                                   self.ignore_users,
-                                                   self.blacklist,
-                                                   self.potency_ratio,
-                                                   self.delimit_by_numbers,
-                                                   self.max_followers,
-                                                   self.max_following,
-                                                   self.min_followers,
-                                                   self.min_following,
-                                                   self.logger)
+                                                            user_name,
+                                                            self.username,
+                                                            self.ignore_users,
+                                                            self.blacklist,
+                                                            self.potency_ratio,
+                                                            self.delimit_by_numbers,
+                                                            self.max_followers,
+                                                            self.max_following,
+                                                            self.min_followers,
+                                                            self.min_following,
+                                                            self.min_posts,
+                                                            self.max_posts,
+                                                            self.logger)
                     if validation != True:
                         self.logger.info(details)
                         not_valid_users += 1
@@ -3560,12 +3588,12 @@ class InstaPy:
                     else:
                         web_address_navigator(self.browser, url)
 
-                    #try to like
+                    # try to like
                     like_state, msg = like_image(self.browser,
-                                       user_name,
-                                       self.blacklist,
-                                       self.logger,
-                                       self.logfolder)
+                                                 user_name,
+                                                 self.blacklist,
+                                                 self.logger,
+                                                 self.logfolder)
 
                     if like_state == True:
                         liked_img += 1
@@ -3593,10 +3621,9 @@ class InstaPy:
                                 self.logger.error(
                                     'Image check error: {}'.format(err))
 
-
                         if (self.do_comment and
-                            user_name not in self.dont_include and
-                            checked_img and
+                                user_name not in self.dont_include and
+                                checked_img and
                                 commenting):
 
                             if self.delimit_commenting:
@@ -3605,7 +3632,7 @@ class InstaPy:
                                                                          self.max_comments,
                                                                          self.min_comments,
                                                                          self.comments_mandatory_words,
-                                                                          self.logger)
+                                                                         self.logger)
                             if self.commenting_approved:
                                 if temp_comments:
                                     # Use clarifai related comments only!
@@ -3617,11 +3644,11 @@ class InstaPy:
                                     comments = (self.comments +
                                                 self.photo_comments)
                                 comment_state, msg = comment_image(self.browser,
-                                                           user_name,
-                                                           comments,
-                                                           self.blacklist,
-                                                           self.logger,
-                                                           self.logfolder)
+                                                                   user_name,
+                                                                   comments,
+                                                                   self.blacklist,
+                                                                   self.logger,
+                                                                   self.logfolder)
                                 if comment_state == True:
                                     commented += 1
 
@@ -3633,20 +3660,20 @@ class InstaPy:
                             sleep(1)
 
                         if (self.do_follow and
-                            user_name not in self.dont_include and
-                            checked_img and
-                            following and
-                            not follow_restriction("read", user_name,
-                             self.follow_times, self.logger)):
+                                user_name not in self.dont_include and
+                                checked_img and
+                                following and
+                                not follow_restriction("read", user_name,
+                                                       self.follow_times, self.logger)):
 
                             follow_state, msg = follow_user(self.browser,
-                                                    "post",
-                                                    self.username,
-                                                    user_name,
-                                                    None,
-                                                    self.blacklist,
-                                                    self.logger,
-                                                    self.logfolder)
+                                                            "post",
+                                                            self.username,
+                                                            user_name,
+                                                            None,
+                                                            self.blacklist,
+                                                            self.logger,
+                                                            self.logfolder)
                             if follow_state == True:
                                 followed += 1
                         else:
@@ -3657,14 +3684,14 @@ class InstaPy:
                         if interact == True:
                             do_interact = random.randint(0, 100) <= self.user_interact_percentage
                             # Do interactions if any
-                            if do_interact and self.user_interact_amount>0:
+                            if do_interact and self.user_interact_amount > 0:
                                 self.logger.info(
-                                        '--> Starting to interact {}..'
-                                            .format(user_name))
+                                    '--> Starting to interact {}..'
+                                        .format(user_name))
                                 self.interact_by_users(user_name,
-                                                        self.user_interact_amount,
-                                                         self.user_interact_random,
-                                                          self.user_interact_media)
+                                                       self.user_interact_amount,
+                                                       self.user_interact_random,
+                                                       self.user_interact_media)
 
                     elif msg == "already liked":
                         already_liked += 1
@@ -3697,14 +3724,13 @@ class InstaPy:
 
         return self
 
-
-
-    def set_quota_supervisor(self, enabled=False, sleep_after=[], sleepyhead=False, stochastic_flow=False, notify_me=False,
-                              peak_likes=(None, None),
-                               peak_comments=(None, None),
-                                peak_follows=(None, None),
-                                 peak_unfollows=(None, None),
-                                  peak_server_calls=(None, None)):
+    def set_quota_supervisor(self, enabled=False, sleep_after=[], sleepyhead=False, stochastic_flow=False,
+                             notify_me=False,
+                             peak_likes=(None, None),
+                             peak_comments=(None, None),
+                             peak_follows=(None, None),
+                             peak_unfollows=(None, None),
+                             peak_server_calls=(None, None)):
         """ Sets aside QS configuration ANY time in a session """
         # take a reference of the global configuration
         configuration = Settings.QS_config
@@ -3724,36 +3750,36 @@ class InstaPy:
         # set QS if peak values are eligible
         if (peaks_are_tuple and
                 peaks_are_provided and
-                    peaks_are_valid and
-                        peaks_are_good):
+                peaks_are_valid and
+                peaks_are_good):
 
-            peaks = {"likes":{"hourly":peak_likes[0], "daily":peak_likes[1]},
-                     "comments":{"hourly":peak_comments[0], "daily":peak_comments[1]},
-                     "follows":{"hourly":peak_follows[0], "daily":peak_follows[1]},
-                     "unfollows":{"hourly":peak_unfollows[0], "daily":peak_unfollows[1]},
-                     "server_calls":{"hourly":peak_server_calls[0], "daily":peak_server_calls[1]}}
+            peaks = {"likes": {"hourly": peak_likes[0], "daily": peak_likes[1]},
+                     "comments": {"hourly": peak_comments[0], "daily": peak_comments[1]},
+                     "follows": {"hourly": peak_follows[0], "daily": peak_follows[1]},
+                     "unfollows": {"hourly": peak_unfollows[0], "daily": peak_unfollows[1]},
+                     "server_calls": {"hourly": peak_server_calls[0], "daily": peak_server_calls[1]}}
 
             if not isinstance(sleep_after, list):
                 sleep_after = [sleep_after]
 
             rt = time.time()
-            latesttime = {"hourly":rt, "daily":rt}
-            orig_peaks = deepcopy(peaks)   # original peaks always remain static
-            stochasticity = {"enabled":stochastic_flow,
-                              "latesttime":latesttime,
-                               "original_peaks":orig_peaks}
+            latesttime = {"hourly": rt, "daily": rt}
+            orig_peaks = deepcopy(peaks)  # original peaks always remain static
+            stochasticity = {"enabled": stochastic_flow,
+                             "latesttime": latesttime,
+                             "original_peaks": orig_peaks}
 
             if (platform.startswith("win32") and
                     python_version().startswith(('2', '3.7'))):
-                notify_me = False   # remove this block once plyer>1.3.0 is released to PyPI
+                notify_me = False  # remove this block once plyer>1.3.0 is released to PyPI
 
             # update QS configuration with the fresh settings
-            configuration.update({"state":enabled,
-                                   "sleep_after":sleep_after,
-                                    "sleepyhead":sleepyhead,
-                                     "stochasticity":stochasticity,
-                                      "notify":notify_me,
-                                       "peaks":peaks})
+            configuration.update({"state": enabled,
+                                  "sleep_after": sleep_after,
+                                  "sleepyhead": sleepyhead,
+                                  "stochasticity": stochasticity,
+                                  "notify": notify_me,
+                                  "peaks": peaks})
 
         else:
             # turn off QS for the rest of the session since peak values are ineligible
@@ -3762,24 +3788,20 @@ class InstaPy:
             # user should be warned only if has had QS turned on
             if enabled == True:
                 self.logger.warning("Quota Supervisor: peak rates are misfit! "
-                                  "Please use supported formats."
-                                   "\t~disabled QS")
-
-
+                                    "Please use supported formats."
+                                    "\t~disabled QS")
 
     @contextmanager
     def feature_in_feature(self, feature, validate_users):
         """ USE once a host feature calls a guest feature WHERE guest needs special behaviour(s) """
         try:
             # add the guest which is gonna be used by the host :)
-            self.internal_usage[feature] = {"validate":validate_users}
+            self.internal_usage[feature] = {"validate": validate_users}
             yield
 
         finally:
             # remove the guest just after using it
             self.internal_usage.pop(feature)
-
-
 
     def live_report(self):
         """ Report live sessional statistics """
@@ -3791,16 +3813,13 @@ class InstaPy:
                          "\t|> INAPPROPRIATE images: {}\n"
                          "\t|> NOT VALID users: {}\n"
                          "currently FOLLOWING {} users & has got {} FOLLOWERS\n"
-                            .format(self.liked_img,
-                                    self.already_liked,
-                                    self.commented,
-                                    self.followed,
-                                    self.already_followed,
-                                    self.unfollowed,
-                                    self.inap_img,
-                                    self.not_valid_users,
-                                    self.following_num,
-                                    self.followed_by))
-
-
-
+                         .format(self.liked_img,
+                                 self.already_liked,
+                                 self.commented,
+                                 self.followed,
+                                 self.already_followed,
+                                 self.unfollowed,
+                                 self.inap_img,
+                                 self.not_valid_users,
+                                 self.following_num,
+                                 self.followed_by))

--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -188,6 +188,11 @@ class InstaPy:
         self.comments_mandatory_words = []
         self.max_posts = None
         self.min_posts = None
+        self.skip_business_categories = []
+        self.dont_skip_business_categories = []
+        self.skip_business = False
+        self.skip_no_profile_pic = False
+        self.skip_private = True
 
         self.relationship_data = {username: {"all_following": [], "all_followers": []}}
 
@@ -867,6 +872,11 @@ class InstaPy:
                                                         self.min_following,
                                                         self.min_posts,
                                                         self.max_posts,
+                                                        self.skip_private,
+                                                        self.skip_no_profile_pic,
+                                                        self.skip_business,
+                                                        self.skip_business_categories,
+                                                        self.dont_skip_business_categories,
                                                         self.logger)
                 if validation != True or acc_to_follow == self.username:
                     self.logger.info("--> Not a valid user: {}\n".format(details))
@@ -980,6 +990,27 @@ class InstaPy:
         self.min_posts = min_posts
         self.max_posts = max_posts
 
+    def set_skip_users(self,
+                       skip_private=True,
+                       skip_no_profile_pic=False,
+                       skip_business=False,
+                       skip_business_categories=[],
+                       dont_skip_business_categories=[]):
+
+        self.skip_business = skip_business
+        self.skip_private = skip_private
+        self.skip_no_profile_pic = skip_no_profile_pic
+        if skip_business:
+            self.skip_business_categories = skip_business_categories
+            if len(skip_business_categories) == 0:
+                self.dont_skip_business_categories = dont_skip_business_categories
+            else:
+                if len(dont_skip_business_categories) != 0:
+                    self.logger.warning("Both skip_business_categories and dont_skip_business categories provided in skip_business feature," +
+                                        "will skip only the categories listed in skip_business_categories parameter")
+                    #dont_skip_business_categories = [] Setted by default in init
+
+
     def set_delimit_liking(self,
                            enabled=None,
                            max=None,
@@ -1092,6 +1123,11 @@ class InstaPy:
                                                                 self.min_following,
                                                                 self.min_posts,
                                                                 self.max_posts,
+                                                                self.skip_private,
+                                                                self.skip_no_profile_pic,
+                                                                self.skip_business,
+                                                                self.skip_business_categories,
+                                                                self.dont_skip_business_categories,
                                                                 self.logger)
                         if validation != True:
                             self.logger.info("--> Not a valid user: {}".format(details))
@@ -1299,6 +1335,11 @@ class InstaPy:
                                                                 self.min_following,
                                                                 self.min_posts,
                                                                 self.max_posts,
+                                                                self.skip_private,
+                                                                self.skip_no_profile_pic,
+                                                                self.skip_business,
+                                                                self.skip_business_categories,
+                                                                self.dont_skip_business_categories,
                                                                 self.logger)
                         if validation != True:
                             self.logger.info(details)
@@ -1511,6 +1552,11 @@ class InstaPy:
                                                                 self.min_following,
                                                                 self.min_posts,
                                                                 self.max_posts,
+                                                                self.skip_private,
+                                                                self.skip_no_profile_pic,
+                                                                self.skip_business,
+                                                                self.skip_business_categories,
+                                                                self.dont_skip_business_categories,
                                                                 self.logger)
                         if validation != True:
                             self.logger.info(details)
@@ -1700,6 +1746,11 @@ class InstaPy:
                                                     self.min_following,
                                                     self.min_posts,
                                                     self.max_posts,
+                                                    self.skip_private,
+                                                    self.skip_no_profile_pic,
+                                                    self.skip_business,
+                                                    self.skip_business_categories,
+                                                    self.dont_skip_business_categories,
                                                     self.logger)
             if not validation:
                 self.logger.info("--> not a valid user: {}".format(details))
@@ -1933,6 +1984,11 @@ class InstaPy:
                                                         self.min_following,
                                                         self.min_posts,
                                                         self.max_posts,
+                                                        self.skip_private,
+                                                        self.skip_no_profile_pic,
+                                                        self.skip_business,
+                                                        self.skip_business_categories,
+                                                        self.dont_skip_business_categories,
                                                         self.logger)
                 if not validation:
                     self.logger.info("--> not a valid user: {}".format(details))
@@ -2270,6 +2326,11 @@ class InstaPy:
                                                         self.min_following,
                                                         self.min_posts,
                                                         self.max_posts,
+                                                        self.skip_private,
+                                                        self.skip_no_profile_pic,
+                                                        self.skip_business,
+                                                        self.skip_business_categories,
+                                                        self.dont_skip_business_categories,
                                                         self.logger)
                 if validation != True:
                     self.logger.info(details)
@@ -2427,6 +2488,11 @@ class InstaPy:
                                                         self.min_following,
                                                         self.min_posts,
                                                         self.max_posts,
+                                                        self.skip_private,
+                                                        self.skip_no_profile_pic,
+                                                        self.skip_business,
+                                                        self.skip_business_categories,
+                                                        self.dont_skip_business_categories,
                                                         self.logger)
                 if validation != True:
                     self.logger.info(details)
@@ -2587,6 +2653,11 @@ class InstaPy:
                                                         self.min_following,
                                                         self.min_posts,
                                                         self.max_posts,
+                                                        self.skip_private,
+                                                        self.skip_no_profile_pic,
+                                                        self.skip_business,
+                                                        self.skip_business_categories,
+                                                        self.dont_skip_business_categories,
                                                         self.logger)
                 if validation != True:
                     self.logger.info(details)
@@ -2758,6 +2829,11 @@ class InstaPy:
                                                         self.min_following,
                                                         self.min_posts,
                                                         self.max_posts,
+                                                        self.skip_private,
+                                                        self.skip_no_profile_pic,
+                                                        self.skip_business,
+                                                        self.skip_business_categories,
+                                                        self.dont_skip_business_categories,
                                                         self.logger)
                 if validation != True:
                     self.logger.info(details)
@@ -3013,6 +3089,11 @@ class InstaPy:
                                                                         self.min_following,
                                                                         self.min_posts,
                                                                         self.max_posts,
+                                                                        self.skip_private,
+                                                                        self.skip_no_profile_pic,
+                                                                        self.skip_business,
+                                                                        self.skip_business_categories,
+                                                                        self.dont_skip_business_categories,
                                                                         self.logger)
                                 if validation != True:
                                     self.logger.info(details)
@@ -3470,6 +3551,11 @@ class InstaPy:
                                                                 self.min_following,
                                                                 self.min_posts,
                                                                 self.max_posts,
+                                                                self.skip_private,
+                                                                self.skip_no_profile_pic,
+                                                                self.skip_business,
+                                                                self.skip_business_categories,
+                                                                self.dont_skip_business_categories,
                                                                 self.logger)
                         if validation != True:
                             self.logger.info(details)
@@ -3580,6 +3666,11 @@ class InstaPy:
                                                             self.min_following,
                                                             self.min_posts,
                                                             self.max_posts,
+                                                            self.skip_private,
+                                                            self.skip_no_profile_pic,
+                                                            self.skip_business,
+                                                            self.skip_business_categories,
+                                                            self.dont_skip_business_categories,
                                                             self.logger)
                     if validation != True:
                         self.logger.info(details)

--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -91,7 +91,6 @@ class InstaPy:
                  bypass_suspicious_attempt=False,
                  multi_logs=True):
 
-
         if nogui:
             self.display = Display(visible=0, size=(800, 600))
             self.display.start()
@@ -863,28 +862,7 @@ class InstaPy:
 
             if not users_validated:
                 # Verify if the user should be followed
-                validation, details = validate_username(self.browser,
-                                                        acc_to_follow,
-                                                        self.username,
-                                                        self.ignore_users,
-                                                        self.blacklist,
-                                                        self.potency_ratio,
-                                                        self.delimit_by_numbers,
-                                                        self.max_followers,
-                                                        self.max_following,
-                                                        self.min_followers,
-                                                        self.min_following,
-                                                        self.min_posts,
-                                                        self.max_posts,
-                                                        self.skip_private,
-                                                        self.skip_private_percentage,
-                                                        self.skip_no_profile_pic,
-                                                        self.skip_no_profile_pic_percentage,
-                                                        self.skip_business,
-                                                        self.skip_business_percentage,
-                                                        self.skip_business_categories,
-                                                        self.dont_skip_business_categories,
-                                                        self.logger)
+                validation, details = self.validate_user_call(acc_to_follow)
                 if validation != True or acc_to_follow == self.username:
                     self.logger.info("--> Not a valid user: {}\n".format(details))
                     not_valid_users += 1
@@ -997,6 +975,32 @@ class InstaPy:
         self.min_posts = min_posts
         self.max_posts = max_posts
 
+    def validate_user_call(self, user_name):
+        """Call the validate_username() function"""
+        validation, details = validate_username(self.browser,
+                                                user_name,
+                                                self.username,
+                                                self.ignore_users,
+                                                self.blacklist,
+                                                self.potency_ratio,
+                                                self.delimit_by_numbers,
+                                                self.max_followers,
+                                                self.max_following,
+                                                self.min_followers,
+                                                self.min_following,
+                                                self.min_posts,
+                                                self.max_posts,
+                                                self.skip_private,
+                                                self.skip_private_percentage,
+                                                self.skip_no_profile_pic,
+                                                self.skip_no_profile_pic_percentage,
+                                                self.skip_business,
+                                                self.skip_business_percentage,
+                                                self.skip_business_categories,
+                                                self.dont_skip_business_categories,
+                                                self.logger)
+        return validation, details
+
     def set_skip_users(self,
                        skip_private=True,
                        private_percentage=100,
@@ -1019,10 +1023,10 @@ class InstaPy:
                 self.dont_skip_business_categories = dont_skip_business_categories
             else:
                 if len(dont_skip_business_categories) != 0:
-                    self.logger.warning("Both skip_business_categories and dont_skip_business categories provided in skip_business feature," +
-                                        "will skip only the categories listed in skip_business_categories parameter")
-                    #dont_skip_business_categories = [] Setted by default in init
-
+                    self.logger.warning(
+                        "Both skip_business_categories and dont_skip_business categories provided in skip_business feature," +
+                        "will skip only the categories listed in skip_business_categories parameter")
+                    # dont_skip_business_categories = [] Setted by default in init
 
     def set_delimit_liking(self,
                            enabled=None,
@@ -1123,28 +1127,7 @@ class InstaPy:
 
                     if not inappropriate and self.liking_approved:
                         # validate user
-                        validation, details = validate_username(self.browser,
-                                                                user_name,
-                                                                self.username,
-                                                                self.ignore_users,
-                                                                self.blacklist,
-                                                                self.potency_ratio,
-                                                                self.delimit_by_numbers,
-                                                                self.max_followers,
-                                                                self.max_following,
-                                                                self.min_followers,
-                                                                self.min_following,
-                                                                self.min_posts,
-                                                                self.max_posts,
-                                                                self.skip_private,
-                                                                self.skip_private_percentage,
-                                                                self.skip_no_profile_pic,
-                                                                self.skip_no_profile_pic_percentage,
-                                                                self.skip_business,
-                                                                self.skip_business_percentage,
-                                                                self.skip_business_categories,
-                                                                self.dont_skip_business_categories,
-                                                                self.logger)
+
                         if validation != True:
                             self.logger.info("--> Not a valid user: {}".format(details))
                             not_valid_users += 1
@@ -1338,28 +1321,7 @@ class InstaPy:
                                    self.logger))
                     if not inappropriate:
                         # validate user
-                        validation, details = validate_username(self.browser,
-                                                                user_name,
-                                                                self.username,
-                                                                self.ignore_users,
-                                                                self.blacklist,
-                                                                self.potency_ratio,
-                                                                self.delimit_by_numbers,
-                                                                self.max_followers,
-                                                                self.max_following,
-                                                                self.min_followers,
-                                                                self.min_following,
-                                                                self.min_posts,
-                                                                self.max_posts,
-                                                                self.skip_private,
-                                                                self.skip_private_percentage,
-                                                                self.skip_no_profile_pic,
-                                                                self.skip_no_profile_pic_percentage,
-                                                                self.skip_business,
-                                                                self.skip_business_percentage,
-                                                                self.skip_business_categories,
-                                                                self.dont_skip_business_categories,
-                                                                self.logger)
+                        validation, details = self.validate_user_call(user_name)
                         if validation != True:
                             self.logger.info(details)
                             not_valid_users += 1
@@ -1558,28 +1520,7 @@ class InstaPy:
 
                     if not inappropriate and self.liking_approved:
                         # validate user
-                        validation, details = validate_username(self.browser,
-                                                                user_name,
-                                                                self.username,
-                                                                self.ignore_users,
-                                                                self.blacklist,
-                                                                self.potency_ratio,
-                                                                self.delimit_by_numbers,
-                                                                self.max_followers,
-                                                                self.max_following,
-                                                                self.min_followers,
-                                                                self.min_following,
-                                                                self.min_posts,
-                                                                self.max_posts,
-                                                                self.skip_private,
-                                                                self.skip_private_percentage,
-                                                                self.skip_no_profile_pic,
-                                                                self.skip_no_profile_pic_percentage,
-                                                                self.skip_business,
-                                                                self.skip_business_percentage,
-                                                                self.skip_business_categories,
-                                                                self.dont_skip_business_categories,
-                                                                self.logger)
+                        validation, details = self.validate_user_call(user_name)
                         if validation != True:
                             self.logger.info(details)
                             not_valid_users += 1
@@ -1755,28 +1696,7 @@ class InstaPy:
 
             following = random.randint(0, 100) <= self.follow_percentage
 
-            validation, details = validate_username(self.browser,
-                                                    username,
-                                                    self.username,
-                                                    self.ignore_users,
-                                                    self.blacklist,
-                                                    self.potency_ratio,
-                                                    self.delimit_by_numbers,
-                                                    self.max_followers,
-                                                    self.max_following,
-                                                    self.min_followers,
-                                                    self.min_following,
-                                                    self.min_posts,
-                                                    self.max_posts,
-                                                    self.skip_private,
-                                                    self.skip_private_percentage,
-                                                    self.skip_no_profile_pic,
-                                                    self.skip_no_profile_pic_percentage,
-                                                    self.skip_business,
-                                                    self.skip_business_percentage,
-                                                    self.skip_business_categories,
-                                                    self.dont_skip_business_categories,
-                                                    self.logger)
+            validation, details = self.validate_user_call(username)
             if not validation:
                 self.logger.info("--> not a valid user: {}".format(details))
                 not_valid_users += 1
@@ -1996,28 +1916,7 @@ class InstaPy:
             self.logger.info('--> {}'.format(username.encode('utf-8')))
 
             if not users_validated:
-                validation, details = validate_username(self.browser,
-                                                        username,
-                                                        self.username,
-                                                        self.ignore_users,
-                                                        self.blacklist,
-                                                        self.potency_ratio,
-                                                        self.delimit_by_numbers,
-                                                        self.max_followers,
-                                                        self.max_following,
-                                                        self.min_followers,
-                                                        self.min_following,
-                                                        self.min_posts,
-                                                        self.max_posts,
-                                                        self.skip_private,
-                                                        self.skip_private_percentage,
-                                                        self.skip_no_profile_pic,
-                                                        self.skip_no_profile_pic_percentage,
-                                                        self.skip_business,
-                                                        self.skip_business_percentage,
-                                                        self.skip_business_categories,
-                                                        self.dont_skip_business_categories,
-                                                        self.logger)
+                validation, details = self.validate_user_call(username)
                 if not validation:
                     self.logger.info("--> not a valid user: {}".format(details))
                     not_valid_users += 1
@@ -2341,28 +2240,7 @@ class InstaPy:
 
                 self.logger.info("User '{}' [{}/{}]".format((person), index + 1, len(person_list)))
 
-                validation, details = validate_username(self.browser,
-                                                        person,
-                                                        self.username,
-                                                        self.ignore_users,
-                                                        self.blacklist,
-                                                        self.potency_ratio,
-                                                        self.delimit_by_numbers,
-                                                        self.max_followers,
-                                                        self.max_following,
-                                                        self.min_followers,
-                                                        self.min_following,
-                                                        self.min_posts,
-                                                        self.max_posts,
-                                                        self.skip_private,
-                                                        self.skip_private_percentage,
-                                                        self.skip_no_profile_pic,
-                                                        self.skip_no_profile_pic_percentage,
-                                                        self.skip_business,
-                                                        self.skip_business_percentage,
-                                                        self.skip_business_categories,
-                                                        self.dont_skip_business_categories,
-                                                        self.logger)
+                validation, details = self.validate_user_call(person)
                 if validation != True:
                     self.logger.info(details)
                     not_valid_users += 1
@@ -2506,28 +2384,7 @@ class InstaPy:
 
                 self.logger.info("User '{}' [{}/{}]".format((person), index + 1, len(person_list)))
 
-                validation, details = validate_username(self.browser,
-                                                        person,
-                                                        self.username,
-                                                        self.ignore_users,
-                                                        self.blacklist,
-                                                        self.potency_ratio,
-                                                        self.delimit_by_numbers,
-                                                        self.max_followers,
-                                                        self.max_following,
-                                                        self.min_followers,
-                                                        self.min_following,
-                                                        self.min_posts,
-                                                        self.max_posts,
-                                                        self.skip_private,
-                                                        self.skip_private_percentage,
-                                                        self.skip_no_profile_pic,
-                                                        self.skip_no_profile_pic_percentage,
-                                                        self.skip_business,
-                                                        self.skip_business_percentage,
-                                                        self.skip_business_categories,
-                                                        self.dont_skip_business_categories,
-                                                        self.logger)
+                validation, details = self.validate_user_call(person)
                 if validation != True:
                     self.logger.info(details)
                     not_valid_users += 1
@@ -2674,28 +2531,7 @@ class InstaPy:
                 self.logger.info(
                     "Ongoing Follow [{}/{}]: now following '{}'...".format(index + 1, len(person_list), person))
 
-                validation, details = validate_username(self.browser,
-                                                        person,
-                                                        self.username,
-                                                        self.ignore_users,
-                                                        self.blacklist,
-                                                        self.potency_ratio,
-                                                        self.delimit_by_numbers,
-                                                        self.max_followers,
-                                                        self.max_following,
-                                                        self.min_followers,
-                                                        self.min_following,
-                                                        self.min_posts,
-                                                        self.max_posts,
-                                                        self.skip_private,
-                                                        self.skip_private_percentage,
-                                                        self.skip_no_profile_pic,
-                                                        self.skip_no_profile_pic_percentage,
-                                                        self.skip_business,
-                                                        self.skip_business_percentage,
-                                                        self.skip_business_categories,
-                                                        self.dont_skip_business_categories,
-                                                        self.logger)
+                validation, details = self.validate_user_call(person)
                 if validation != True:
                     self.logger.info(details)
                     not_valid_users += 1
@@ -2853,28 +2689,7 @@ class InstaPy:
                 self.logger.info(
                     "Ongoing Follow [{}/{}]: now following '{}'...".format(index + 1, len(person_list), person))
 
-                validation, details = validate_username(self.browser,
-                                                        person,
-                                                        self.username,
-                                                        self.ignore_users,
-                                                        self.blacklist,
-                                                        self.potency_ratio,
-                                                        self.delimit_by_numbers,
-                                                        self.max_followers,
-                                                        self.max_following,
-                                                        self.min_followers,
-                                                        self.min_following,
-                                                        self.min_posts,
-                                                        self.max_posts,
-                                                        self.skip_private,
-                                                        self.skip_private_percentage,
-                                                        self.skip_no_profile_pic,
-                                                        self.skip_no_profile_pic_percentage,
-                                                        self.skip_business,
-                                                        self.skip_business_percentage,
-                                                        self.skip_business_categories,
-                                                        self.dont_skip_business_categories,
-                                                        self.logger)
+                validation, details = self.validate_user_call(person)
                 if validation != True:
                     self.logger.info(details)
                     not_valid_users += 1
@@ -3116,28 +2931,7 @@ class InstaPy:
 
                             if not inappropriate and self.liking_approved:
                                 # validate user
-                                validation, details = validate_username(self.browser,
-                                                                        user_name,
-                                                                        self.username,
-                                                                        self.ignore_users,
-                                                                        self.blacklist,
-                                                                        self.potency_ratio,
-                                                                        self.delimit_by_numbers,
-                                                                        self.max_followers,
-                                                                        self.max_following,
-                                                                        self.min_followers,
-                                                                        self.min_following,
-                                                                        self.min_posts,
-                                                                        self.max_posts,
-                                                                        self.skip_private,
-                                                                        self.skip_private_percentage,
-                                                                        self.skip_no_profile_pic,
-                                                                        self.skip_no_profile_pic_percentage,
-                                                                        self.skip_business,
-                                                                        self.skip_business_percentage,
-                                                                        self.skip_business_categories,
-                                                                        self.dont_skip_business_categories,
-                                                                        self.logger)
+                                validation, details = self.validate_user_call(user_name)
                                 if validation != True:
                                     self.logger.info(details)
                                     not_valid_users += 1
@@ -3581,28 +3375,7 @@ class InstaPy:
 
                     if not inappropriate:
                         # validate user
-                        validation, details = validate_username(self.browser,
-                                                                user_name,
-                                                                self.username,
-                                                                self.ignore_users,
-                                                                self.blacklist,
-                                                                self.potency_ratio,
-                                                                self.delimit_by_numbers,
-                                                                self.max_followers,
-                                                                self.max_following,
-                                                                self.min_followers,
-                                                                self.min_following,
-                                                                self.min_posts,
-                                                                self.max_posts,
-                                                                self.skip_private,
-                                                                self.skip_private_percentage,
-                                                                self.skip_no_profile_pic,
-                                                                self.skip_no_profile_pic_percentage,
-                                                                self.skip_business,
-                                                                self.skip_business_percentage,
-                                                                self.skip_business_categories,
-                                                                self.dont_skip_business_categories,
-                                                                self.logger)
+                        validation, details = self.validate_user_call(user_name)
                         if validation != True:
                             self.logger.info(details)
                             not_valid_users += 1
@@ -3699,28 +3472,7 @@ class InstaPy:
 
                 if not inappropriate and self.liking_approved:
                     # validate user
-                    validation, details = validate_username(self.browser,
-                                                            user_name,
-                                                            self.username,
-                                                            self.ignore_users,
-                                                            self.blacklist,
-                                                            self.potency_ratio,
-                                                            self.delimit_by_numbers,
-                                                            self.max_followers,
-                                                            self.max_following,
-                                                            self.min_followers,
-                                                            self.min_following,
-                                                            self.min_posts,
-                                                            self.max_posts,
-                                                            self.skip_private,
-                                                            self.skip_private_percentage,
-                                                            self.skip_no_profile_pic,
-                                                            self.skip_no_profile_pic_percentage,
-                                                            self.skip_business,
-                                                            self.skip_business_percentage,
-                                                            self.skip_business_categories,
-                                                            self.dont_skip_business_categories,
-                                                            self.logger)
+                    validation, details = self.validate_user_call(user_name)
                     if validation != True:
                         self.logger.info(details)
                         not_valid_users += 1

--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -1127,6 +1127,7 @@ class InstaPy:
 
                     if not inappropriate and self.liking_approved:
                         # validate user
+                        validation, details = self.validate_user_call(user_name)
 
                         if validation != True:
                             self.logger.info("--> Not a valid user: {}".format(details))

--- a/instapy/util.py
+++ b/instapy/util.py
@@ -1,4 +1,5 @@
 """ Common utilities """
+import random
 import time
 import datetime
 import re
@@ -77,8 +78,11 @@ def validate_username(browser,
                       min_posts,
                       max_posts,
                       skip_private,
+                      skip_private_percentage,
                       skip_no_profile_pic,
+                      skip_no_profile_pic_percentage,
                       skip_business,
+                      skip_business_percentage,
                       skip_business_categories,
                       dont_skip_business_categories,
                       logger):
@@ -203,13 +207,14 @@ def validate_username(browser,
                     number_of_posts, username, min_posts)
     """Skip users"""
     # Skip private
+
     if skip_private:
         try:
             is_private = getUserData("graphql.user.is_private", browser)
         except WebDriverException:
             logger.error("~cannot get if user is private")
             return False, "---> Sorry, couldn't get if user is private\n"
-        if is_private:
+        if is_private and (random.randint(0, 100) <= skip_private_percentage):
             return False, "{} is private account, by default skip\n".format(username)
 
     # Skip no profile pic
@@ -219,7 +224,7 @@ def validate_username(browser,
         except WebDriverException:
             logger.error("~cannot get the post profile pic url")
             return False, "---> Sorry, couldn't get if user profile pic url\n"
-        if profile_pic in default_profile_pic_instagram or str(profile_pic).find("11906329_960233084022564_1448528159_a.jpg") > 0:
+        if (profile_pic in default_profile_pic_instagram or str(profile_pic).find("11906329_960233084022564_1448528159_a.jpg") > 0) and (random.randint(0, 100) <= skip_no_profile_pic_percentage):
             return False, "{} has default instagram profile picture\n".format(username)
 
     # Skip business
@@ -239,7 +244,7 @@ def validate_username(browser,
             if len(skip_business_categories) == 0:
                 # skip if not in dont_include
                 if category not in dont_skip_business_categories:
-                    if len(dont_skip_business_categories) == 0:
+                    if len(dont_skip_business_categories) == 0 and (random.randint(0, 100) <= skip_business_percentage):
                         return False, "{} has business account\n".format(username)
                     else:
                         return False, "{} has business account as a {} which is in the skip_business_categories list given\n".format(

--- a/instapy/util.py
+++ b/instapy/util.py
@@ -27,7 +27,7 @@ from selenium.common.exceptions import NoSuchElementException
 from selenium.common.exceptions import WebDriverException
 from selenium.common.exceptions import TimeoutException
 
-default_profile_pic_instagram = "https://instagram.fhen1-1.fna.fbcdn.net/vp/a8539c22ed9fec8e1c43b538b1ebfd1d/5C5A1A7A/t51.2885-19/11906329_960233084022564_1448528159_a.jpg"
+default_profile_pic_instagram = "https://instagram.fbts2-1.fna.fbcdn.net/vp/a8539c22ed9fec8e1c43b538b1ebfd1d/5C5A1A7A/t51.2885-19/11906329_960233084022564_1448528159_a.jpg"
 
 
 def is_private_profile(browser, logger, following=True):

--- a/instapy/util.py
+++ b/instapy/util.py
@@ -211,7 +211,7 @@ def validate_username(browser,
     # Skip no profile pic
     if skip_no_profile_pic:
         try:
-            profile_pic = getUserData("profile_pic_url", browser)
+            profile_pic = getUserData("graphql.user.profile_pic_url", browser)
         except WebDriverException:
             logger.error("~cannot get the post profile pic url")
             return False, "---> Sorry, couldn't get if user profile pic url\n"

--- a/instapy/util.py
+++ b/instapy/util.py
@@ -27,7 +27,6 @@ from selenium.common.exceptions import NoSuchElementException
 from selenium.common.exceptions import WebDriverException
 from selenium.common.exceptions import TimeoutException
 
-
 default_profile_pic_instagram = "https://instagram.fhen1-1.fna.fbcdn.net/vp/a8539c22ed9fec8e1c43b538b1ebfd1d/5C5A1A7A/t51.2885-19/11906329_960233084022564_1448528159_a.jpg"
 
 
@@ -60,7 +59,6 @@ def is_private_profile(browser, logger, following=True):
     return is_private
 
 
-
 def validate_username(browser,
                       username_or_link,
                       own_username,
@@ -84,43 +82,43 @@ def validate_username(browser,
 
     # Some features may not povide `username` and in those cases we will get it from post's page.
     if '/' in username_or_link:
-        link = username_or_link   # if there is a `/` in `username_or_link`, then it is a `link`
+        link = username_or_link  # if there is a `/` in `username_or_link`, then it is a `link`
 
         # check URL of the webpage, if it already is user's profile page, then do not navigate to it again
         web_address_navigator(browser, link)
 
         try:
             username = browser.execute_script(
-                    "return window._sharedData.entry_data."
-                    "PostPage[0].graphql.shortcode_media.owner.username")
+                "return window._sharedData.entry_data."
+                "PostPage[0].graphql.shortcode_media.owner.username")
 
         except WebDriverException:
             try:
-                browser.execute_script("location.relaod()")
+                browser.execute_script("location.reload()")
                 update_activity()
 
                 username = browser.execute_script(
-                        "return window._sharedData.entry_data."
-                        "PostPage[0].graphql.shortcode_media.owner.username")
+                    "return window._sharedData.entry_data."
+                    "PostPage[0].graphql.shortcode_media.owner.username")
 
             except WebDriverException:
                 logger.error("Username validation failed! ~cannot get the post owner's username")
                 return False, \
-                        "---> Sorry, this page isn't available! ~link is broken, or page is removed\n"
+                       "---> Sorry, this page isn't available! ~link is broken, or page is removed\n"
     else:
-        username = username_or_link   # if there is no `/` in `username_or_link`, then it is a `username`
+        username = username_or_link  # if there is no `/` in `username_or_link`, then it is a `username`
 
     if username == own_username:
         return False, \
-                "---> Username '{}' is yours!  ~skipping user\n".format(own_username)
+               "---> Username '{}' is yours!  ~skipping user\n".format(own_username)
 
     if username in ignore_users:
         return False, \
-                "---> {} is in ignore_users list  ~skipping user\n".format(username)
+               "---> {} is in ignore_users list  ~skipping user\n".format(username)
 
     if username in blacklist:
         return False, \
-                "---> {} is in blacklist  ~skipping user\n".format(username)
+               "---> {} is in blacklist  ~skipping user\n".format(username)
 
     """Checks the potential of target user by relationship status in order to delimit actions within the desired boundary"""
     if potency_ratio or delimit_by_numbers and (max_followers or max_following or min_followers or min_following):
@@ -136,98 +134,136 @@ def validate_username(browser,
             reverse_relationship = True
 
         if followers_count and following_count:
-            relationship_ratio = (float(followers_count)/float(following_count)
-                       if not reverse_relationship
-                        else float(following_count)/float(followers_count))
+            relationship_ratio = (float(followers_count) / float(following_count)
+                                  if not reverse_relationship
+                                  else float(following_count) / float(followers_count))
 
         logger.info('User: {} >> followers: {}  |  following: {}  |  relationship ratio: {}'.format(username,
-        followers_count if followers_count else 'unknown',
-        following_count if following_count else 'unknown',
-        float("{0:.2f}".format(relationship_ratio)) if relationship_ratio else 'unknown'))
+                                                                                                    followers_count if followers_count else 'unknown',
+                                                                                                    following_count if following_count else 'unknown',
+                                                                                                    float(
+                                                                                                        "{0:.2f}".format(
+                                                                                                            relationship_ratio)) if relationship_ratio else 'unknown'))
 
-        if followers_count  or following_count:
+        if followers_count or following_count:
             if potency_ratio and not delimit_by_numbers:
                 if relationship_ratio and relationship_ratio < potency_ratio:
-                        return False, \
-                            "{} is not a {} with the relationship ratio of {}  ~skipping user\n".format(
-                            username, "potential user" if not reverse_relationship else "massive follower",
-                            float("{0:.2f}".format(relationship_ratio)))
+                    return False, \
+                           "{} is not a {} with the relationship ratio of {}  ~skipping user\n".format(
+                               username, "potential user" if not reverse_relationship else "massive follower",
+                               float("{0:.2f}".format(relationship_ratio)))
 
             elif delimit_by_numbers:
                 if followers_count:
                     if max_followers:
                         if followers_count > max_followers:
                             return False, \
-                                "User {}'s followers count exceeds maximum limit  ~skipping user\n".format(username)
+                                   "User {}'s followers count exceeds maximum limit  ~skipping user\n".format(username)
                     if min_followers:
                         if followers_count < min_followers:
                             return False, \
-                                "User {}'s followers count is less than minimum limit  ~skipping user\n".format(username)
+                                   "User {}'s followers count is less than minimum limit  ~skipping user\n".format(
+                                       username)
                 if following_count:
                     if max_following:
                         if following_count > max_following:
                             return False, \
-                                "User {}'s following count exceeds maximum limit  ~skipping user\n".format(username)
+                                   "User {}'s following count exceeds maximum limit  ~skipping user\n".format(username)
                     if min_following:
                         if following_count < min_following:
                             return False, \
-                                "User {}'s following count is less than minimum limit  ~skipping user\n".format(username)
+                                   "User {}'s following count is less than minimum limit  ~skipping user\n".format(
+                                       username)
                 if potency_ratio:
                     if relationship_ratio and relationship_ratio < potency_ratio:
                         return False, \
-                            "{} is not a {} with the relationship ratio of {}  ~skipping user\n".format(
-                            username, "potential user" if not reverse_relationship else "massive follower",
-                            float("{0:.2f}".format(relationship_ratio)))
+                               "{} is not a {} with the relationship ratio of {}  ~skipping user\n".format(
+                                   username, "potential user" if not reverse_relationship else "massive follower",
+                                   float("{0:.2f}".format(relationship_ratio)))
 
-    #Since we are already in user page check number of posts using apinsta.herokuapp
-
-    browser.get('http://apinsta.herokuapp.com/u/' + username)
-    pre = browser.find_element_by_tag_name("pre").text
-    browser.execute_script("window.history.go(-1)")
-    user_data = json.loads(pre)['graphql']['user']
+    # Since we are already in user page check number of posts using apinsta.herokuapp
+    #https://www.instagram.com/web/search/topsearch/?context=user&count=0&query=gabrielecalarota
+    web_address_navigator(browser, "https://www.instagram.com/"+username+"/")
     if min_posts or max_posts:
         # If you are interested in relationship number of posts boundaries
-        number_of_posts = user_data['edge_owner_to_timeline_media']['count']
+        try:
+            number_of_posts = getUserData("graphql.user.edge_owner_to_timeline_media.count", browser)
+        except WebDriverException:
+            logger.error("~cannot get number of posts for username")
+            return False, "---> Sorry, couldn't check for number of posts of username\n"
         if max_posts:
             if number_of_posts > max_posts:
-                return False, "Number of posts ({}) of {} exceeds the max limit given {}".format(number_of_posts,username,max_posts)
+                return False, "Number of posts ({}) of {} exceeds the max limit given {}\n".format(number_of_posts,
+                                                                                                 username, max_posts)
         if min_posts:
             if number_of_posts < min_posts:
-                return False, "Number of posts ({}) of {} is not enough for the minimum limit given {}".format(number_of_posts,username,min_posts)
-
+                return False, "Number of posts ({}) of {} is not enough for the minimum limit given {}\n".format(
+                    number_of_posts, username, min_posts)
     """Skip users"""
-    #Skip private
+    # Skip private
     if skip_private:
-        if user_data['is_private']:
-            return False, "{} is private account, by default skip".format(username)
+        try:
+            is_private = getUserData("graphql.user.is_private", browser)
+        except WebDriverException:
+            logger.error("~cannot get if user is private")
+            return False, "---> Sorry, couldn't get if user is private\n"
+        if is_private:
+            return False, "{} is private account, by default skip\n".format(username)
 
-    #Skip no profile pic
+    # Skip no profile pic
     if skip_no_profile_pic:
-        if user_data['profile_pic_url'] == default_profile_pic_instagram:
-            return False, "{} has default instagram profile picture".format(username)
+        try:
+            profile_pic = getUserData("profile_pic_url", browser)
+        except WebDriverException:
+            logger.error("~cannot get the post profile pic url")
+            return False, "---> Sorry, couldn't get if user profile pic url\n"
+        if profile_pic == default_profile_pic_instagram:
+            return False, "{} has default instagram profile picture\n".format(username)
 
-
-    #Skip business
+    # Skip business
     if skip_business:
-        #If is business account skip under conditions
-        if user_data['is_business_account']:
-            category = user_data['business_category_name']
+        # If is business account skip under conditions
+        try:
+            is_business_account = getUserData("graphql.user.is_business_account", browser)
+        except WebDriverException:
+            logger.error("~cannot get if user has business account active")
+            return False, "---> Sorry, couldn't get if user has business account active\n"
+        if is_business_account:
+            try:
+                category = getUserData("graphql.user.business_category_name", browser)
+            except WebDriverException:
+                logger.error("~cannot get category name for user")
+                return False, "---> Sorry, couldn't get category name for user\n"
             if len(skip_business_categories) == 0:
-                #skip if not in dont_include
+                # skip if not in dont_include
                 if category not in dont_skip_business_categories:
                     if len(dont_skip_business_categories) == 0:
-                        return False, "{} has business account".format(username)
+                        return False, "{} has business account\n".format(username)
                     else:
-                        return False, "{} has business account as a {} which is in the skip_business_categories list given".format(username, category)
+                        return False, "{} has business account as a {} which is in the skip_business_categories list given\n".format(
+                            username, category)
             else:
                 if category in skip_business_categories:
-                    return False, "{} has business account as a {} which is in the skip_business_categories list given".format(username, category)
-
-
+                    return False, "{} has business account as a {} which is in the skip_business_categories list given\n".format(
+                        username, category)
 
     # if everything ok
     return True, "Valid user"
 
+
+def getUserData(query, browser, basequery="return window._sharedData.entry_data.PostPage[0]."):
+    try:
+        data = browser.execute_script(
+            "return window._sharedData.entry_data."
+            "PostPage[0]." + query)
+        return data
+    except WebDriverException:
+        browser.execute_script("location.reload()")
+        update_activity()
+
+        data = browser.execute_script(
+            basequery + query)
+        return data
 
 
 def update_activity(action="server_calls"):
@@ -246,7 +282,7 @@ def update_activity(action="server_calls"):
         # collect today data
         cur.execute("SELECT * FROM recordActivity WHERE profile_id=:var AND "
                     "STRFTIME('%Y-%m-%d %H', created) == STRFTIME('%Y-%m-%d %H', 'now', 'localtime')",
-                        {"var":id})
+                    {"var": id})
         data = cur.fetchone()
 
         if data is None:
@@ -281,9 +317,7 @@ def update_activity(action="server_calls"):
         conn.commit()
 
 
-
 def add_user_to_blacklist(username, campaign, action, logger, logfolder):
-
     file_exists = os.path.isfile('{}blacklist.csv'.format(logfolder))
     fieldnames = ['date', 'username', 'campaign', 'action']
     today = datetime.date.today().strftime('%m/%d/%y')
@@ -294,17 +328,16 @@ def add_user_to_blacklist(username, campaign, action, logger, logfolder):
             if not file_exists:
                 writer.writeheader()
             writer.writerow({
-                    'date': today,
-                    'username': username,
-                    'campaign': campaign,
-                    'action': action
+                'date': today,
+                'username': username,
+                'campaign': campaign,
+                'action': action
             })
     except Exception as err:
         logger.error('blacklist dictWrite error {}'.format(err))
 
     logger.info('--> {} added to blacklist for {} campaign (action: {})'
                 .format(username, campaign, action))
-
 
 
 def get_active_users(browser, username, posts, boundary, logger):
@@ -325,7 +358,7 @@ def get_active_users(browser, username, posts, boundary, logger):
             topCount_elements = browser.find_elements_by_xpath(
                 "//span[contains(@class,'g47SY')]")
 
-            if topCount_elements: #prevent an empty string scenario
+            if topCount_elements:  # prevent an empty string scenario
                 total_posts = format_number(topCount_elements[0].text)
 
             else:
@@ -342,7 +375,7 @@ def get_active_users(browser, username, posts, boundary, logger):
     # click latest post
     try:
         latest_post = browser.find_elements_by_xpath(
-                            "//div[contains(@class, '_9AhH0')]")[0]
+            "//div[contains(@class, '_9AhH0')]")[0]
         click_element(browser, latest_post)
 
     except (NoSuchElementException, WebDriverException):
@@ -371,7 +404,7 @@ def get_active_users(browser, username, posts, boundary, logger):
                 try:
                     likers_count = (browser.find_element_by_xpath(
                         "//a[contains(@class, 'zV_Nj')]/span").text)
-                    if likers_count: ##prevent an empty string scenarios
+                    if likers_count:  ##prevent an empty string scenarios
                         likers_count = format_number(likers_count)
                     else:
                         logger.info("Failed to get likers count on your post {}  ~empty string".format(count))
@@ -381,12 +414,12 @@ def get_active_users(browser, username, posts, boundary, logger):
                     likers_count = None
 
             likes_button = browser.find_element_by_xpath(
-                                       "//a[contains(@class, 'zV_Nj')]")
+                "//a[contains(@class, 'zV_Nj')]")
             click_element(browser, likes_button)
             sleep_actual(5)
 
             dialog = browser.find_element_by_xpath(
-                                 "//div[text()='Likes']/following-sibling::div")
+                "//div[text()='Likes']/following-sibling::div")
 
             scroll_it = True
             try_again = 0
@@ -422,16 +455,16 @@ def get_active_users(browser, username, posts, boundary, logger):
                         break
 
                 if (scroll_it == False and
-                      likers_count and
+                        likers_count and
                         likers_count - 1 > len(tmp_list)):
 
                     if ((boundary is not None and likers_count - 1 > boundary) or
-                                boundary is None):
+                            boundary is None):
 
                         if try_again <= 1:  # you can increase the amount of tries here
                             logger.info("Cor! ~failed to get the desired amount of usernames, "
-                                            "trying again!  |  post:{}  |  attempt: {}".format(
-                                                                                posts, try_again + 1))
+                                        "trying again!  |  post:{}  |  attempt: {}".format(
+                                posts, try_again + 1))
                             try_again += 1
                             too_many_requests += 1
                             scroll_it = True
@@ -442,7 +475,7 @@ def get_active_users(browser, username, posts, boundary, logger):
                 "//a[contains(@class, 'FPmhX')]")
 
             logger.info("Post {}  |  Likers: found {}, catched {}".format(
-                                            count, likers_count, len(tmp_list)))
+                count, likers_count, len(tmp_list)))
 
         except NoSuchElementException:
             try:
@@ -462,12 +495,12 @@ def get_active_users(browser, username, posts, boundary, logger):
         sleep_actual(1)
 
         # if not reached posts(parameter) value, continue
-        if count +1 != posts +1 and count != 0:
+        if count + 1 != posts + 1 and count != 0:
             try:
                 # click next button
                 next_button = browser.find_element_by_xpath(
-                                    "//a[contains(@class, 'HBoOv')]"
-                                        "[text()='Next']")
+                    "//a[contains(@class, 'HBoOv')]"
+                    "[text()='Next']")
                 click_element(browser, next_button)
 
             except:
@@ -482,23 +515,22 @@ def get_active_users(browser, username, posts, boundary, logger):
 
     logger.info("Gathered total of {} unique active followers from the latest {}"
                 "posts in {} minutes and {} seconds".format(len(active_users),
-                                                             posts,
-                                                              diff_in_minutes,
-                                                              diff_in_seconds))
+                                                            posts,
+                                                            diff_in_minutes,
+                                                            diff_in_seconds))
 
     return active_users
-
 
 
 def delete_line_from_file(filepath, userToDelete, logger):
     """ Remove user's record from the followed pool file after unfollowing """
     if not os.path.isfile(filepath):
-        #in case of there is no any followed pool file yet
+        # in case of there is no any followed pool file yet
         return 0
 
     try:
-        file_path_old = filepath+".old"
-        file_path_Temp = filepath+".temp"
+        file_path_old = filepath + ".old"
+        file_path_Temp = filepath + ".temp"
 
         with open(filepath, "r") as f:
             lines = f.readlines()
@@ -543,6 +575,7 @@ def delete_line_from_file(filepath, userToDelete, logger):
     except BaseException as e:
         logger.error("delete_line_from_file error {}\n{}".format(str(e).encode("utf-8")))
 
+
 def scroll_bottom(browser, element, range_int):
     # put a limit to the scrolling
     if range_int > 50:
@@ -556,7 +589,6 @@ def scroll_bottom(browser, element, range_int):
         sleep(1)
 
     return
-
 
 
 def click_element(browser, element, tryNum=0):
@@ -591,7 +623,8 @@ def click_element(browser, element, tryNum=0):
 
         if tryNum == 0:
             # try scrolling the element into view
-            browser.execute_script("document.getElementsByClassName('" +  element.get_attribute("class") + "')[0].scrollIntoView({ inline: 'center' });")
+            browser.execute_script("document.getElementsByClassName('" + element.get_attribute(
+                "class") + "')[0].scrollIntoView({ inline: 'center' });")
 
         elif tryNum == 1:
             # well, that didn't work, try scrolling to the top and then clicking again
@@ -604,7 +637,8 @@ def click_element(browser, element, tryNum=0):
         else:
             # try `execute_script` as a last resort
             # print("attempting last ditch effort for click, `execute_script`")
-            browser.execute_script("document.getElementsByClassName('" +  element.get_attribute("class") + "')[0].click()")
+            browser.execute_script(
+                "document.getElementsByClassName('" + element.get_attribute("class") + "')[0].click()")
             # update server calls after last click attempt by JS
             update_activity()
             # end condition for the recursive function
@@ -622,7 +656,6 @@ def click_element(browser, element, tryNum=0):
         click_element(browser, element, tryNum)
 
 
-
 def format_number(number):
     """
     Format number. Remove the unused comma. Replace the concatenation with relevant zeros. Remove the dot.
@@ -638,12 +671,10 @@ def format_number(number):
     return int(formatted_num)
 
 
-
 def username_url_to_username(username_url):
-    a = username_url.replace ("https://www.instagram.com/","")
-    username = a.split ('/')
+    a = username_url.replace("https://www.instagram.com/", "")
+    username = a.split('/')
     return username[0]
-
 
 
 def get_number_of_posts(browser):
@@ -653,7 +684,6 @@ def get_number_of_posts(browser):
     num_of_posts_txt = num_of_posts_txt.replace(",", "")
     num_of_posts = int(num_of_posts_txt)
     return num_of_posts
-
 
 
 def get_relationship_counts(browser, username, logger):
@@ -736,12 +766,11 @@ def get_relationship_counts(browser, username, logger):
     return followers_count, following_count
 
 
-
 def web_address_navigator(browser, link):
     """Checks and compares current URL of web page and the URL to be navigated and if it is different, it does navigate"""
     current_url = get_current_url(browser)
     total_timeouts = 0
-    page_type = None   # file or directory
+    page_type = None  # file or directory
 
     # remove slashes at the end to compare efficiently
     if current_url is not None and current_url.endswith('/'):
@@ -749,12 +778,12 @@ def web_address_navigator(browser, link):
 
     if link.endswith('/'):
         link = link[:-1]
-        page_type = "dir"   # slash at the end is a directory
+        page_type = "dir"  # slash at the end is a directory
 
     new_navigation = (current_url != link)
 
     if current_url is None or new_navigation:
-        link = link+'/' if page_type=="dir" else link   # directory links navigate faster
+        link = link + '/' if page_type == "dir" else link  # directory links navigate faster
 
         while True:
             try:
@@ -767,11 +796,11 @@ def web_address_navigator(browser, link):
             except TimeoutException as exc:
                 if total_timeouts >= 7:
                     raise TimeoutException("Retried {} times to GET '{}' webpage "
-                       "but failed out of a timeout!\n\t{}".format(total_timeouts,
-                             str(link).encode("utf-8"), str(exc).encode("utf-8")))
+                                           "but failed out of a timeout!\n\t{}".format(total_timeouts,
+                                                                                       str(link).encode("utf-8"),
+                                                                                       str(exc).encode("utf-8")))
                 total_timeouts += 1
                 sleep(2)
-
 
 
 @contextmanager
@@ -789,36 +818,35 @@ def interruption_handler(SIG_type=signal.SIGINT, handler=signal.SIG_IGN, notify=
         signal.signal(SIG_type, original_handler)
 
 
-
 def highlight_print(username=None, message=None, priority=None, level=None, logger=None):
     """ Print headers in a highlighted style """
-    #can add other highlighters at other priorities enriching this function
+    # can add other highlighters at other priorities enriching this function
 
-    #find the number of chars needed off the length of the logger message
-    output_len = 28+len(username)+3+len(message)
+    # find the number of chars needed off the length of the logger message
+    output_len = 28 + len(username) + 3 + len(message)
 
     if priority in ["initialization", "end"]:
-        #OOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOO
-        #E.g.:          Session started!
-        #oooooooooooooooooooooooooooooooooooooooooooooooo
+        # OOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOO
+        # E.g.:          Session started!
+        # oooooooooooooooooooooooooooooooooooooooooooooooo
         upper_char = "O"
         lower_char = "o"
 
     elif priority == "login":
-        #................................................
-        #E.g.:        Logged in successfully!
-        #''''''''''''''''''''''''''''''''''''''''''''''''
+        # ................................................
+        # E.g.:        Logged in successfully!
+        # ''''''''''''''''''''''''''''''''''''''''''''''''
         upper_char = "."
         lower_char = "'"
 
-    elif priority == "feature":  #feature highlighter
-        #________________________________________________
-        #E.g.:    Starting to interact by users..
-        #""""""""""""""""""""""""""""""""""""""""""""""""
+    elif priority == "feature":  # feature highlighter
+        # ________________________________________________
+        # E.g.:    Starting to interact by users..
+        # """"""""""""""""""""""""""""""""""""""""""""""""
         upper_char = "_"
         lower_char = "\""
 
-    print("\n{}".format(upper_char*output_len))
+    print("\n{}".format(upper_char * output_len))
 
     if level == "info":
         logger.info(message)
@@ -827,8 +855,7 @@ def highlight_print(username=None, message=None, priority=None, level=None, logg
     elif level == "critical":
         logger.critical(message)
 
-    print("{}".format(lower_char*output_len))
-
+    print("{}".format(lower_char * output_len))
 
 
 def remove_duplicates(container, keep_order, logger):
@@ -845,11 +872,10 @@ def remove_duplicates(container, keep_order, logger):
     else:
         logger.warning("The given data type- '{}' is not supported "
                        "in `remove_duplicates` function, yet!"
-                           .format(type(container)))
+                       .format(type(container)))
         result = container
 
     return result
-
 
 
 def dump_record_activity(profile_name, logger, logfolder):
@@ -864,7 +890,7 @@ def dump_record_activity(profile_name, logger, logfolder):
             conn.row_factory = sqlite3.Row
             cur = conn.cursor()
 
-            cur.execute("SELECT * FROM recordActivity WHERE profile_id=:var", {"var":id})
+            cur.execute("SELECT * FROM recordActivity WHERE profile_id=:var", {"var": id})
             user_data = cur.fetchall()
 
         if user_data:
@@ -886,27 +912,27 @@ def dump_record_activity(profile_name, logger, logfolder):
                 if day not in ordered_user_data.keys():
                     ordered_user_data.update({day: {}})
 
-                ordered_user_data[day].update({hour: {"likes":hourly_data[1],
-                                                      "comments":hourly_data[2],
-                                                      "follows":hourly_data[3],
-                                                      "unfollows":hourly_data[4],
-                                                       "server_calls":hourly_data[5]}})
+                ordered_user_data[day].update({hour: {"likes": hourly_data[1],
+                                                      "comments": hourly_data[2],
+                                                      "follows": hourly_data[3],
+                                                      "unfollows": hourly_data[4],
+                                                      "server_calls": hourly_data[5]}})
 
             # update user data with live data whilst preserving all other data (keys)
-            current_data.update({profile_name:ordered_user_data})
+            current_data.update({profile_name: ordered_user_data})
 
             # dump the fresh record data to a local human readable JSON
             with open(filename, 'w') as recordActFile:
                 json.dump(current_data, recordActFile)
 
     except Exception as exc:
-        logger.error("Pow! Error occured while dumping record activity data to a local JSON:\n\t{}".format(str(exc).encode("utf-8")))
+        logger.error("Pow! Error occured while dumping record activity data to a local JSON:\n\t{}".format(
+            str(exc).encode("utf-8")))
 
     finally:
         if conn:
             # close the open connection
             conn.close()
-
 
 
 def ping_server(host, logger):
@@ -917,10 +943,10 @@ def ping_server(host, logger):
     logger.info("Pinging '{}' to check the connectivity...".format(str(host)))
 
     # ping command count option as function of OS
-    param = "-n" if system().lower()=="windows" else "-c"
+    param = "-n" if system().lower() == "windows" else "-c"
     # building the command. Ex: "ping -c 1 google.com"
     command = ' '.join(["ping", param, '1', str(host)])
-    need_sh = False if  system().lower()=="windows" else True
+    need_sh = False if system().lower() == "windows" else True
 
     # pinging
     ping_attempts = 2
@@ -931,7 +957,7 @@ def ping_server(host, logger):
 
         if connectivity == False:
             logger.warning("Pinging the server again!\t~total attempts left: {}"
-                                .format(ping_attempts))
+                           .format(ping_attempts))
             ping_attempts -= 1
             sleep(5)
 
@@ -940,7 +966,6 @@ def ping_server(host, logger):
         return False
 
     return True
-
 
 
 def emergency_exit(browser, username, logger):
@@ -960,7 +985,6 @@ def emergency_exit(browser, username, logger):
         return True, "not logged in"
 
     return False, "no emergency"
-
 
 
 def load_user_id(username, person, logger, logfolder):
@@ -991,13 +1015,12 @@ def load_user_id(username, person, logger, logfolder):
     return user_id
 
 
-
 def check_authorization(browser, username, method, logger):
     """ Check if user is NOW logged in """
     logger.info("Checking if '{}' is logged in...".format(username))
 
     # different methods can be added in future
-    if method=="activity counts":
+    if method == "activity counts":
 
         profile_link = 'https://www.instagram.com/{}/'.format(username)
         web_address_navigator(browser, profile_link)
@@ -1013,7 +1036,7 @@ def check_authorization(browser, username, method, logger):
                 update_activity()
 
                 activity_counts = browser.execute_script(
-                                    "return window._sharedData.activity_counts")
+                    "return window._sharedData.activity_counts")
 
             except WebDriverException:
                 activity_counts = None
@@ -1039,7 +1062,6 @@ def check_authorization(browser, username, method, logger):
     return True
 
 
-
 def get_username(browser, track, logger):
     """ Get the username of a user from the loaded profile page """
     if track == "profile":
@@ -1063,13 +1085,12 @@ def get_username(browser, track, logger):
         except WebDriverException:
             current_url = get_current_url(browser)
             logger.info("Failed to get the username from '{}' page".format(current_url or
-                                                        "user" if track == "profile" else "post"))
+                                                                           "user" if track == "profile" else "post"))
             username = None
 
     # in future add XPATH ways of getting username
 
     return username
-
 
 
 def find_user_id(browser, track, username, logger):
@@ -1115,7 +1136,6 @@ def find_user_id(browser, track, username, logger):
     return user_id
 
 
-
 @contextmanager
 def new_tab(browser):
     """ USE once a host tab must remain untouched and yet needs extra data- get from guest tab """
@@ -1137,7 +1157,6 @@ def new_tab(browser):
         sleep(2)
 
 
-
 def explicit_wait(browser, track, ec_params, logger, timeout=35, notify=True):
     """
     Explicitly wait until expected condition validates
@@ -1153,7 +1172,6 @@ def explicit_wait(browser, track, ec_params, logger, timeout=35, notify=True):
 
     if not isinstance(ec_params, list):
         ec_params = [ec_params]
-
 
     # find condition according to the tracks
     if track == "VOEL":
@@ -1175,7 +1193,7 @@ def explicit_wait(browser, track, ec_params, logger, timeout=35, notify=True):
     elif track == "PFL":
         ec_name = "page fully loaded"
         condition = (lambda browser: browser.execute_script("return document.readyState")
-                                                in ["complete" or "loaded"])
+                                     in ["complete" or "loaded"])
 
     # generic wait block
     try:
@@ -1185,11 +1203,10 @@ def explicit_wait(browser, track, ec_params, logger, timeout=35, notify=True):
     except TimeoutException:
         if notify == True:
             logger.info("Timed out with failure while explicitly waiting until {}!\n"
-                            .format(ec_name))
+                        .format(ec_name))
         return False
 
     return result
-
 
 
 def get_current_url(browser):
@@ -1207,15 +1224,14 @@ def get_current_url(browser):
     return current_url
 
 
-
 def get_username_from_id(browser, user_id, logger):
     """ Convert user ID to username """
     # method using graphql 'Account media' endpoint
     logger.info("Trying to find the username from the given user ID by loading a post")
 
-    query_hash = "42323d64886122307be10013ad2dcc44"   # earlier- "472f257a40c653c64c666ce877d59d2b"
+    query_hash = "42323d64886122307be10013ad2dcc44"  # earlier- "472f257a40c653c64c666ce877d59d2b"
     graphql_query_URL = "https://www.instagram.com/graphql/query/?query_hash={}".format(query_hash)
-    variables = {"id":str(user_id), "first":1}
+    variables = {"id": str(user_id), "first": 1}
     post_url = u"{}&variables={}".format(graphql_query_URL, str(json.dumps(variables)))
 
     web_address_navigator(browser, post_url)
@@ -1245,25 +1261,23 @@ def get_username_from_id(browser, user_id, logger):
         logger.info("No profile found, the user may have blocked you (ID: {})".format(user_id))
         return None
 
-
     # method using private API
     logger.info("Trying to find the username from the given user ID by a quick API call")
 
     req = requests.get(u"https://i.instagram.com/api/v1/users/{}/info/"
-                            .format(user_id))
+                       .format(user_id))
     if req:
         data = json.loads(req.text)
         if data["user"]:
             username = data["user"]["username"]
             return username
 
-
     # method using graphql 'Follow' endpoint
     logger.info("Trying to find the username from the given user ID "
-                   "by using the GraphQL Follow endpoint")
+                "by using the GraphQL Follow endpoint")
 
     user_link_by_id = ("https://www.instagram.com/web/friendships/{}/follow/"
-                            .format(user_id))
+                       .format(user_id))
 
     web_address_navigator(browser, user_link_by_id)
     username = get_username(browser, "profile", logger)
@@ -1271,8 +1285,7 @@ def get_username_from_id(browser, user_id, logger):
     return username
 
 
- 
-def is_page_available(browser, logger): 
+def is_page_available(browser, logger):
     """ Check if the page is available and valid """
     # wait for the current page fully load
     explicit_wait(browser, "PFL", [], logger, 10)
@@ -1306,10 +1319,8 @@ def is_page_available(browser, logger):
     return True
 
 
-
 @contextmanager
 def smart_run(session):
-    
     try:
         session.login()
         yield
@@ -1323,7 +1334,7 @@ def smart_run(session):
                 fp.write(session.browser.page_source.encode("utf-8"))
             print("{0}\nIf raising an issue, "
                   "please also upload the file located at:\n{1}\n{0}"
-                    .format('*' * 70, file_path))
+                  .format('*' * 70, file_path))
 
         # provide full stacktrace (else than external interrupt)
         if isinstance(exc, KeyboardInterrupt):
@@ -1334,6 +1345,3 @@ def smart_run(session):
 
     finally:
         session.end()
-
-
-

--- a/instapy/util.py
+++ b/instapy/util.py
@@ -71,6 +71,8 @@ def validate_username(browser,
                       max_following,
                       min_followers,
                       min_following,
+                      min_posts,
+                      max_posts,
                       logger):
     """Check if we can interact with the user"""
 
@@ -170,6 +172,23 @@ def validate_username(browser,
                             "{} is not a {} with the relationship ratio of {}  ~skipping user\n".format(
                             username, "potential user" if not reverse_relationship else "massive follower",
                             float("{0:.2f}".format(relationship_ratio)))
+
+    #Since we are already in user page check number of posts using apinsta.herokuapp
+    if min_posts or max_posts:
+        #If you are interested in relationship number of posts boundaries
+        browser.get(
+            'http://apinsta.herokuapp.com/u/' + username)
+        pre = browser.find_element_by_tag_name("pre").text
+        browser.execute_script("window.history.go(-1)")
+        number_of_posts = json.loads(pre)['graphql']['user']['edge_owner_to_timeline_media']['count']
+        if max_posts:
+            if number_of_posts > max_posts:
+                return False
+        if min_posts:
+            if number_of_posts < min_posts:
+                return False
+
+
 
 
     # if everything ok

--- a/instapy/util.py
+++ b/instapy/util.py
@@ -27,7 +27,9 @@ from selenium.common.exceptions import NoSuchElementException
 from selenium.common.exceptions import WebDriverException
 from selenium.common.exceptions import TimeoutException
 
-default_profile_pic_instagram = "https://instagram.fbts2-1.fna.fbcdn.net/vp/a8539c22ed9fec8e1c43b538b1ebfd1d/5C5A1A7A/t51.2885-19/11906329_960233084022564_1448528159_a.jpg"
+default_profile_pic_instagram = ["https://instagram.flas1-2.fna.fbcdn.net/vp/a8539c22ed9fec8e1c43b538b1ebfd1d/5C5A1A7A/t51.2885-19/11906329_960233084022564_1448528159_a.jpg",
+                                 "https://scontent-yyz1-1.cdninstagram.com/vp/a8539c22ed9fec8e1c43b538b1ebfd1d/5C5A1A7A/t51.2885-19/11906329_960233084022564_1448528159_a.jpg",
+                                 "https://instagram.fbts2-1.fna.fbcdn.net/vp/a8539c22ed9fec8e1c43b538b1ebfd1d/5C5A1A7A/t51.2885-19/11906329_960233084022564_1448528159_a.jpg"]
 
 
 def is_private_profile(browser, logger, following=True):
@@ -215,7 +217,8 @@ def validate_username(browser,
         except WebDriverException:
             logger.error("~cannot get the post profile pic url")
             return False, "---> Sorry, couldn't get if user profile pic url\n"
-        if profile_pic == default_profile_pic_instagram:
+        print(profile_pic)
+        if profile_pic in default_profile_pic_instagram:
             return False, "{} has default instagram profile picture\n".format(username)
 
     # Skip business

--- a/instapy/util.py
+++ b/instapy/util.py
@@ -181,9 +181,7 @@ def validate_username(browser,
                                    username, "potential user" if not reverse_relationship else "massive follower",
                                    float("{0:.2f}".format(relationship_ratio)))
 
-    # Since we are already in user page check number of posts using apinsta.herokuapp
-    #https://www.instagram.com/web/search/topsearch/?context=user&count=0&query=gabrielecalarota
-    web_address_navigator(browser, "https://www.instagram.com/"+username+"/")
+    web_address_navigator(browser, "https://www.instagram.com/" + username + "/")
     if min_posts or max_posts:
         # If you are interested in relationship number of posts boundaries
         try:
@@ -194,7 +192,7 @@ def validate_username(browser,
         if max_posts:
             if number_of_posts > max_posts:
                 return False, "Number of posts ({}) of {} exceeds the max limit given {}\n".format(number_of_posts,
-                                                                                                 username, max_posts)
+                                                                                                   username, max_posts)
         if min_posts:
             if number_of_posts < min_posts:
                 return False, "Number of posts ({}) of {} is not enough for the minimum limit given {}\n".format(
@@ -251,11 +249,10 @@ def validate_username(browser,
     return True, "Valid user"
 
 
-def getUserData(query, browser, basequery="return window._sharedData.entry_data.PostPage[0]."):
+def getUserData(query, browser, basequery="return window._sharedData.entry_data.ProfilePage[0]."):
     try:
         data = browser.execute_script(
-            "return window._sharedData.entry_data."
-            "PostPage[0]." + query)
+            basequery + query)
         return data
     except WebDriverException:
         browser.execute_script("location.reload()")

--- a/instapy/util.py
+++ b/instapy/util.py
@@ -29,7 +29,9 @@ from selenium.common.exceptions import TimeoutException
 
 default_profile_pic_instagram = ["https://instagram.flas1-2.fna.fbcdn.net/vp/a8539c22ed9fec8e1c43b538b1ebfd1d/5C5A1A7A/t51.2885-19/11906329_960233084022564_1448528159_a.jpg",
                                  "https://scontent-yyz1-1.cdninstagram.com/vp/a8539c22ed9fec8e1c43b538b1ebfd1d/5C5A1A7A/t51.2885-19/11906329_960233084022564_1448528159_a.jpg",
-                                 "https://instagram.fbts2-1.fna.fbcdn.net/vp/a8539c22ed9fec8e1c43b538b1ebfd1d/5C5A1A7A/t51.2885-19/11906329_960233084022564_1448528159_a.jpg"]
+                                 "https://instagram.faep12-1.fna.fbcdn.net/vp/a8539c22ed9fec8e1c43b538b1ebfd1d/5C5A1A7A/t51.2885-19/11906329_960233084022564_1448528159_a.jpg",
+                                 "https://instagram.fbts2-1.fna.fbcdn.net/vp/a8539c22ed9fec8e1c43b538b1ebfd1d/5C5A1A7A/t51.2885-19/11906329_960233084022564_1448528159_a.jpg",
+                                 "https://scontent-mia3-1.cdninstagram.com/vp/a8539c22ed9fec8e1c43b538b1ebfd1d/5C5A1A7A/t51.2885-19/11906329_960233084022564_1448528159_a.jpg"]
 
 
 def is_private_profile(browser, logger, following=True):
@@ -218,7 +220,7 @@ def validate_username(browser,
             logger.error("~cannot get the post profile pic url")
             return False, "---> Sorry, couldn't get if user profile pic url\n"
         print(profile_pic)
-        if profile_pic in default_profile_pic_instagram:
+        if profile_pic in default_profile_pic_instagram or str(profile_pic).find("11906329_960233084022564_1448528159_a.jpg") > 0:
             return False, "{} has default instagram profile picture\n".format(username)
 
     # Skip business

--- a/instapy/util.py
+++ b/instapy/util.py
@@ -180,13 +180,14 @@ def validate_username(browser,
                             float("{0:.2f}".format(relationship_ratio)))
 
     #Since we are already in user page check number of posts using apinsta.herokuapp
+
+    browser.get('http://apinsta.herokuapp.com/u/' + username)
+    pre = browser.find_element_by_tag_name("pre").text
+    browser.execute_script("window.history.go(-1)")
+    user_data = json.loads(pre)['graphql']['user']
     if min_posts or max_posts:
-        #If you are interested in relationship number of posts boundaries
-        browser.get(
-            'http://apinsta.herokuapp.com/u/' + username)
-        pre = browser.find_element_by_tag_name("pre").text
-        browser.execute_script("window.history.go(-1)")
-        number_of_posts = json.loads(pre)['graphql']['user']['edge_owner_to_timeline_media']['count']
+        # If you are interested in relationship number of posts boundaries
+        number_of_posts = user_data['edge_owner_to_timeline_media']['count']
         if max_posts:
             if number_of_posts > max_posts:
                 return False, "Number of posts ({}) of {} exceeds the max limit given {}".format(number_of_posts,username,max_posts)
@@ -197,20 +198,20 @@ def validate_username(browser,
     """Skip users"""
     #Skip private
     if skip_private:
-        if json.loads(pre)['graphql']['user']['is_private']:
+        if user_data['is_private']:
             return False, "{} is private account, by default skip".format(username)
 
     #Skip no profile pic
     if skip_no_profile_pic:
-        if json.loads(pre)['graphql']['user']['profile_pic_url'] == default_profile_pic_instagram:
+        if user_data['profile_pic_url'] == default_profile_pic_instagram:
             return False, "{} has default instagram profile picture".format(username)
 
 
     #Skip business
     if skip_business:
         #If is business account skip under conditions
-        if json.loads(pre)['graphql']['user']['is_business_account']:
-            category = json.loads(pre)['graphql']['user']['business_category_name']
+        if user_data['is_business_account']:
+            category = user_data['business_category_name']
             if len(skip_business_categories) == 0:
                 #skip if not in dont_include
                 if category not in dont_skip_business_categories:

--- a/instapy/util.py
+++ b/instapy/util.py
@@ -219,7 +219,6 @@ def validate_username(browser,
         except WebDriverException:
             logger.error("~cannot get the post profile pic url")
             return False, "---> Sorry, couldn't get if user profile pic url\n"
-        print(profile_pic)
         if profile_pic in default_profile_pic_instagram or str(profile_pic).find("11906329_960233084022564_1448528159_a.jpg") > 0:
             return False, "{} has default instagram profile picture\n".format(username)
 

--- a/quickstart_templates/like_by_tag_interact_unfollow.py
+++ b/quickstart_templates/like_by_tag_interact_unfollow.py
@@ -1,80 +1,59 @@
 """This script is automatically executed every 6h on my server via cron"""
 
 # additional imports random amount of likes and unfollows
-import json
 import random
 
 from instapy import InstaPy
 from instapy.util import smart_run
 
 
-####
-def getUsername():
-    with open('../../../../Manutenzione_PC_Portable/InstaPy-master/logs/file.txt', 'r') as input:
-        d = json.load(input)
-    return d['username']
-
-
-def getPassword():
-    with open('../../../../Manutenzione_PC_Portable/InstaPy-master/logs/file.txt', 'r') as input:
-        d = json.load(input)
-    return d['psw']
-
 
 # login credentials
-insta_username = getUsername()
-insta_password = getPassword()
-####
+insta_username = ''
+insta_password = ''
 
-insta_username = ""
-insta_password = ""
-
-dont_likes = ['sex', 'nude', 'naked', 'beef', 'pork', 'seafood',
-              'egg', 'chicken', 'cheese', 'sausage', 'lobster',
-              'fisch', 'schwein', 'lamm', 'rind', 'kuh', 'meeresfrüchte',
-              'schaf', 'ziege', 'hummer', 'yoghurt', 'joghurt', 'dairy',
-              'meal', 'food', 'eat', 'pancake', 'cake', 'dessert',
-              'protein', 'essen', 'mahl', 'breakfast', 'lunch',
-              'dinner', 'turkey', 'truthahn', 'plate', 'bacon',
-              'sushi', 'burger', 'salmon', 'shrimp', 'steak',
-              'schnitzel', 'goat', 'oxtail', 'mayo', 'fur', 'leather',
-              'cream', 'hunt', 'gun', 'shoot', 'slaughter', 'pussy',
-              'breakfast', 'dinner', 'lunch']
+dont_likes = ['sex','nude','naked','beef','pork','seafood',
+            'egg','chicken','cheese','sausage','lobster',
+            'fisch','schwein','lamm','rind','kuh','meeresfrüchte',
+            'schaf','ziege','hummer','yoghurt','joghurt','dairy',
+            'meal','food','eat','pancake','cake','dessert',
+            'protein','essen','mahl','breakfast','lunch',
+            'dinner','turkey','truthahn','plate','bacon',
+            'sushi','burger','salmon','shrimp','steak',
+            'schnitzel','goat','oxtail','mayo','fur','leather',
+            'cream','hunt','gun','shoot','slaughter','pussy',
+            'breakfast','dinner','lunch']
 
 friends = ['list of friends I do not want to interact with']
 
-like_tag_list = ['vegan', 'veganfoodshare', 'veganfood', 'whatveganseat', 'veganfoodie', 'veganism', 'govegan',
-                 'veganism', 'vegansofig', 'veganfoodshare', 'veganfit', 'veggies']
+like_tag_list = ['vegan','veganfoodshare', 'veganfood', 'whatveganseat', 'veganfoodie', 'veganism', 'govegan', 'veganism', 'vegansofig', 'veganfoodshare', 'veganfit', 'veggies']
 
 # prevent posts that contain some plantbased meat from being skipped
 ignore_list = ['vegan', 'veggie', 'plantbased']
 
 accounts = ['accounts with similar content']
 
-"""session = InstaPy(username=insta_username,
-                      password=insta_password,
-                        headless_browser=True)"""
+
 session = InstaPy(username=insta_username,
-                      password=insta_password)
+                      password=insta_password,
+                      headless_browser=True)
 
 with smart_run(session):
     session.login()
 
     # settings
     session.set_relationship_bounds(enabled=True,
-                                    max_followers=15000, min_posts=5, max_posts=100)
+				   max_followers=15000)
 
-    #session.set_dont_include(friends)
-    #session.set_dont_like(dont_likes)
-    #session.set_ignore_if_contains(ignore_list)
+    session.set_dont_include(friends)
+    session.set_dont_like(dont_likes)
+    session.set_ignore_if_contains(ignore_list)
 
-    #session.set_user_interact(amount=2, randomize=True, percentage=60)
-    #session.set_do_follow(enabled=True, percentage=40)
+    session.set_user_interact(amount=2, randomize=True, percentage=60)
+    session.set_do_follow(enabled=True, percentage=40)
     session.set_do_like(enabled=True, percentage=80)
-    session.like_by_users(['frasca2', 'drusianialberto', 'instaosso_', 'natgeo'], amount=1)
 
     # actions
-    #session.like_by_tags(random.sample(like_tag_list, 3), amount=random.randint(50, 100), interact=True)
+    session.like_by_tags(random.sample(like_tag_list, 3), amount=random.randint(50, 100), interact=True)
 
-    #session.unfollow_users(amount=random.randint(75, 150), InstapyFollowed=(True, "all"), style="FIFO",
-    #                      unfollow_after=90 * 60 * 60, sleep_delay=501)
+    session.unfollow_users(amount=random.randint(75,150), InstapyFollowed=(True, "all"), style="FIFO", unfollow_after=90*60*60, sleep_delay=501)

--- a/quickstart_templates/like_by_tag_interact_unfollow.py
+++ b/quickstart_templates/like_by_tag_interact_unfollow.py
@@ -1,59 +1,80 @@
 """This script is automatically executed every 6h on my server via cron"""
 
 # additional imports random amount of likes and unfollows
+import json
 import random
 
 from instapy import InstaPy
 from instapy.util import smart_run
 
 
+####
+def getUsername():
+    with open('../../../../Manutenzione_PC_Portable/InstaPy-master/logs/file.txt', 'r') as input:
+        d = json.load(input)
+    return d['username']
+
+
+def getPassword():
+    with open('../../../../Manutenzione_PC_Portable/InstaPy-master/logs/file.txt', 'r') as input:
+        d = json.load(input)
+    return d['psw']
+
 
 # login credentials
-insta_username = ''
-insta_password = ''
+insta_username = getUsername()
+insta_password = getPassword()
+####
 
-dont_likes = ['sex','nude','naked','beef','pork','seafood',
-            'egg','chicken','cheese','sausage','lobster',
-            'fisch','schwein','lamm','rind','kuh','meeresfrüchte',
-            'schaf','ziege','hummer','yoghurt','joghurt','dairy',
-            'meal','food','eat','pancake','cake','dessert',
-            'protein','essen','mahl','breakfast','lunch',
-            'dinner','turkey','truthahn','plate','bacon',
-            'sushi','burger','salmon','shrimp','steak',
-            'schnitzel','goat','oxtail','mayo','fur','leather',
-            'cream','hunt','gun','shoot','slaughter','pussy',
-            'breakfast','dinner','lunch']
+insta_username = ""
+insta_password = ""
+
+dont_likes = ['sex', 'nude', 'naked', 'beef', 'pork', 'seafood',
+              'egg', 'chicken', 'cheese', 'sausage', 'lobster',
+              'fisch', 'schwein', 'lamm', 'rind', 'kuh', 'meeresfrüchte',
+              'schaf', 'ziege', 'hummer', 'yoghurt', 'joghurt', 'dairy',
+              'meal', 'food', 'eat', 'pancake', 'cake', 'dessert',
+              'protein', 'essen', 'mahl', 'breakfast', 'lunch',
+              'dinner', 'turkey', 'truthahn', 'plate', 'bacon',
+              'sushi', 'burger', 'salmon', 'shrimp', 'steak',
+              'schnitzel', 'goat', 'oxtail', 'mayo', 'fur', 'leather',
+              'cream', 'hunt', 'gun', 'shoot', 'slaughter', 'pussy',
+              'breakfast', 'dinner', 'lunch']
 
 friends = ['list of friends I do not want to interact with']
 
-like_tag_list = ['vegan','veganfoodshare', 'veganfood', 'whatveganseat', 'veganfoodie', 'veganism', 'govegan', 'veganism', 'vegansofig', 'veganfoodshare', 'veganfit', 'veggies']
+like_tag_list = ['vegan', 'veganfoodshare', 'veganfood', 'whatveganseat', 'veganfoodie', 'veganism', 'govegan',
+                 'veganism', 'vegansofig', 'veganfoodshare', 'veganfit', 'veggies']
 
 # prevent posts that contain some plantbased meat from being skipped
 ignore_list = ['vegan', 'veggie', 'plantbased']
 
 accounts = ['accounts with similar content']
 
-
-session = InstaPy(username=insta_username,
+"""session = InstaPy(username=insta_username,
                       password=insta_password,
-                      headless_browser=True)
+                        headless_browser=True)"""
+session = InstaPy(username=insta_username,
+                      password=insta_password)
 
 with smart_run(session):
     session.login()
 
     # settings
     session.set_relationship_bounds(enabled=True,
-				   max_followers=15000)
+                                    max_followers=15000, min_posts=5, max_posts=100)
 
-    session.set_dont_include(friends)
-    session.set_dont_like(dont_likes)
-    session.set_ignore_if_contains(ignore_list)
+    #session.set_dont_include(friends)
+    #session.set_dont_like(dont_likes)
+    #session.set_ignore_if_contains(ignore_list)
 
-    session.set_user_interact(amount=2, randomize=True, percentage=60)
-    session.set_do_follow(enabled=True, percentage=40)
+    #session.set_user_interact(amount=2, randomize=True, percentage=60)
+    #session.set_do_follow(enabled=True, percentage=40)
     session.set_do_like(enabled=True, percentage=80)
+    session.like_by_users(['frasca2', 'drusianialberto', 'instaosso_', 'natgeo'], amount=1)
 
     # actions
-    session.like_by_tags(random.sample(like_tag_list, 3), amount=random.randint(50, 100), interact=True)
-    
-    session.unfollow_users(amount=random.randint(75,150), InstapyFollowed=(True, "all"), style="FIFO", unfollow_after=90*60*60, sleep_delay=501)
+    #session.like_by_tags(random.sample(like_tag_list, 3), amount=random.randint(50, 100), interact=True)
+
+    #session.unfollow_users(amount=random.randint(75, 150), InstapyFollowed=(True, "all"), style="FIFO",
+    #                      unfollow_after=90 * 60 * 60, sleep_delay=501)


### PR DESCRIPTION
#### This is used to skip users with certain condition
```python
session.set_skip_users(skip_private=True,
                       private_percentage=100,
                       skip_no_profile_pic=False,
                       no_profile_pic_percentage=100,
                       skip_business=False,
                       business_percentage=100,
                       skip_business_categories=[],
                       dont_skip_business_categories=[])
```
##### Skip private account
**This is done by default**
```python
session.set_skip_users(skip_private=True,
                       private_percentage=100)
```
Will skip users that have private account, even if are followed by running account.
You can set a percentage of skipping:
    _private_percentage_= 100 always skip private users
    _private_percentage_= 0 never skip private users (so set skip_private=False)

##### Skip users that don't have profile picture

```python
session.set_skip_users(skip_private=True,
                       skip_no_profile_pic=True,
                       no_profile_pic_percentage=100)
```
Will skip users that haven't uploaded yet a profile picture
You can set a percentage of skipping:
    _no_profile_pic_percentage_= 100 always skip users without profile picture
    _no_profile_pic_percentage_= 0 never skip users without profile picture (so set _skip_no_profile_pic_=False)

##### Skip users that have business account

```python
session.set_skip_users(skip_private=True,
                       skip_no_profile_pic=True,
		               skip_business=True,
		               business_percentage=100)
```
This will skip all users that have business account activated.
You can set a percentage of skipping:
    _business_percentage_= 100 always skip business users
    _business_percentage_= 0 never skip business users (so set _skip_business_=False)

**N.B.:** This _business_percentage_ parameter works only if no _skip_business_categories_ or _dont_skip_business_categories_ are provided!

###### Skip only users that have certain business account
```python
session.set_skip_users(skip_private=True,
                       skip_no_profile_pic=True,
		       skip_business=True,
		       skip_business_categories=['Creators & Celebrities'])
```
This will skip all business accounts that have category in given list
**N.B.** In _skip_business_categories_ you can add more than one category
###### Skip all business accounts, except from list given
```python
session.set_skip_users(skip_private=True,
                       skip_no_profile_pic=True,
		       skip_business=True,
		       dont_skip_business_categories=['Creators & Celebrities'])
```
This will skip all business accounts except the ones that have a category that matches one item in the list of _dont_skip_business_categories_
**N.B.** If both _dont_skip_business_categories_ and _skip_business_categories_, InstaPy will skip only business accounts in the list given from _skip_business_categories_.