### PR TITLE
Add issue bot for automatic closing of stale issues

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,57 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+ # Number of days of inactivity before an Issue or Pull Request becomes stale
+ daysUntilStale: 30
+
+ # Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
+ # Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
+ daysUntilClose: 7
+
+ # Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
+ exemptLabels:
+   - pinned
+   - security
+   - bounty
+   - feature request
+
+ # Set to true to ignore issues in a project (defaults to false)
+ exemptProjects: false
+
+ # Set to true to ignore issues in a milestone (defaults to false)
+ exemptMilestones: false
+
+ # Label to use when marking as stale
+ staleLabel: wontfix
+
+ # Comment to post when marking as stale. Set to `false` to disable
+ markComment: >
+   This issue has been automatically marked as stale because it has not had
+   recent activity. It will be closed if no further activity occurs. Thank you
+   for your contributions.
+   > If this problem still occurs, please open a new issue 
+
+ # Comment to post when removing the stale label.
+ # unmarkComment: >
+ #   Your comment here.
+
+ # Comment to post when closing a stale Issue or Pull Request.
+ # closeComment: >
+ #   Your comment here.
+
+ # Limit the number of actions per hour, from 1-30. Default is 30
+ limitPerRun: 30
+
+ # Limit to only `issues` or `pulls`
+ only: issues
+
+ # Optionally, specify configuration settings that are specific to just 'issues' or 'pulls':
+ # pulls:
+ #   daysUntilStale: 30
+ #   markComment: >
+ #     This pull request has been automatically marked as stale because it has not had
+ #     recent activity. It will be closed if no further activity occurs. Thank you
+ #     for your contributions.
+
+ # issues:
+ #   exemptLabels:
+ #     - confirmed


### PR DESCRIPTION
Based on @converge idea about having a bot that closes old and stale issues to get a better overview on the still remaining issues and especially the most recent ones that haven't been fixed, this PR introduces a bot that marks issues where there was no activity in the last 30 days. After 7 more days the issue will then be closed.

Any comments or requests about the time till stale and time till close?

Thank you for this very good idea, @converge! 👍 

> P.S. we really need to get that PEP change working with the pipeline...