### PR TITLE
Optimizing Dockerfile for smaller docker image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ __pycache__/
 *$py.class
 
 quickstart.py
+docker_quickstart.py
 
 # C extensions
 *.so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ The **goal** of this file is explaining to the users of our project the notable 
 
 _The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)_.
 
+## [Unreleased] - 2019-01-17
+### Updated
+- Optimizing Dockerfile for smaller docker image
+
 ## [Unreleased] - 2019-01-15
 ### Fixed
 - Handle A/B-Test for comments (graphql edge)

--- a/docker_conf/python/Dockerfile
+++ b/docker_conf/python/Dockerfile
@@ -1,4 +1,16 @@
-FROM python:3.6
-RUN apt-get update && apt-get install -y chromedriver
-COPY ./requirements.txt /
-RUN pip install -r /requirements.txt
+FROM python:3.6-slim-stretch
+COPY ./requirements.txt /tmp
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends --no-install-suggests \
+      chromedriver \
+      wget \
+      gcc \
+      g++ \
+    && pip install --no-cache-dir -r /tmp/requirements.txt \
+    && apt-get purge -y --auto-remove \
+      gcc \
+      g++ \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+CMD ["./code/wait-for-selenium.sh", "http://selenium:4444/wd/hub", "--", "python", "code/docker_quickstart.py"]


### PR DESCRIPTION
Hello all,

I am running `InstaPy` with `Docker` and a best practice when creating Docker containers is keeping the size of the final image to the minimum possible. For a number of reasons including:

- Disk on space
- Reducing attack surface
- Upload time (if so)
- Performance (for old Docker version)

So, I rewrite `./docker_conf/python/Dockerfile` to reduce by half the size the final image from `1.34GB` to `512MB`. I'm pretty sure there is still few optimization possible and the size might be lowered, but it's a first step.
More generally regarding Docker, I'm pretty sure we can do some cleaning in the configuration:

- I also think it could be possible to reduce the size of `selenium` image (which is around `1GB` too) but I haven't already look at it.
- Cleaning `docker-*.yml` files: it's better to stay with only one file
- Cleaning `docker_conf` directory

I also include in the `.gitignore` file `docker_quickstart.py` to avoid overwriting of the file that happened sometimes.

WAiting for your feedback.

Regards,
Herrox