### PR TITLE
#3656 (bug fix) change the way the login link is clicked

### DIFF
--- a/instapy/login_util.py
+++ b/instapy/login_util.py
@@ -16,6 +16,7 @@ from .util import check_authorization
 # import exceptions
 from selenium.common.exceptions import NoSuchElementException
 from selenium.common.exceptions import WebDriverException
+from selenium.common.exceptions import MoveTargetOutOfBoundsException
 
 
 def bypass_suspicious_login(browser, bypass_with_mobile):
@@ -203,7 +204,14 @@ def login_user(browser,
         "//article//a[text()='Log in']")
 
     if login_elem is not None:
-        login_elem.click()
+        try:
+            (ActionChains(browser)
+             .move_to_element(login_elem)
+             .click()
+             .perform())
+        except MoveTargetOutOfBoundsException:
+            login_elem.click()
+
         # update server calls
         update_activity()
 

--- a/instapy/login_util.py
+++ b/instapy/login_util.py
@@ -203,11 +203,7 @@ def login_user(browser,
         "//article//a[text()='Log in']")
 
     if login_elem is not None:
-        (ActionChains(browser)
-         .move_to_element(login_elem)
-         .click()
-         .perform())
-
+        login_elem.click()
         # update server calls
         update_activity()
 


### PR DESCRIPTION
Sometimes the screen is smaller than the Instagram page, and the Login button wont be visible. ActionChains works looking for elements visible on viewport:

```python
(ActionChains(browser)
         .move_to_element(login_elem)
         .click()
         .perform())
```

throws this exception if the Login link isn't visible on viewport:
```selenium.common.exceptions.MoveTargetOutOfBoundsException: Message: (901.4916915893555, 640) is out of bounds of viewport width (1280) and height (638)```

(Login button isn't visible)
![captura de tela 2019-01-02 as 08 59 34](https://user-images.githubusercontent.com/188671/50589826-51ea9e80-0e6f-11e9-900e-d7e8ea2d0c11.png)


--
The fix is click the link using the click() function.
