### PR TITLE
Added location to image description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ The **goal** of this file is explaining to the users of our project the notable 
 
 _The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)_.
 
+## [Unreleased] - 2018-11-22
+### Fixed
+- "Added location to image_text in the check_link method in like_util.py, so the script also searches for mandatory words in the location information.
+
 ## [Unreleased] - 2018-11-17
 ### Fixed
 - "Cookie file not found, creating cookie..." bug fix

--- a/README.md
+++ b/README.md
@@ -838,7 +838,7 @@ session.like_by_tags(amount=10, use_smart_hashtags=True)
 session.set_mandatory_words(['#food', '#instafood'])
 ```
 
-`.set_mandatory_words` searches the description and owner comments for words and
+`.set_mandatory_words` searches the description, location and owner comments for words and
 will like the image if **all** of those words are in there
 
 ### Restricting Likes

--- a/instapy/like_util.py
+++ b/instapy/like_util.py
@@ -460,6 +460,8 @@ def check_link(browser, post_link, dont_like, mandatory_words, ignore_if_contain
         user_name = media['owner']['username']
         image_text = media['edge_media_to_caption']['edges']
         image_text = image_text[0]['node']['text'] if image_text else None
+        location = media['location']
+        location_name = location['name'] if location else None
         owner_comments = browser.execute_script('''
             latest_comments = window._sharedData.entry_data.PostPage[0].graphql.shortcode_media.edge_media_to_comment.edges;
             if (latest_comments === undefined) {
@@ -518,6 +520,11 @@ def check_link(browser, post_link, dont_like, mandatory_words, ignore_if_contain
     logger.info('Link: {}'.format(post_link.encode('utf-8')))
     logger.info('Description: {}'.format(image_text.encode('utf-8')))
 
+    """Append location to image_text so we can search through both in one go."""
+    if location_name:
+        logger.info('Location: {}'.format(location_name.encode('utf-8')))
+        image_text = image_text + '\n' + location_name
+    
     if mandatory_words :
         if not all((word in image_text for word in mandatory_words)) :
             return True, user_name, is_video, 'Mandatory words not fulfilled', "Not mandatory likes"


### PR DESCRIPTION
Added the location (if any) of an image to the image_text in the check_link method in like_util.py, so the mandatory words check also checks the location. 

This is useful when targeting images with a certain hashtag that where taking in a certain location. Sometimes the user tags the location, sometimes the location is in the description. Both should be included.