### PR TITLE
verify private users in get_links_for_username; small fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ The **goal** of this file is explaining to the users of our project the notable 
 _The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)_.
 
 
+## [Unreleased] - 2018-11-07
+### Changed
+- Maintain names: 'person' for target user and 'username' for our running user
+- Verify private users in get_links_for_username
+
 ## [Unreleased] - 2018-11-01
 ### Added
 - Interact with tagged images of users, and validation of a user to be optional

--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -1792,9 +1792,11 @@ class InstaPy:
             try:
                 links = get_links_for_username(
                     self.browser,
+                    self.username,
                     username,
                     amount,
                     self.logger,
+                    self.logfolder,
                     randomize,
                     media)
 
@@ -2030,9 +2032,11 @@ class InstaPy:
 
             try:
                 links = get_links_for_username(self.browser,
+                                               self.username,
                                                username,
                                                amount,
                                                self.logger,
+                                               self.logfolder,
                                                randomize,
                                                media)
             except NoSuchElementException:
@@ -2281,9 +2285,11 @@ class InstaPy:
 
             try:
                 links = get_links_for_username(self.browser,
+                                               self.username,
                                                username,
                                                amount,
                                                self.logger,
+                                               self.logfolder,
                                                randomize,
                                                media,
                                                taggedImages=True)
@@ -2354,14 +2360,7 @@ class InstaPy:
 
                                 if self.use_clarifai and commenting:
                                     try:
-                                        checked_img, temp_comments = (
-                                            check_image(self.browser,
-                                                        self.clarifai_api_key,
-                                                        self.clarifai_img_tags,
-                                                        self.clarifai_img_tags_skip,
-                                                        self.logger,
-                                                        self.clarifai_full_match))
-
+                                        checked_img, temp_comments, clarifai_tags = (self.query_clarifai())
                                     except Exception as err:
                                         self.logger.error(
                                             'Image check error: {}'.format(err))

--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -2360,7 +2360,7 @@ class InstaPy:
 
                                 if self.use_clarifai and commenting:
                                     try:
-                                        checked_img, temp_comments, clarifai_tags = (self.query_clarifai())
+                                        checked_img, temp_comments, clarifai_tags = self.query_clarifai()
                                     except Exception as err:
                                         self.logger.error(
                                             'Image check error: {}'.format(err))

--- a/instapy/like_util.py
+++ b/instapy/like_util.py
@@ -328,8 +328,10 @@ def get_links_for_tag(browser,
 
 def get_links_for_username(browser,
                            username,
+                           person,
                            amount,
                            logger,
+                           logfolder,
                            randomize=False,
                            media=None,
                            taggedImages=False):
@@ -346,9 +348,9 @@ def get_links_for_username(browser,
         # Make it an array to use it in the following part
         media = [media]
 
-    logger.info('Getting {} image list...'.format(username))
+    logger.info('Getting {} image list...'.format(person))
 
-    user_link = "https://www.instagram.com/{}/".format(username)
+    user_link = "https://www.instagram.com/{}/".format(person)
     if taggedImages:
         user_link = user_link + 'tagged/'
 
@@ -358,17 +360,16 @@ def get_links_for_username(browser,
     body_elem = browser.find_element_by_tag_name('body')
     abort = True
 
-    try:
-        is_private = is_private_profile(browser, logger)
-    except:
-        logger.info('Interaction begin...')
-    else:
-        if is_private:
-            logger.warning('This user is private...')
-            return False
-
     if "Page Not Found" in browser.title:
         logger.error('Intagram error: The link you followed may be broken, or the page may have been removed...')
+        return False
+
+    # if private user, we can get links only if we following
+    following, follow_button = get_following_status(browser, 'profile', username, person, logger, logfolder)
+    if following == 'Following':
+        following = True
+    is_private = is_private_profile(browser, logger, following)
+    if (is_private is None) or (is_private is True and not following) or (following == 'Blocked'):
         return False
 
     #Get links
@@ -379,7 +380,7 @@ def get_links_for_username(browser,
 
     if posts_count is not None and amount > posts_count:
         logger.info("You have requested to get {} posts from {}'s profile page BUT"
-                    " there only {} posts available :D".format(amount, username, posts_count))
+                    " there only {} posts available :D".format(amount, person, posts_count))
         amount = posts_count
 
     while len(links) < amount:
@@ -391,12 +392,12 @@ def get_links_for_username(browser,
         sleep(0.66)
 
         # using `extend`  or `+=` results reference stay alive which affects previous assignment (can use `copy()` for it)
-        links = links + get_links(browser, username, logger, media, main_elem)
+        links = links + get_links(browser, person, logger, media, main_elem)
         links = sorted(set(links), key=links.index)
 
         if len(links) == len(initial_links):
             if attempt >= 7:
-                logger.info("There are possibly less posts than {} in {}'s profile page!".format(amount, username))
+                logger.info("There are possibly less posts than {} in {}'s profile page!".format(amount, person))
                 break
             else:
                 attempt += 1

--- a/instapy/like_util.py
+++ b/instapy/like_util.py
@@ -17,6 +17,7 @@ from .quota_supervisor import quota_supervisor
 
 from selenium.common.exceptions import WebDriverException
 from selenium.common.exceptions import NoSuchElementException
+from .unfollow_util import get_following_status
 
 
 

--- a/instapy/like_util.py
+++ b/instapy/like_util.py
@@ -366,7 +366,7 @@ def get_links_for_username(browser,
         return False
 
     # if private user, we can get links only if we following
-    following, follow_button = get_following_status(browser, 'profile', username, person, logger, logfolder)
+    following, follow_button = get_following_status(browser, 'profile', username, person, None, logger, logfolder)
     if following == 'Following':
         following = True
     is_private = is_private_profile(browser, logger, following)

--- a/instapy/unfollow_util.py
+++ b/instapy/unfollow_util.py
@@ -115,7 +115,7 @@ def get_following_status(browser, track, username, person, person_id, logger, lo
                         )
     failure_msg = "--> Unable to detect the following status of '{}'!"
     user_inaccessible_msg = ("Couldn't access the profile page of '{}'!"
-                             "\t~might have changed the username".format(username))
+                             "\t~might have changed the username".format(person))
 
     # check if the page is available
     valid_page = is_page_available(browser, logger)


### PR DESCRIPTION
I also think we shall maintain names: 'person' for target user and 'username' for our running user.