### PR TITLE
Allow custom ChromeDriver paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 # pylint file
 googlecl-pylint.rc.txt
-assets/chromedriver
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/assets/.gitignore
+++ b/assets/.gitignore
@@ -1,5 +1,0 @@
-# Ignore everything
-*
-
-# But not these files...
-!unicodes.md

--- a/instapy/settings.py
+++ b/instapy/settings.py
@@ -15,10 +15,17 @@ class Settings:
     # chromedriver-specific settings
     chromedriver_min_version = 2.36
 
-    specific_chromedriver = "chromedriver_{}".format(OS_ENV)
-    chromedriver_location = os.path.join(BASE_DIR,
-                                         'assets',
-                                         specific_chromedriver)
+    # Prefer environment variable
+    chromedriver_location = os.environ.get('CHROMEDRIVER_PATH', None)
+
+    if (
+        not chromedriver_location
+        or not os.path.exists(chromedriver_location)
+    ):
+        specific_chromedriver = "chromedriver_{}".format(OS_ENV)
+        chromedriver_location = os.path.join(BASE_DIR,
+                                             'assets',
+                                             specific_chromedriver)
 
     if not os.path.exists(chromedriver_location):
         chromedriver_location = os.path.join(BASE_DIR,


### PR DESCRIPTION
This change allows for a custom ChromeDriver path to be set via the environment variable `CHROMEDRIVER_PATH`.