### PR TITLE
unfollow_fix_converge

### DIFF
--- a/instapy/unfollow_util.py
+++ b/instapy/unfollow_util.py
@@ -401,7 +401,7 @@ def unfollow(browser,
 
         # find dialog box
         dialog = browser.find_element_by_xpath(
-            "//div[text()='Following']/../../following-sibling::div")
+            "//div[text()='Following']/../../../following-sibling::div")
 
         sleep(3)
 
@@ -645,9 +645,8 @@ def get_users_through_dialog(browser,
         amount = int(users_count*0.85)
     try_again = 0
     sc_rolled = 0
-
     # find dialog box
-    dialog_address = "//div[text()='Followers' or text()='Following']/../../following-sibling::div"
+    dialog_address = "//div[3]/div/div/div[2]"
     dialog = browser.find_element_by_xpath(dialog_address)
 
     # scroll to end of follower list to initiate first load which hides the suggestions


### PR DESCRIPTION
This PR fix the issue with unfollow feature.
```python
session.unfollow_users(amount=5,
                       allFollowing=True,
                       style="LIFO",
                       sleep_delay=600)
```
I had two options:
1. dialog_address = "//div[3]/div/div/div[2]"
2. dialog_address = "//button[text()='Followers' or text()='Following']/../../../../../.."

I choosed the first option one because it's easier to understand


