### PR TITLE
New feature: Mandatory Language (updated to latest master)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ The **goal** of this file is explaining to the users of our project the notable 
 
 _The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)_.
 
+## [Unreleased] - 2018-12-03
+### Added
+- Added mandatory_language (updated check_link definition in like_util)
+
 ## [Unreleased] - 2018-11-26
 ### Changed
 - Switch mandatory_words from ALL to ANY

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ The **goal** of this file is explaining to the users of our project the notable 
 
 _The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)_.
 
-## [Unreleased] - 2018-12-03
+## [Unreleased] - 2018-12-05
 ### Added
 - Added mandatory_language (updated check_link definition in like_util)
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Table of Contents
   * [Like by Tags](#like-by-tags)
   * [Like by Feeds](#like-by-feeds)
   * [Mandatory Words](#mandatory-words)
+  * [Mandatory Language](#mandatory-language)
   * [Restricting Likes](#restricting-likes)
   * [Ignoring Users](#ignoring-users)
   * [Ignoring Restrictions](#ignoring-restrictions)
@@ -962,6 +963,16 @@ session.set_mandatory_words(['#food', '#instafood'])
 
 `.set_mandatory_words` searches the description, location and owner comments for words and
 will like the image if **any** of those words are in there
+
+### Mandatory Language
+
+```python
+session.set_mandatory_language(enabled=True, character_set='LATIN')
+```
+
+`.set_mandatory_language` restrict the interactions, liking and following if the character set of the description do not match the specified language (the location is not included).
+
+* Available character sets: `LATIN`,  `GREEK`, `CYRILLIC`, `ARABIC`, `HEBREW`, `CJK`, `HANGUL`, `HIRAGANA`, `KATAKANA` and `THAI`
 
 ### Restricting Likes
 

--- a/README.md
+++ b/README.md
@@ -970,7 +970,7 @@ will like the image if **any** of those words are in there
 session.set_mandatory_language(enabled=True, character_set='LATIN')
 ```
 
-`.set_mandatory_language` restrict the interactions, liking and following if the character set of the description do not match the specified language (the location is not included).
+`.set_mandatory_language` restrict the interactions, liking and following if any character of the description is outside of the character set selected (the location is not included and non-alphabetic characters are ignored). For example if you choose `LATIN`, any character in Cyrillic will flag the post as inappropriate.
 
 * Available character sets: `LATIN`,  `GREEK`, `CYRILLIC`, `ARABIC`, `HEBREW`, `CJK`, `HANGUL`, `HIRAGANA`, `KATAKANA` and `THAI`
 

--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -19,6 +19,7 @@ from pyvirtualdisplay import Display
 import logging
 from contextlib import contextmanager
 from copy import deepcopy
+import unicodedata
 
 # import InstaPy modules
 from .clarifai_util import check_image
@@ -226,6 +227,10 @@ class InstaPy:
         self.relationship_data = {username: {"all_following": [], "all_followers": []}}
 
         self.simulation = {"enabled": True, "percentage": 100}
+
+        self.mandatory_language = False
+        self.mandatory_character = []
+        self.check_letters = {}
 
         # use this variable to terminate the nested loops after quotient reaches
         self.quotient_breach = False
@@ -714,6 +719,22 @@ class InstaPy:
 
         # delete duplicated tags
         self.smart_hashtags = list(set(self.smart_hashtags))
+        return self
+
+
+
+    def set_mandatory_language(self, enabled=False, character_set='LATIN'):
+        """Restrict the description of the image to a character set"""
+        if self.aborting:
+            return self
+
+        if (character_set not in ['LATIN', 'GREEK', 'CYRILLIC','ARABIC','HEBREW','CJK','HANGUL','HIRAGANA','KATAKANA','THAI']):
+            self.logger.warning('Unkown character set! Treating as "LATIN".')
+            character_set = 'LATIN'
+
+        self.mandatory_language = enabled
+        self.mandatory_character = character_set
+
         return self
 
 
@@ -1266,9 +1287,12 @@ class InstaPy:
                                    link,
                                    self.dont_like,
                                    self.mandatory_words,
+                                   self.mandatory_language,
+                                   self.is_mandatory_character,
+                                   self.mandatory_character,
+                                   self.check_character_set,
                                    self.ignore_if_contains,
-                                   self.logger)
-                    )
+                                   self.logger))
 
                     if not inappropriate and self.delimit_liking:
                         self.liking_approved = verify_liking(self.browser, self.max_likes, self.min_likes, self.logger)
@@ -1457,6 +1481,10 @@ class InstaPy:
                                    link,
                                    self.dont_like,
                                    self.mandatory_words,
+                                   self.mandatory_language,
+                                   self.is_mandatory_character,
+                                   self.mandatory_character,
+                                   self.check_character_set,
                                    self.ignore_if_contains,
                                    self.logger))
                     if not inappropriate:
@@ -1639,6 +1667,10 @@ class InstaPy:
                                    link,
                                    self.dont_like,
                                    self.mandatory_words,
+                                   self.mandatory_language,
+                                   self.is_mandatory_character,
+                                   self.mandatory_character,
+                                   self.check_character_set,
                                    self.ignore_if_contains,
                                    self.logger)
                     )
@@ -1887,6 +1919,10 @@ class InstaPy:
                                    link,
                                    self.dont_like,
                                    self.mandatory_words,
+                                   self.mandatory_language,
+                                   self.is_mandatory_character,
+                                   self.mandatory_character,
+                                   self.check_character_set,
                                    self.ignore_if_contains,
                                    self.logger))
 
@@ -2108,6 +2144,10 @@ class InstaPy:
                                    link,
                                    self.dont_like,
                                    self.mandatory_words,
+                                   self.mandatory_language,
+                                   self.is_mandatory_character,
+                                   self.mandatory_character,
+                                   self.check_character_set,
                                    self.ignore_if_contains,
                                    self.logger))
 
@@ -2362,6 +2402,10 @@ class InstaPy:
                                    link,
                                    self.dont_like,
                                    self.mandatory_words,
+                                   self.mandatory_language,
+                                   self.is_mandatory_character,
+                                   self.mandatory_character,
+                                   self.check_character_set,
                                    self.ignore_if_contains,
                                    self.logger))
 
@@ -3361,6 +3405,10 @@ class InstaPy:
                                 link,
                                 self.dont_like,
                                 self.mandatory_words,
+                                self.mandatory_language,
+                                self.is_mandatory_character,
+                                self.mandatory_character,
+                                self.check_character_set,
                                 self.ignore_if_contains,
                                 self.logger)
 
@@ -3894,6 +3942,10 @@ class InstaPy:
                                    link,
                                    self.dont_like,
                                    self.mandatory_words,
+                                   self.mandatory_language,
+                                   self.is_mandatory_character,
+                                   self.mandatory_character,
+                                   self.check_character_set,
                                    self.ignore_if_contains,
                                    self.logger)
                     )
@@ -3993,6 +4045,10 @@ class InstaPy:
                                url,
                                self.dont_like,
                                self.mandatory_words,
+                               self.mandatory_language,
+                               self.is_mandatory_character,
+                               self.mandatory_character,
+                               self.check_character_set,
                                self.ignore_if_contains,
                                self.logger))
 
@@ -4522,6 +4578,10 @@ class InstaPy:
                     link,
                     self.dont_like,
                     self.mandatory_words,
+                    self.mandatory_language,
+                    self.is_mandatory_character,
+                    self.mandatory_character,
+                    self.check_character_set,
                     self.ignore_if_contains,
                     self.logger)
 
@@ -4713,4 +4773,18 @@ class InstaPy:
             self.logger.info("\tNot valid users: {}".format(not_valid_users))
 
 
+    def is_mandatory_character(self, uchr):
+        if self.aborting:
+            return self
+        try:
+            return self.check_letters[uchr]
+        except KeyError:
+             return self.check_letters.setdefault(uchr, self.mandatory_character in unicodedata.name(uchr))
 
+    def check_character_set(self, unistr):
+        self.check_letters = {}
+        if self.aborting:
+            return self
+        return all(self.is_mandatory_character(uchr)
+               for uchr in unistr
+               if uchr.isalpha())

--- a/instapy/like_util.py
+++ b/instapy/like_util.py
@@ -414,7 +414,7 @@ def get_links_for_username(browser,
 
 
 
-def check_link(browser, post_link, dont_like, mandatory_words, ignore_if_contains, logger):
+def check_link(browser, post_link, dont_like, mandatory_words, mandatory_language, mandatory_character, is_mandatory_character, check_character_set, ignore_if_contains, logger):
     """
     Check the given link if it is appropriate
 
@@ -523,11 +523,16 @@ def check_link(browser, post_link, dont_like, mandatory_words, ignore_if_contain
     logger.info('Link: {}'.format(post_link.encode('utf-8')))
     logger.info('Description: {}'.format(image_text.encode('utf-8')))
 
+    """Check if mandatory character set, before adding the location to the text"""
+    if mandatory_language:
+        if not check_character_set(image_text):
+            return True, user_name, is_video, 'Mandatory language not fulfilled', "Not mandatory language"
+
     """Append location to image_text so we can search through both in one go."""
     if location_name:
         logger.info('Location: {}'.format(location_name.encode('utf-8')))
         image_text = image_text + '\n' + location_name
-    
+
     if mandatory_words :
         if not any((word in image_text for word in mandatory_words)) :
             return True, user_name, is_video, 'Mandatory words not fulfilled', "Not mandatory likes"
@@ -737,6 +742,3 @@ def like_comment(browser, original_comment_text, logger):
 
 
     return None, "unknown"
-
-
-


### PR DESCRIPTION
https://github.com/timgrossmann/InstaPy/pull/3434 
Updated to latest master.

```python
session.set_mandatory_language(enabled=True, character_set='LATIN')
```

`.set_mandatory_language` restrict the interactions, liking and following if any character of the description is outside of the character set selected (the location is not included and non-alphabetic characters are ignored). For example if you choose `LATIN`, any character in Cyrillic will flag the post as inappropriate.

* Available character sets: `LATIN`,  `GREEK`, `CYRILLIC`, `ARABIC`, `HEBREW`, `CJK`, `HANGUL`, `HIRAGANA`, `KATAKANA` and `THAI`