### PR TITLE
Support for Checking Video Inputs with Clarifai

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ _The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [Unreleased] - 2018-11-01
 ### Added
 - Interact with tagged images of users, and validation of a user to be optional
-- Use Clarifai to check video content by setting `check_video=True` in `session.set_use_clarifai`. By default `check_video` is set to `False` and should only be used if necessary (_see **README**_ for further details). Clarifai will check one frame of video for content for every one second of video. Feature to be updated with ability to check frames every X seconds as soon as Clarifai enables that feature in their API.
+- Use Clarifai to check video content. By default deactivated and should only be used if necessary.
 
 ## [Unreleased] - 2018-10-29
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ _The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [Unreleased] - 2018-11-01
 ### Added
 - Interact with tagged images of users, and validation of a user to be optional
+- Use Clarifai to check video content by setting `check_video=True` in `session.set_use_clarifai`. By default `check_video` is set to `False` and should only be used if necessary (_see **README**_ for further details). Clarifai will check one frame of video for content for every one second of video. Feature to be updated with ability to check frames every X seconds as soon as Clarifai enables that feature in their API.
 
 ## [Unreleased] - 2018-10-29
 ### Added

--- a/README.md
+++ b/README.md
@@ -1562,6 +1562,21 @@ We have 3 options:
 2. user:pass@ip:port
 3. None
 
+### Checking Video
+**WARNING**: Clarifai checks one frame of video for content for every second of video. **That is, in a 60 second video, 60 billable operations would be run for every model that the video is being checked against.** Running checks on video should only be used if you have special needs and are prepared to use a large number of billable operations.
+
+To have Clarifai run a predict on video posts, you can set the `check_video` argument in `session.set_use_clarifai` to `True`. By default, this argument is set to `False`. Even if you do not choose to check the entire video, Clarifai will still check the video's keyframe for content.
+
+For example:
+
+```python
+session.set_use_clarifai(enabled=True, api_key='xxx', check_video=True)
+```
+
+With video inputs, Clarifai's Predict API response will return a list of concepts at a rate of one frame for every second of a video.
+
+Be aware that you cannot check video using a `workflow` and that only a select number of public models are currently supported. Models currently supported are: Apparel, Food, General, NSFW, Travel, and Wedding. In the event that the models being used do not support video inputs or you are using a workflow, the video's keyframe will still be checked for content.
+
 ##### Check out [https://clarifai.com/demo](https://clarifai.com/demo) to see some of the available tags.</h6>
 
 ## Running on a Server

--- a/instapy/clarifai_util.py
+++ b/instapy/clarifai_util.py
@@ -15,9 +15,9 @@ def check_image(
     workflow,
     probability,
     full_match=False,
-    picture_url=None,
     check_video=False,
     proxy=None,
+    picture_url=None,
 ):
 
     try:
@@ -37,7 +37,7 @@ def check_image(
             source_link = [picture_url]
 
         # No image in page
-        if source_link is None:
+        if not source_link:
             return True, [], []
 
         # Check image using workflow if provided. If no workflow, check image using model(s)
@@ -63,7 +63,9 @@ def check_image(
                 clarifai_tags.extend(results)
 
         logger.info(
-            'img_link {} got predicted result:\n{}'.format(source_link, clarifai_tags)
+            'source_link {} got predicted result(s):\n{}'.format(
+                source_link, clarifai_tags
+            )
         )
 
         # Will not comment on an image if any of the tags in img_tags_skip_if_contain are matched

--- a/instapy/clarifai_util.py
+++ b/instapy/clarifai_util.py
@@ -214,6 +214,18 @@ def get_clarifai_tags(clarifai_response, probability):
     except KeyError:
         pass
 
+    # Parse response for Video input
+    try:
+        for frame in clarifai_response['data']['frames']:
+            concepts.extend(
+                [
+                    {concept.get('name').lower(): concept.get('value')}
+                    for concept in frame['data']['concepts']
+                ]
+            )
+    except KeyError:
+        pass
+
     # Filter concepts based on probability threshold
     for concept in concepts:
         if float([x for x in concept.values()][0]) > probability:

--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -172,6 +172,7 @@ class InstaPy:
         self.clarifai_img_tags = []
         self.clarifai_img_tags_skip = []
         self.clarifai_full_match = False
+        self.clarifai_check_video = False
         self.clarifai_proxy = None
 
         self.potency_ratio = 1.3466
@@ -613,6 +614,7 @@ class InstaPy:
                          workflow=None,
                          probability=0.50,
                          full_match=False,
+                         check_video=False,
                          proxy=None):
         """
         Defines if the clarifai img api should be used
@@ -638,6 +640,7 @@ class InstaPy:
         self.clarifai_workflow = workflow or []
         self.clarifai_probability = probability
         self.clarifai_full_match = full_match
+        self.clarifai_check_video = check_video
 
         if proxy is not None:
             self.clarifai_proxy = 'https://' + proxy
@@ -708,7 +711,8 @@ class InstaPy:
         return check_image(self.browser, self.clarifai_api_key, self.clarifai_img_tags,
                            self.clarifai_img_tags_skip, self.logger, self.clarifai_models,
                            self.clarifai_workflow, self.clarifai_probability,
-                           self.clarifai_full_match, proxy=self.clarifai_proxy)
+                           self.clarifai_full_match, self.clarifai_check_video,
+                           proxy=self.clarifai_proxy)
 
 
     def follow_commenters(self, usernames, amount=10, daysold=365, max_pic=50, sleep_delay=600, interact=False):


### PR DESCRIPTION
Updated a couple of the functions in clarifai_util.py to add support for checking videos via the Clarifai API. Since workflows do not take video inputs and only a few of the models accept video inputs, in many cases the keyframe will still be checked for content. 

Also fixed blocks for compiling the list of concepts for the Celebrity and Demographics models.