### PR TITLE
revert pyyaml requirement back to stable release

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,4 +18,4 @@ six>=1.11.0
 urllib3>=1.24.1
 regex>=2018.11.22
 MeaningCloud-python>=1.1.1
-PyYAML==4.2b1
+PyYAML>=3.13


### PR DESCRIPTION
I made a fault with updating the requirement to get rid of the security warning with pyyaml.
4.2b1 is only a pre-release which makes it "more difficult" to install and fail with the new pip install instapy that will be introduced in #3722 

> Please note that this might introduce a "security warning" for this dependency. Will be fixed once 4.2b1 is released as stable