### PR TITLE
Firefox unfollow fix

### DIFF
--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -133,6 +133,7 @@ class InstaPy:
         self.page_delay = page_delay
         self.switch_language = True
         self.use_firefox = use_firefox
+        Settings.use_firefox = self.use_firefox
         self.browser_profile_path = browser_profile_path
 
         self.do_comment = False

--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -3213,6 +3213,7 @@ class InstaPy:
                                   self.relationship_data,
                                   self.dont_include,
                                   self.white_list,
+                                  self.use_firefox,
                                   sleep_delay,
                                   self.jumps,
                                   self.logger,
@@ -3610,6 +3611,7 @@ class InstaPy:
                                           amount,
                                           self.relationship_data,
                                           live_match,
+                                          self.use_firefox,
                                           store_locally,
                                           self.logger,
                                           self.logfolder)
@@ -3652,6 +3654,7 @@ class InstaPy:
                                           amount,
                                           self.relationship_data,
                                           live_match,
+                                          self.use_firefox,
                                           store_locally,
                                           self.logger,
                                           self.logfolder)
@@ -3681,6 +3684,7 @@ class InstaPy:
             compare_track,
             self.relationship_data,
             live_match,
+            self.use_firefox,
             store_locally,
             print_out,
             self.logger,
@@ -3704,6 +3708,7 @@ class InstaPy:
                                         username,
                                         self.relationship_data,
                                         live_match,
+                                        self.use_firefox,
                                         store_locally,
                                         self.logger,
                                         self.logfolder)
@@ -3729,6 +3734,7 @@ class InstaPy:
                         username,
                         self.relationship_data,
                         live_match,
+                        self.use_firefox,
                         store_locally,
                         self.logger,
                         self.logfolder)
@@ -3754,6 +3760,7 @@ class InstaPy:
                                                 username,
                                                 self.relationship_data,
                                                 live_match,
+                                                self.use_firefox,
                                                 store_locally,
                                                 self.logger,
                                                 self.logfolder)

--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -3213,7 +3213,6 @@ class InstaPy:
                                   self.relationship_data,
                                   self.dont_include,
                                   self.white_list,
-                                  self.use_firefox,
                                   sleep_delay,
                                   self.jumps,
                                   self.logger,
@@ -3611,7 +3610,6 @@ class InstaPy:
                                           amount,
                                           self.relationship_data,
                                           live_match,
-                                          self.use_firefox,
                                           store_locally,
                                           self.logger,
                                           self.logfolder)
@@ -3654,7 +3652,6 @@ class InstaPy:
                                           amount,
                                           self.relationship_data,
                                           live_match,
-                                          self.use_firefox,
                                           store_locally,
                                           self.logger,
                                           self.logfolder)
@@ -3684,7 +3681,6 @@ class InstaPy:
             compare_track,
             self.relationship_data,
             live_match,
-            self.use_firefox,
             store_locally,
             print_out,
             self.logger,
@@ -3708,7 +3704,6 @@ class InstaPy:
                                         username,
                                         self.relationship_data,
                                         live_match,
-                                        self.use_firefox,
                                         store_locally,
                                         self.logger,
                                         self.logfolder)
@@ -3734,7 +3729,6 @@ class InstaPy:
                         username,
                         self.relationship_data,
                         live_match,
-                        self.use_firefox,
                         store_locally,
                         self.logger,
                         self.logfolder)
@@ -3760,7 +3754,6 @@ class InstaPy:
                                                 username,
                                                 self.relationship_data,
                                                 live_match,
-                                                self.use_firefox,
                                                 store_locally,
                                                 self.logger,
                                                 self.logfolder)

--- a/instapy/relationship_tools.py
+++ b/instapy/relationship_tools.py
@@ -13,6 +13,7 @@ from .util import interruption_handler
 from .util import truncate_float
 from .settings import Settings
 
