### PR TITLE
Updates for Working with Clarifai API Image 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,7 @@ logs/
 # pytest
 .pytest_cache/
 tests/logs
+
+# Pipfile
+Pipfile
+Pipfile.lock

--- a/README.md
+++ b/README.md
@@ -1387,9 +1387,9 @@ session.end()
 ### Enabling Imagechecking
 
 ```python
-# default enabled=False , enables the checking with the clarifai api (image
+# default enabled=False , enables the checking with the Clarifai API (image
 # tagging) if secret and proj_id are not set, it will get the environment
-# variables 'CLARIFAI_API_KEY'
+# variables 'CLARIFAI_API_KEY'.
 
 session.set_use_clarifai(enabled=True, api_key='xxx')
 ```
@@ -1401,14 +1401,25 @@ session.set_use_clarifai(enabled=True, api_key='xxx')
 
 session.clarifai_check_img_for(['nsfw'])
 ```
+
+### Filtering by keyword
+
+```python
+# uses the clarifai api to check if the image concepts contain the keyword(s)
+# -> won't comment if image contains the keyword
+
+session.clarifai_check_img_for(['building'])
+```
 ### Specialized comments for images with specific content
 
 ```python
-# checks the image for keywords food and lunch, if both are found,
-# comments with the given comments. If full_match is False (default), it only
+# checks the image for keywords food and lunch. To check for both, set full_match in 
+# in session.set_use_clarifia to True, and if both keywords are found,
+# InstaPy will comment with the given comments. If full_match is False (default), it only
 # requires a single tag to match Clarifai results.
 
