### PR TITLE
add line break to use citation in markdown

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -27,7 +27,8 @@
  markComment: >
    This issue has been automatically marked as stale because it has not had
    recent activity. It will be closed if no further activity occurs. Thank you
-   for your contributions.
+   for your contributions.   
+   
    > If this problem still occurs, please open a new issue 
 
  # Comment to post when removing the stale label.


### PR DESCRIPTION
The way the bot crates the stale text in the issues is not formatted correctly.
Changed it to be in a new line. Uses the citation the right way now,