### PR TITLE
new feature: unfollow everyone not following you back except custom list

### DIFF
--- a/instapy/unfollow_util.py
+++ b/instapy/unfollow_util.py
@@ -181,7 +181,7 @@ def unfollow(browser,
                 customList[0] == True and
                     type(customList[1]) in [list, tuple, set] and
                     len(customList[1]) > 0 and
-                     customList[2] in ["all", "nonfollowers"]):
+                     customList[2] in ["all", "nonfollowers", "keepfollowing"]):
         customList_data = customList[1]
         if type(customList_data) != list:
             customList_data = list(customList_data)
@@ -260,6 +260,16 @@ def unfollow(browser,
                 loyal_users = [user for user in unfollow_list if user in all_followers]
                 logger.info("Found {} loyal followers!  ~will not unfollow them".format(len(loyal_users)))
                 unfollow_list = [user for user in unfollow_list if user not in loyal_users]
+            
+            elif unfollow_track == "keepfollowing":
+                non_followers_list = get_nonfollowers(browser,
+                                              username,
+                                               relationship_data,
+                                                False,
+                                                 True,
+                                                  logger,
+                                                   logfolder)      
+                unfollow_list = [user for user in non_followers_list if user not in unfollow_list]  
 
             elif unfollow_track != "all":
                 logger.info("Unfollow track is not specified! ~choose \"all\" or \"nonfollowers\"")


### PR DESCRIPTION
Hello!
I'm a new InstaPy user. While reading through the very detailed config guide of InstaPy I've noticed that InstaPy lacked a feature I wanted.

The feature is being able to unfollow everyone not following you back except the accounts included in a custom list.
Famous accounts like **natgeo** for example are very unlikely to follow you back. However I wanted some of these accounts to remain in my main feed as I find their content useful.

Now one could always unfollow everyone not following back and then follow a specific lists of accounts to ensure we always follow natgeo for example (in case we unfollowed them due to InstaPy).
However this approach is more likely to make people believe we are using a bot , plus it may not always work since InstaPy can be limited on the times it can follow a user again after unfollowing.

That's why I decided to implement this new feature.
My approach is implemented in the **custom list unfollow** method.
I could have probably done it as well in the **unfollow everyone not following you back method** but then a list would be needed in that method too and it would be confusing in my opinion with the custom list method. I think the logic behind the code suits best this way as it modifies the custom list method with a just an extra small elif.

I've tested my feature numerous times and it worked always fine, unfollowing people not following me back that weren't included in the custom list I created.

Feel free to make any comments and/or discuss my feature further to improve it.
Thanks for your awesome program btw 👍 