### PR TITLE
Check_link > Switch mandatory_words to ANY instead of ALL

### DIFF
--- a/README.md
+++ b/README.md
@@ -843,7 +843,7 @@ session.set_mandatory_words(['#food', '#instafood'])
 ```
 
 `.set_mandatory_words` searches the description, location and owner comments for words and
-will like the image if **all** of those words are in there
+will like the image if **any** of those words are in there
 
 ### Restricting Likes
 

--- a/instapy/like_util.py
+++ b/instapy/like_util.py
@@ -526,7 +526,7 @@ def check_link(browser, post_link, dont_like, mandatory_words, ignore_if_contain
         image_text = image_text + '\n' + location_name
     
     if mandatory_words :
-        if not all((word in image_text for word in mandatory_words)) :
+        if not any((word in image_text for word in mandatory_words)) :
             return True, user_name, is_video, 'Mandatory words not fulfilled', "Not mandatory likes"
 
     image_text_lower = [x.lower() for x in image_text]


### PR DESCRIPTION
Change mandatory_words to ANY instead of ALL under check_link def. Mandatory words for commenting is already using ANY so maybe this was a typo.

Mandatory Words ALL might be useful on rare occasions but it is very restrictive and use quite a lot of connections. 

**Edit: if you want to keep both ANY and ALL, we can introduce any_mandatory_words and all_mandatory_words (for commenting and liking). Let me know!**