### PR TITLE
resolve security warning with new pyyaml version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,4 +18,4 @@ six>=1.11.0
 urllib3>=1.24.1
 regex>=2018.11.22
 MeaningCloud-python>=1.1.1
-PyYAML==3.13
+PyYAML==4.2b1


### PR DESCRIPTION
- Fixes 

Remediation

Upgrade pyyaml to version 4.2b1 or later. For example:

pyyaml>=4.2b1
Always verify the validity and compatibility of suggestions with your codebase.

Details

CVE-2017-18342 More information

high severity
Vulnerable versions: < 4.2b1
Patched version: 4.2b1
In PyYAML before 4.1, the yaml.load() API could execute arbitrary code. In other words, yaml.safe_load is not used.