-session.clarifai_check_img_for(['food', 'lunch'], comment=True, comments=['Tasty!', 'Yum!'], full_match=True)
+session.set_use_clarifai(enabled=True, api_key='xxx', full_match=True)
+session.clarifai_check_img_for(['food', 'lunch'], comment=True, comments=['Tasty!', 'Yum!'])
 ```
 
 ###### Check out [https://clarifai.com/demo](https://clarifai.com/demo) to see some of the available tags.</h6>

--- a/instapy/clarifai_util.py
+++ b/instapy/clarifai_util.py
@@ -1,9 +1,10 @@
 """Module which handles the clarifai api and checks
 the image for invalid content"""
-from clarifai.rest import ClarifaiApp, Image as ClImage
+from clarifai.rest import ClarifaiApp
 
 
-def check_image(browser, clarifai_api_key, img_tags, img_tags_skip_if_contain, logger, full_match=False, picture_url=None):
+def check_image(browser, clarifai_api_key, img_tags, img_tags_skip_if_contain, logger,
+                full_match=False, picture_url=None):
     """Uses the link to the image to check for invalid content in the image"""
     clarifai_api = ClarifaiApp(api_key=clarifai_api_key)
     # set req image to given one or get it from current page
@@ -11,22 +12,24 @@ def check_image(browser, clarifai_api_key, img_tags, img_tags_skip_if_contain, l
         img_link = get_imagelink(browser)
     else:
         img_link = picture_url
-    # Uses Clarifai's v2 API
-    model = clarifai_api.models.get('general-v1.3')
-    image = ClImage(url=img_link)
-    result = model.predict([image])
-    clarifai_tags = [concept.get('name').lower() for concept in result[
-        'outputs'][0]['data']['concepts']]
+    # Select the appropriate Clarifai model
+    if ['nsfw'] in (tags for (tags, should_comment, comments) in img_tags):
+        model = clarifai_api.models.get('nsfw-v1.0')
+    else:
+        model = clarifai_api.public_models.general_model
+    # Get Clarifai Response
+    result = model.predict_by_url(img_link)
+    # Use get_clarifai_tags method to filter results returned from Clarifai
+    clarifai_tags = get_clarifai_tags(result)
 
     for (tags, should_comment, comments) in img_tags:
-        if should_comment:
-            if given_tags_in_result(tags, clarifai_tags, full_match):
-                return True, comments
-        else:
-            if given_tags_in_result(tags, clarifai_tags, full_match):
-                if not given_tags_in_result(img_tags_skip_if_contain, clarifai_tags, full_match):
-                    logger.info('Not Commenting, image reco contains: "{}".'.format(', '.join(list(set(clarifai_tags)&set(tags)))))
-                    return False, []
+        if should_comment and given_tags_in_result(tags, clarifai_tags, full_match):
+            return True, comments
+        elif given_tags_in_result(tags, clarifai_tags, full_match):
+            if not given_tags_in_result(img_tags_skip_if_contain, clarifai_tags, full_match):
+                logger.info('Not Commenting, image contains concept(s): "{}".'.format(
+                    ', '.join(list(set(clarifai_tags) & set(tags)))))
+                return False, []
 
     return True, []
 
@@ -41,5 +44,18 @@ def given_tags_in_result(search_tags, clarifai_tags, full_match=False):
 
 def get_imagelink(browser):
     """Gets the imagelink from the given webpage open in the browser"""
-    return browser.find_element_by_xpath('//img[@class = "FFVAD"]') \
+    return browser.find_element_by_xpath('//img[@class = "FFVAD" or @class="_8jZFn"]') \
         .get_attribute('src')
+
+
+def get_clarifai_tags(clarifai_response):
+    """Get the response from the Clarifai API and return results filtered by
+    models with 50% or higher confidence"""
+    results = []
+    concepts = [{concept.get('name').lower(): concept.get('value')}
+                for concept in clarifai_response['outputs'][0]['data']['concepts']]
+    for concept in concepts:
+        if float([x for x in concept.values()][0]) > 0.50:
+            results.append(str([x for x in concept.keys()][0]))
+
+    return results

--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -605,7 +605,7 @@ class InstaPy:
         return self
 
     def clarifai_check_img_for(self, tags=None, tags_skip=None, comment=False, comments=None):
-        """Defines the tags, the images should be checked for"""
+        """Defines the tags the images should be checked for"""
         if self.aborting:
             return self
 
@@ -613,9 +613,14 @@ class InstaPy:
             self.use_clarifai = False
         elif tags:
             self.clarifai_img_tags.append((tags, comment, comments))
-            self.clarifai_img_tags_skip = tags_skip
+            self.clarifai_img_tags_skip = tags_skip or []
 
         return self
+
+    def query_clarifai(self):
+        """Method for querying Clarifai using parameters set in clarifai_check_img_for"""
+        return check_image(self.browser, self.clarifai_api_key, self.clarifai_img_tags,
+                           self.clarifai_img_tags_skip, self.logger, self.clarifai_full_match)
 
     def follow_commenters(self, usernames, amount=10, daysold=365, max_pic=50, sleep_delay=600, interact=False):
         """ Follows users' commenters """
@@ -1158,14 +1163,8 @@ class InstaPy:
 
                             if self.use_clarifai and (following or commenting):
                                 try:
-                                    checked_img, temp_comments = (
-                                        check_image(self.browser,
-                                                    self.clarifai_api_key,
-                                                    self.clarifai_img_tags,
-                                                    self.clarifai_img_tags_skip,
-                                                    self.logger,
-                                                    self.clarifai_full_match)
-                                    )
+                                    checked_img, temp_comments = (self.query_clarifai())
+
                                 except Exception as err:
                                     self.logger.error(
                                         'Image check error: {}'.format(err))
@@ -1347,14 +1346,8 @@ class InstaPy:
 
                         if self.use_clarifai:
                             try:
-                                checked_img, temp_comments = (
-                                    check_image(self.browser,
-                                                self.clarifai_api_key,
-                                                self.clarifai_img_tags,
-                                                self.clarifai_img_tags_skip,
-                                                self.logger,
-                                                self.clarifai_full_match)
-                                )
+                                checked_img, temp_comments = (self.query_clarifai())
+
                             except Exception as err:
                                 self.logger.error(
                                     'Image check error: {}'.format(err))
@@ -1551,14 +1544,8 @@ class InstaPy:
 
                             if self.use_clarifai and (following or commenting):
                                 try:
-                                    checked_img, temp_comments = (
-                                        check_image(self.browser,
-                                                    self.clarifai_api_key,
-                                                    self.clarifai_img_tags,
-                                                    self.clarifai_img_tags_skip,
-                                                    self.logger,
-                                                    self.clarifai_full_match)
-                                    )
+                                    checked_img, temp_comments = (self.query_clarifai())
+
                                 except Exception as err:
                                     self.logger.error(
                                         'Image check error: {}'.format(err))
@@ -1793,14 +1780,8 @@ class InstaPy:
 
                             if self.use_clarifai and (following or commenting):
                                 try:
-                                    checked_img, temp_comments = (
-                                        check_image(self.browser,
-                                                    self.clarifai_api_key,
-                                                    self.clarifai_img_tags,
-                                                    self.clarifai_img_tags_skip,
-                                                    self.logger,
-                                                    self.clarifai_full_match)
-                                    )
+                                    checked_img, temp_comments = (self.query_clarifai())
+
                                 except Exception as err:
                                     self.logger.error(
                                         'Image check error: {}'.format(err))
@@ -2028,13 +2009,7 @@ class InstaPy:
 
                                 if self.use_clarifai and commenting:
                                     try:
-                                        checked_img, temp_comments = (
-                                            check_image(self.browser,
-                                                        self.clarifai_api_key,
-                                                        self.clarifai_img_tags,
-                                                        self.clarifai_img_tags_skip,
-                                                        self.logger,
-                                                        self.clarifai_full_match))
+                                        checked_img, temp_comments = (self.query_clarifai())
 
                                     except Exception as err:
                                         self.logger.error(
@@ -2963,15 +2938,8 @@ class InstaPy:
                                     if (self.use_clarifai and
                                             (following or commenting)):
                                         try:
-                                            checked_img, temp_comments = (
-                                                check_image(
-                                                    self.browser,
-                                                    self.clarifai_api_key,
-                                                    self.clarifai_img_tags,
-                                                    self.clarifai_img_tags_skip,
-                                                    self.logger,
-                                                    self.clarifai_full_match)
-                                            )
+                                            checked_img, temp_comments = (self.query_clarifai())
+
                                         except Exception as err:
                                             self.logger.error(
                                                 'Image check error:'
@@ -3503,13 +3471,7 @@ class InstaPy:
 
                         if self.use_clarifai and (following or commenting):
                             try:
-                                checked_img, temp_comments = (
-                                    check_image(self.browser,
-                                                self.clarifai_api_key,
-                                                self.clarifai_img_tags,
-                                                self.logger,
-                                                self.clarifai_full_match)
-                                )
+                                checked_img, temp_comments = (self.query_clarifai())
                             except Exception as err:
                                 self.logger.error(
                                     'Image check error: {}'.format(err))


### PR DESCRIPTION
I made several updates to both in `instapy.py` and `clarifai_util.py` to resolve some issues caused when using the Clarifai API.

In `instapy.py`, I made the following updates:

To reduce the amount of duplicate code used (and chance for errors to arise), I added the instance method `query_clarifai` to call the `check_image` method. Updated `clarifai_check_img_for` so that if no value was provided for a `tags_skip` it would default to an empty list (i.e. `[]`).

In `clarifai_util.py` the following updates were made:

Removed import of `Image` from `clarifai.rest` and use `predict_by_url` instead of `predict`. 

Added a check to see if the `nsfw` tag is used. If detected Clarifai’s nsfw model will be used for prediction. At present, only two models, nsfw and general, are being used. This is a feature which could be expanded on in the future to include additional models that Clarifai provides. 

Changed the xpath selector to `//img[@class = "FFVAD" or @class="_8jZFn”]` to ensure that the function also checks for keyframe images for video posts. 

Added `get_clarifai_tags` function to filter the results from returned from Clarifia. At present, the confidence level is set to log concepts with 50% or higher confidence. If the results are not filtered, any request to nsfw model, for example, will return both nsfw and sfw concepts. The end result being that every image queried would be flagged as nsfw.

Current implementation not perfect as the nsfw test can still be fooled if the keyframe image for a posted video is considered sfw. Also, 50% confidence threshold may still allow some suggestive content to get through. 


