### PR TITLE
Fix `set_dont_unfollow_active_users()` feature completely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,18 @@ The **goal** of this file is explaining to the users of our project the notable 
 _The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)_.
 
 
+
+## [Unreleased] - 2019-01-22
+### Added
+- Now `set_dont_unfollow_active_users()` feature also has a Progress Tracker support.
+
+### Fixed
+- Fix `set_dont_unfollow_active_users()` feature completely.
+
+
 ## [Unreleased] - 2019-01-17
 ### Changed
-- Optimizing Dockerfile for smaller docker image
+- Optimizing Dockerfile for smaller docker image.
 
 ### Fixed
 - Fix "_Unable to locate element: ...xpath","selector":"//div[text()=\'Likes\'..._" error.

--- a/instapy/commenters_util.py
+++ b/instapy/commenters_util.py
@@ -16,7 +16,6 @@ from .util import update_activity
 from .util import web_address_navigator
 from .util import username_url_to_username
 from .util import scroll_bottom
-from .util import extract_text_from_element
 from .util import get_users_from_dialog
 from .util import progress_tracker
 from .util import close_dialog_box

--- a/instapy/commenters_util.py
+++ b/instapy/commenters_util.py
@@ -20,6 +20,7 @@ from .util import scroll_bottom
 from .util import extract_text_from_element
 from .util import get_users_from_dialog
 from .util import progress_tracker
+from .util import close_dialog_box
 from .settings import Selectors
 
 from selenium.common.exceptions import NoSuchElementException
@@ -368,13 +369,7 @@ def likers_from_photo(browser, amount=20):
         random.shuffle(user_list)
         sleep(1)
 
-        try:
-            close = browser.find_element_by_xpath("//span[text()='Close']")
-            click_element(browser, close)
-            print("Like window closed")
-
-        except Exception:
-            pass
+        close_dialog_box(browser)
 
         print(
             "Got {} likers shuffled randomly whom you can follow:\n{}"

--- a/instapy/commenters_util.py
+++ b/instapy/commenters_util.py
@@ -19,6 +19,7 @@ from .util import remove_duplicates
 from .util import scroll_bottom
 from .util import extract_text_from_element
 from .relationship_tools import progress_tracker
+from .settings import Selectors
 
 from selenium.common.exceptions import NoSuchElementException
 
@@ -331,9 +332,9 @@ def likers_from_photo(browser, amount=20):
 
         sleep(1)
 
-        # find dialog box
+        # get a reference to the 'Likes' dialog box
         dialog = browser.find_element_by_xpath(
-            "//h1[text()='Likes']/../../following-sibling::div/div")
+            Selectors.likes_dialog_body_xpath)
 
         # scroll down the page
         previous_len = -1

--- a/instapy/commenters_util.py
+++ b/instapy/commenters_util.py
@@ -338,7 +338,6 @@ def likers_from_photo(browser, amount=20):
 
         # scroll down the page
         previous_len = -1
-        follow_buttons = []
         browser.execute_script(
             "arguments[0].scrollTop = arguments[0].scrollHeight", dialog)
         update_activity()

--- a/instapy/commenters_util.py
+++ b/instapy/commenters_util.py
@@ -15,7 +15,6 @@ from .util import click_element
 from .util import update_activity
 from .util import web_address_navigator
 from .util import username_url_to_username
-from .util import remove_duplicates
 from .util import scroll_bottom
 from .util import extract_text_from_element
 from .util import get_users_from_dialog

--- a/instapy/commenters_util.py
+++ b/instapy/commenters_util.py
@@ -18,7 +18,8 @@ from .util import username_url_to_username
 from .util import remove_duplicates
 from .util import scroll_bottom
 from .util import extract_text_from_element
-from .relationship_tools import progress_tracker
+from .util import get_users_from_dialog
+from .util import progress_tracker
 from .settings import Selectors
 
 from selenium.common.exceptions import NoSuchElementException
@@ -358,11 +359,7 @@ def likers_from_photo(browser, amount=20):
             previous_len = len(user_list)
             scroll_bottom(browser, dialog, 2)
 
-            user_blocks = dialog.find_elements_by_tag_name('a')
-            loaded_users = [extract_text_from_element(u) for u in user_blocks
-                            if extract_text_from_element(u)]
-            user_list.extend(loaded_users)
-            user_list = remove_duplicates(user_list, True, None)
+            user_list = get_users_from_dialog(user_list, dialog)
 
             # write & update records at Progress Tracker
             progress_tracker(len(user_list), amount, start_time, None)

--- a/instapy/relationship_tools.py
+++ b/instapy/relationship_tools.py
@@ -1,7 +1,6 @@
 import time
 from datetime import datetime
 import os
-import sys
 import glob
 import random
 import json
@@ -11,6 +10,7 @@ from .util import web_address_navigator
 from .util import get_relationship_counts
 from .util import interruption_handler
 from .util import truncate_float
+from .util import progress_tracker
 from .settings import Settings
 
 from selenium.common.exceptions import NoSuchElementException
