### PR TITLE
[Proposition] Add option to inject selenium driver for remote session

### DIFF
--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -363,20 +363,30 @@ class InstaPy:
 
         return self
 
-    def set_selenium_remote_session(self, selenium_url=''):
-        """Starts remote session for a selenium server.
-         Useful for docker setup."""
+    def set_selenium_remote_session(self, selenium_url='', selenium_driver=None):
+        """
+        Starts remote session for a selenium server.
+        Creates a new selenium driver instance for remote session or uses provided
+        one. Useful for docker setup.
+
+        :param selenium_url: string
+        :param selenium_driver: selenium WebDriver
+        :return: self
+        """
         if self.aborting:
             return self
 
-        if self.use_firefox:
-            self.browser = webdriver.Remote(
-                command_executor=selenium_url,
-                desired_capabilities=DesiredCapabilities.FIREFOX)
+        if selenium_driver:
+            self.browser = selenium_driver
         else:
-            self.browser = webdriver.Remote(
-                command_executor=selenium_url,
-                desired_capabilities=DesiredCapabilities.CHROME)
+            if self.use_firefox:
+                self.browser = webdriver.Remote(
+                    command_executor=selenium_url,
+                    desired_capabilities=DesiredCapabilities.FIREFOX)
+            else:
+                self.browser = webdriver.Remote(
+                    command_executor=selenium_url,
+                    desired_capabilities=DesiredCapabilities.CHROME)
 
         message = "Session started!"
         highlight_print(self.username, message, "initialization", "info", self.logger)


### PR DESCRIPTION
Hey,
I wanted to propose making remote selenium driver injectable. This would allow providing pre-configured driver instance to InstaPy, which now is impossible. 
My use-case is running several sessions in parallel from Celery workers which fails with current configuration of remote Selenium session.
Let me know what you think, sorry for not making an issue first to discuss it but it's such a small change that I just went ahead and did it 😄 