+from selenium.common.exceptions import NoSuchElementException
 
 def get_followers(browser,
                   username,
@@ -120,7 +121,15 @@ def get_followers(browser,
         highest_value = followers_count if grab == "full" else grab
         # fetch all user while still has data
         while has_next_data:
-            pre = browser.find_element_by_tag_name("pre").text
+            try:
+                pre = browser.find_element_by_tag_name("pre").text
+            except NoSuchElementException as exc:
+                logger.info("Encountered an error to find `pre` in page!"
+                            "\t~grabbed {} usernames \n\t{}"
+                            .format(len(set(all_followers)),
+                                    str(exc).encode("utf-8")))
+                return all_followers
+            
             data = json.loads(pre)['data']
 
             # get followers
@@ -329,7 +338,15 @@ def get_following(browser,
         highest_value = following_count if grab == "full" else grab
         # fetch all user while still has data
         while has_next_data:
-            pre = browser.find_element_by_tag_name("pre").text
+            try:
+                pre = browser.find_element_by_tag_name("pre").text
+            except NoSuchElementException as exc:
+                logger.info("Encountered an error to find `pre` in page!"
+                            "\t~grabbed {} usernames \n\t{}"
+                            .format(len(set(all_following)),
+                                    str(exc).encode("utf-8")))
+                return all_following
+
             data = json.loads(pre)['data']
 
             # get following

--- a/instapy/relationship_tools.py
+++ b/instapy/relationship_tools.py
@@ -19,6 +19,7 @@ def get_followers(browser,
                   grab,
                   relationship_data,
                   live_match,
+                  use_firefox,
                   store_locally,
                   logger,
                   logfolder):
@@ -50,8 +51,10 @@ def get_followers(browser,
     all_prior_followers = relationship_data[username]["all_followers"] if match is not None else None
 
     user_data = {}
-
-    graphql_endpoint = 'https://www.instagram.com/graphql/query/'
+    if use_firefox:
+        graphql_endpoint = 'view-source:https://www.instagram.com/graphql/query/'
+    else:
+        graphql_endpoint = 'https://www.instagram.com/graphql/query/'
     graphql_followers = (
         graphql_endpoint + '?query_hash=37479f2b8209594dde7facb0d904896a')
 
@@ -227,6 +230,7 @@ def get_following(browser,
                   grab,
                   relationship_data,
                   live_match,
+                  use_firefox,
                   store_locally,
                   logger,
                   logfolder):
@@ -258,8 +262,10 @@ def get_following(browser,
     all_prior_following = relationship_data[username]["all_following"] if match is not None else None
 
     user_data = {}
-
-    graphql_endpoint = 'https://www.instagram.com/graphql/query/'
+    if use_firefox:
+        graphql_endpoint = 'view-source:https://www.instagram.com/graphql/query/'
+    else:
+        graphql_endpoint = 'https://www.instagram.com/graphql/query/'
     graphql_following = (
         graphql_endpoint + '?query_hash=58712303d941c6855d4e888c5f0cd22f')
 
@@ -432,6 +438,7 @@ def get_unfollowers(browser,
                     compare_track,
                     relationship_data,
                     live_match,
+                    use_firefox,
                     store_locally,
                     print_out,
                     logger,
@@ -464,6 +471,7 @@ def get_unfollowers(browser,
                                       "full",
                                       relationship_data,
                                       live_match,
+                                      use_firefox,
                                       store_locally,
                                       logger,
                                       logfolder)
@@ -476,6 +484,7 @@ def get_unfollowers(browser,
                                           "full",
                                           relationship_data,
                                           live_match,
+                                          use_firefox,
                                           store_locally,
                                           logger,
                                           logfolder)
@@ -504,6 +513,7 @@ def get_nonfollowers(browser,
                      username,
                      relationship_data,
                      live_match,
+                     use_firefox,
                      store_locally,
                      logger,
                      logfolder):
@@ -519,6 +529,7 @@ def get_nonfollowers(browser,
                                   "full",
                                   relationship_data,
                                   live_match,
+                                  use_firefox,
                                   store_locally,
                                   logger,
                                   logfolder)
@@ -528,6 +539,7 @@ def get_nonfollowers(browser,
                                   "full",
                                   relationship_data,
                                   live_match,
+                                  use_firefox,
                                   store_locally,
                                   logger,
                                   logfolder)
@@ -556,6 +568,7 @@ def get_fans(browser,
              username,
              relationship_data,
              live_match,
+             use_firefox,
              store_locally,
              logger,
              logfolder):
@@ -571,6 +584,7 @@ def get_fans(browser,
                                   "full",
                                   relationship_data,
                                   live_match,
+                                  use_firefox,
                                   store_locally,
                                   logger,
                                   logfolder)
@@ -580,6 +594,7 @@ def get_fans(browser,
                                   "full",
                                   relationship_data,
                                   live_match,
+                                  use_firefox,
                                   store_locally,
                                   logger,
                                   logfolder)
@@ -608,6 +623,7 @@ def get_mutual_following(browser,
                          username,
                          relationship_data,
                          live_match,
+                         use_firefox,
                          store_locally,
                          logger,
                          logfolder):
@@ -623,6 +639,7 @@ def get_mutual_following(browser,
                                   "full",
                                   relationship_data,
                                   live_match,
+                                  use_firefox,
                                   store_locally,
                                   logger,
                                   logfolder)
@@ -632,6 +649,7 @@ def get_mutual_following(browser,
                                   "full",
                                   relationship_data,
                                   live_match,
+                                  use_firefox,
                                   store_locally,
                                   logger,
                                   logfolder)

--- a/instapy/relationship_tools.py
+++ b/instapy/relationship_tools.py
@@ -19,7 +19,6 @@ def get_followers(browser,
                   grab,
                   relationship_data,
                   live_match,
-                  use_firefox,
                   store_locally,
                   logger,
                   logfolder):
@@ -51,10 +50,8 @@ def get_followers(browser,
     all_prior_followers = relationship_data[username]["all_followers"] if match is not None else None
 
     user_data = {}
-    if use_firefox:
-        graphql_endpoint = 'view-source:https://www.instagram.com/graphql/query/'
-    else:
-        graphql_endpoint = 'https://www.instagram.com/graphql/query/'
+
+    graphql_endpoint = 'https://www.instagram.com/graphql/query/'
     graphql_followers = (
         graphql_endpoint + '?query_hash=37479f2b8209594dde7facb0d904896a')
 
@@ -230,7 +227,6 @@ def get_following(browser,
                   grab,
                   relationship_data,
                   live_match,
-                  use_firefox,
                   store_locally,
                   logger,
                   logfolder):
@@ -262,10 +258,8 @@ def get_following(browser,
     all_prior_following = relationship_data[username]["all_following"] if match is not None else None
 
     user_data = {}
-    if use_firefox:
-        graphql_endpoint = 'view-source:https://www.instagram.com/graphql/query/'
-    else:
-        graphql_endpoint = 'https://www.instagram.com/graphql/query/'
+
+    graphql_endpoint = 'https://www.instagram.com/graphql/query/'
     graphql_following = (
         graphql_endpoint + '?query_hash=58712303d941c6855d4e888c5f0cd22f')
 
@@ -438,7 +432,6 @@ def get_unfollowers(browser,
                     compare_track,
                     relationship_data,
                     live_match,
-                    use_firefox,
                     store_locally,
                     print_out,
                     logger,
@@ -471,7 +464,6 @@ def get_unfollowers(browser,
                                       "full",
                                       relationship_data,
                                       live_match,
-                                      use_firefox,
                                       store_locally,
                                       logger,
                                       logfolder)
@@ -484,7 +476,6 @@ def get_unfollowers(browser,
                                           "full",
                                           relationship_data,
                                           live_match,
-                                          use_firefox,
                                           store_locally,
                                           logger,
                                           logfolder)
@@ -513,7 +504,6 @@ def get_nonfollowers(browser,
                      username,
                      relationship_data,
                      live_match,
-                     use_firefox,
                      store_locally,
                      logger,
                      logfolder):
@@ -529,7 +519,6 @@ def get_nonfollowers(browser,
                                   "full",
                                   relationship_data,
                                   live_match,
-                                  use_firefox,
                                   store_locally,
                                   logger,
                                   logfolder)
@@ -539,7 +528,6 @@ def get_nonfollowers(browser,
                                   "full",
                                   relationship_data,
                                   live_match,
-                                  use_firefox,
                                   store_locally,
                                   logger,
                                   logfolder)
@@ -568,7 +556,6 @@ def get_fans(browser,
              username,
              relationship_data,
              live_match,
-             use_firefox,
              store_locally,
              logger,
              logfolder):
@@ -584,7 +571,6 @@ def get_fans(browser,
                                   "full",
                                   relationship_data,
                                   live_match,
-                                  use_firefox,
                                   store_locally,
                                   logger,
                                   logfolder)
@@ -594,7 +580,6 @@ def get_fans(browser,
                                   "full",
                                   relationship_data,
                                   live_match,
-                                  use_firefox,
                                   store_locally,
                                   logger,
                                   logfolder)
@@ -623,7 +608,6 @@ def get_mutual_following(browser,
                          username,
                          relationship_data,
                          live_match,
-                         use_firefox,
                          store_locally,
                          logger,
                          logfolder):
@@ -639,7 +623,6 @@ def get_mutual_following(browser,
                                   "full",
                                   relationship_data,
                                   live_match,
-                                  use_firefox,
                                   store_locally,
                                   logger,
                                   logfolder)
@@ -649,7 +632,6 @@ def get_mutual_following(browser,
                                   "full",
                                   relationship_data,
                                   live_match,
-                                  use_firefox,
                                   store_locally,
                                   logger,
                                   logfolder)

--- a/instapy/relationship_tools.py
+++ b/instapy/relationship_tools.py
@@ -51,7 +51,13 @@ def get_followers(browser,
 
     user_data = {}
 
-    graphql_endpoint = 'https://www.instagram.com/graphql/query/'
+    use_firefox = Settings.use_firefox
+
+    if use_firefox:
+        graphql_endpoint = 'view-source:https://www.instagram.com/graphql/query/'
+    else:
+        graphql_endpoint = 'https://www.instagram.com/graphql/query/'
+
     graphql_followers = (
         graphql_endpoint + '?query_hash=37479f2b8209594dde7facb0d904896a')
 
@@ -259,7 +265,13 @@ def get_following(browser,
 
     user_data = {}
 
-    graphql_endpoint = 'https://www.instagram.com/graphql/query/'
+    use_firefox = Settings.use_firefox
+
+    if use_firefox:
+        graphql_endpoint = 'view-source:https://www.instagram.com/graphql/query/'
+    else:
+        graphql_endpoint = 'https://www.instagram.com/graphql/query/'
+
     graphql_following = (
         graphql_endpoint + '?query_hash=58712303d941c6855d4e888c5f0cd22f')
 

--- a/instapy/settings.py
+++ b/instapy/settings.py
@@ -47,6 +47,9 @@ class Settings:
     # store the parameter for global access
     show_logs = None
 
+    # store what browser the user is using, if they are using firefox it is true, chrome if false.
+    use_firefox = None
+
 
 
 

--- a/instapy/unfollow_util.py
+++ b/instapy/unfollow_util.py
@@ -170,7 +170,6 @@ def unfollow(browser,
              relationship_data,
              dont_include,
              white_list,
-             use_firefox,
              sleep_delay,
              jumps,
              logger,
@@ -241,27 +240,25 @@ def unfollow(browser,
             logger.info("Unfollowing the users who do not follow back\n")
             """  Unfollow only the users who do not follow you back """
             unfollow_list = get_nonfollowers(browser,
-                                             username,
-                                             relationship_data,
-                                             False,
-                                             use_firefox,
-                                             True,
-                                             logger,
-                                             logfolder)
+                                              username,
+                                               relationship_data,
+                                                False,
+                                                 True,
+                                                  logger,
+                                                   logfolder)
 
         # pick only the users in the right track- ["all" or "nonfollowers"] for `customList` and
         #  `InstapyFollowed` unfollow methods
         if customList == True or InstapyFollowed == True:
             if unfollow_track == "nonfollowers":
                 all_followers = get_followers(browser,
-                                              username,
-                                              "full",
-                                              relationship_data,
-                                              False,
-                                              use_firefox,
-                                              True,
-                                              logger,
-                                              logfolder)
+                                               username,
+                                                "full",
+                                                 relationship_data,
+                                                  False,
+                                                   True,
+                                                    logger,
+                                                    logfolder)
                 loyal_users = [user for user in unfollow_list if user in all_followers]
                 logger.info("Found {} loyal followers!  ~will not unfollow them".format(len(loyal_users)))
                 unfollow_list = [user for user in unfollow_list if user not in loyal_users]

--- a/instapy/unfollow_util.py
+++ b/instapy/unfollow_util.py
@@ -170,6 +170,7 @@ def unfollow(browser,
              relationship_data,
              dont_include,
              white_list,
+             use_firefox,
              sleep_delay,
              jumps,
              logger,
@@ -240,25 +241,27 @@ def unfollow(browser,
             logger.info("Unfollowing the users who do not follow back\n")
             """  Unfollow only the users who do not follow you back """
             unfollow_list = get_nonfollowers(browser,
-                                              username,
-                                               relationship_data,
-                                                False,
-                                                 True,
-                                                  logger,
-                                                   logfolder)
+                                             username,
+                                             relationship_data,
+                                             False,
+                                             use_firefox,
+                                             True,
+                                             logger,
+                                             logfolder)
 
         # pick only the users in the right track- ["all" or "nonfollowers"] for `customList` and
         #  `InstapyFollowed` unfollow methods
         if customList == True or InstapyFollowed == True:
             if unfollow_track == "nonfollowers":
                 all_followers = get_followers(browser,
-                                               username,
-                                                "full",
-                                                 relationship_data,
-                                                  False,
-                                                   True,
-                                                    logger,
-                                                    logfolder)
+                                              username,
+                                              "full",
+                                              relationship_data,
+                                              False,
+                                              use_firefox,
+                                              True,
+                                              logger,
+                                              logfolder)
                 loyal_users = [user for user in unfollow_list if user in all_followers]
                 logger.info("Found {} loyal followers!  ~will not unfollow them".format(len(loyal_users)))
                 unfollow_list = [user for user in unfollow_list if user not in loyal_users]

--- a/instapy/util.py
+++ b/instapy/util.py
@@ -1337,7 +1337,7 @@ def get_username_from_id(browser, user_id, logger):
     web_address_navigator(browser, post_url)
     try:
         pre = browser.find_element_by_tag_name("pre").text
-    except NoSuchElementException as exc:
+    except NoSuchElementException:
         logger.info("Encountered an error to find `pre` in page, skipping username.")
         return None
     user_data = json.loads(pre)["data"]["user"]

--- a/instapy/util.py
+++ b/instapy/util.py
@@ -1335,7 +1335,11 @@ def get_username_from_id(browser, user_id, logger):
     post_url = u"{}&variables={}".format(graphql_query_URL, str(json.dumps(variables)))
 
     web_address_navigator(browser, post_url)
-    pre = browser.find_element_by_tag_name("pre").text
+    try:
+        pre = browser.find_element_by_tag_name("pre").text
+    except NoSuchElementException as exc:
+        logger.info("Encountered an error to find `pre` in page, skipping username.")
+        return None
     user_data = json.loads(pre)["data"]["user"]
 
     if user_data:


### PR DESCRIPTION
Fix for unable to locate element "pre" in firefox browser and some minor PEP8 stuff.

When unfollowing users who had changed their names or had their accounts banned/removed in some way. Firefox encountered issues, this was due to the way it interpreted endpoint data, kudos to gitpatrickhub on issue #3444 for figuring this out. 


Edit: Just a note, upon further testing this only fixes it if the user has changed their name. it doesn't fix it if their account is deleted/removed or banned. Still looking for a fix for that.

Edit 2: Came up with a temporary solution for the above. Fix is implemented. This is ready to merge.