@@ -1195,55 +1195,3 @@ def load_followers_data(username, compare_by, compare_track, logger,
     # return that file to be compared
     return followers_data, selected_filename
 
-
-def progress_tracker(current_value, highest_value, initial_time, logger):
-    """ Provide a progress tracker to keep value updated until finishes """
-    if (current_value is None or
-            highest_value is None or
-            highest_value == 0):
-        return
-
-    try:
-        real_time = time.time()
-        progress_percent = int((current_value / highest_value) * 100)
-        show_logs = Settings.show_logs
-
-        elapsed_time = real_time - initial_time
-        elapsed_formatted = truncate_float(elapsed_time, 2)
-        elapsed = ("{} seconds".format(
-            elapsed_formatted) if elapsed_formatted < 60 else
-                   "{} minutes".format(
-                       truncate_float(elapsed_formatted / 60, 2)))
-
-        eta_time = abs((elapsed_time * 100) / (
-            progress_percent if progress_percent != 0 else 1) - elapsed_time)
-        eta_formatted = truncate_float(eta_time, 2)
-        eta = ("{} seconds".format(eta_formatted) if eta_formatted < 60 else
-               "{} minutes".format(truncate_float(eta_formatted / 60, 2)))
-
-        tracker_line = "-----------------------------------"
-        filled_index = int(progress_percent / 2.77)
-        progress_container = "[" + tracker_line[
-                                   :filled_index] + "+" + tracker_line[
-                                                          filled_index:] + "]"
-        progress_container = progress_container[:filled_index + 1].replace("-",
-                                                                           "=") + progress_container[
-                                                                                  filled_index + 1:]
-
-        total_message = ("\r  {}/{} {}  {}%    "
-                         "|> Elapsed: {}    "
-                         "|> ETA: {}      "
-                         .format(current_value, highest_value,
-                                 progress_container, progress_percent,
-                                 elapsed, eta))
-
-        if show_logs is True:
-            sys.stdout.write(total_message)
-            sys.stdout.flush()
-
-    except Exception as exc:
-        if not logger:
-            logger = Settings.logger
-
-        logger.info("Error occurred with Progress Tracker:\n{}".format(
-            str(exc).encode("utf-8")))

--- a/instapy/settings.py
+++ b/instapy/settings.py
@@ -56,5 +56,27 @@ class Settings:
 
 class Storage:
     """ Globally accessible standalone storage """
+
     # store realtime record activity data
     record_activity = {}
+
+
+class Selectors:
+    """
+    Store XPath, CSS, and other element selectors to be used at many places
+    """
+
+    likes_dialog_body_xpath = (
+        "//h1[text()='Likes']/../../following-sibling::div/div")
+
+    likes_dialog_close_xpath = "//span[contains(@aria-label, 'Close')]"
+
+
+
+
+
+
+
+
+
+

--- a/instapy/util.py
+++ b/instapy/util.py
@@ -1856,6 +1856,24 @@ def save_account_progress(browser, username, logger):
     except Exception:
         logger.exception('message')
 
+
+def get_users_from_dialog(old_data, dialog):
+    """
+    Prepared to work specially with the dynamic data load in the 'Likes'
+    dialog box
+    """
+
+    user_blocks = dialog.find_elements_by_tag_name('a')
+    loaded_users = [
+        extract_text_from_element(u) for u in user_blocks
+        if extract_text_from_element(u)
+    ]
+    new_data = (old_data + loaded_users)
+    new_data = remove_duplicates(new_data, True, None)
+
+    return new_data
+
+
 def progress_tracker(current_value, highest_value, initial_time, logger):
     """ Provide a progress tracker to keep value updated until finishes """
     if (current_value is None or

--- a/instapy/util.py
+++ b/instapy/util.py
@@ -1931,3 +1931,15 @@ def progress_tracker(current_value, highest_value, initial_time, logger):
         logger.info("Error occurred with Progress Tracker:\n{}".format(
             str(exc).encode("utf-8")))
 
+
+def close_dialog_box(browser):
+    """ Click on the close button spec. in the 'Likes' dialog box """
+
+    try:
+        close = browser.find_element_by_xpath(
+            Selectors.likes_dialog_close_xpath)
+        click_element(browser, close)
+
+    except NoSuchElementException as exc:
+        pass
+

--- a/instapy/util.py
+++ b/instapy/util.py
@@ -28,6 +28,7 @@ from .time_util import sleep_actual
 from .database_engine import get_database
 from .quota_supervisor import quota_supervisor
 from .settings import Settings
+from .settings import Selectors
 
 from selenium.common.exceptions import NoSuchElementException
 from selenium.common.exceptions import WebDriverException
@@ -555,8 +556,9 @@ def get_active_users(browser, username, posts, boundary, logger):
                 # Video have no likes button / no posts in page
                 continue
 
+            # get a reference to the 'Likes' dialog box
             dialog = browser.find_element_by_xpath(
-                "//div[text()='Likes']/following-sibling::div")
+                Selectors.likes_dialog_body_xpath)
 
             scroll_it = True
             try_again = 0


### PR DESCRIPTION
I wanted to solve this issue after reading @sionking said that feature does not work anymore.

He wanted [proposed] to roughly apply the steps in the newly fixed `likers_from_photo()` function inside this feature- `get_active_users()` at #3764.

But `get_active_users()` function is not as simple as `likers_from_photo()` since `get_active_users()` is written to behave smartly.
E.g. I remember, I made it realize when it hits the bottom of the dialog box and stop scrolling at that point so that no any extra server call would be sent.

That was the main reason I solved it - to save `get_active_users()` from possible loss 😎

---

Also, now `set_dont_unfollow_active_users()` feature also has a Progress Tracker support.

Each commit made is unique with its specific explanation.
Please, read commit descriptions to view the changes occurred inside this PR.


---

Cheers 😁
---