### PR TITLE
Duplicate comments fix

### DIFF
--- a/instapy/comment_util.py
+++ b/instapy/comment_util.py
@@ -47,7 +47,7 @@ def open_comment_section(browser, logger):
 
 
 
-def comment_image(browser, username, comments, blacklist, logger, logfolder):
+def comment_image(browser, username, comments, blacklist, logger, logfolder, user_id):
     """Checks if it should comment on the image"""
     # check action availability
     if quota_supervisor('comments') == 'jump':
@@ -62,6 +62,19 @@ def comment_image(browser, username, comments, blacklist, logger, logfolder):
 
     try:
         if len(comment_input) > 0:
+            try:
+                comment_list = list(browser.execute_script(
+                    "return window._sharedData.entry_data."
+                    "PostPage[0].graphql.shortcode_media.edge_media_to_comment.edges"))
+                for d in comment_list:
+                    if d['node']['owner']['id'] == user_id:
+                        disapproval_reason = "This post is already commented by you! Skipping post..."
+                        return False, disapproval_reason
+
+            except Exception as e:
+                logger.info("Failed to check if post was already commented!\n\t{}".format(str(e).encode("utf-8")))
+                return True, 'Verification failure'
+
             comment_input[0].clear()
             comment_input = get_comment_input(browser)
             comment_to_be_sent = rand_comment+' '   # an extra space is added here to forces the input box to update the reactJS core

--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -108,6 +108,7 @@ class InstaPy:
 
         self.username = username or os.environ.get('INSTA_USER')
         self.password = password or os.environ.get('INSTA_PW')
+        self.user_id = 0
         Settings.profile["name"] = self.username
         self.nogui = nogui
         self.logfolder = Settings.log_location + os.path.sep
@@ -402,6 +403,9 @@ class InstaPy:
 
         self.followed_by = log_follower_num(self.browser, self.username, self.logfolder)
         self.following_num = log_following_num(self.browser, self.username, self.logfolder)
+        self.user_id = self.browser.execute_script(
+            "return window._sharedData.config."
+            "viewer.id")
 
         return self
 
@@ -1205,7 +1209,8 @@ class InstaPy:
                                                                        comments,
                                                                        self.blacklist,
                                                                        self.logger,
-                                                                       self.logfolder)
+                                                                       self.logfolder,
+                                                                       self.user_id)
                                     if comment_state == True:
                                         commented += 1
 
@@ -1387,7 +1392,8 @@ class InstaPy:
                                                                    comments,
                                                                    self.blacklist,
                                                                    self.logger,
-                                                                   self.logfolder)
+                                                                   self.logfolder,
+                                                                   self.user_id)
                                 if comment_state == True:
                                     commented += 1
                                     # reset jump counter after a successful comment
@@ -1586,7 +1592,8 @@ class InstaPy:
                                                                        comments,
                                                                        self.blacklist,
                                                                        self.logger,
-                                                                       self.logfolder)
+                                                                       self.logfolder,
+                                                                       self.user_id)
                                     if comment_state == True:
                                         commented += 1
 
@@ -1822,7 +1829,8 @@ class InstaPy:
                                                                        comments,
                                                                        self.blacklist,
                                                                        self.logger,
-                                                                       self.logfolder)
+                                                                       self.logfolder,
+                                                                       self.user_id)
                                     if comment_state == True:
                                         commented += 1
 
@@ -2051,7 +2059,8 @@ class InstaPy:
                                                                            comments,
                                                                            self.blacklist,
                                                                            self.logger,
-                                                                           self.logfolder)
+                                                                           self.logfolder,
+                                                                           self.user_id)
                                         if comment_state == True:
                                             commented += 1
 
@@ -3511,7 +3520,8 @@ class InstaPy:
                                                                    comments,
                                                                    self.blacklist,
                                                                    self.logger,
-                                                                   self.logfolder)
+                                                                   self.logfolder,
+                                                                   self.user_id)
                                 if comment_state == True:
                                     commented += 1
 


### PR DESCRIPTION
I've noticed that this issue isn't fixed even though several people mentioned it in the issues (as well as myself a while ago) and it I think it is a serious issue so I decided to share my fix.

Basically, I have added a user_id parameter to be logged at start and passed every time to **comment_image** method. In the method itself it goes through each comment and checks if any of the comments author id is your user id and if so, it skips the post.

Perhaps this code could be optimized, I don't know, this was actually my first interaction with python but it works like a charm for me. Any improvements are welcome.

Hope it helps.