### PR TITLE
Fixed bypass_suspicious_login issue

### DIFF
--- a/instapy/login_util.py
+++ b/instapy/login_util.py
@@ -60,7 +60,7 @@ def bypass_suspicious_login(browser, bypass_with_mobile):
     try:
         send_security_code_button = browser.find_element_by_xpath("//button[text()='Send Security Code']")
     except NoSuchElementException:
-        print("Unable to locate email or phone button, maybe "
+        print("Unable to locate security code button, maybe "
               "bypass_suspicious_login=True isn't needed anymore.")
         return False
 

--- a/instapy/login_util.py
+++ b/instapy/login_util.py
@@ -58,40 +58,11 @@ def bypass_suspicious_login(browser, bypass_with_mobile):
         pass
 
     try:
-        choice = browser.find_element_by_xpath(
-            "//label[@for='choice_1']").text
-
+        send_security_code_button = browser.find_element_by_xpath("//button[text()='Send Security Code']")
     except NoSuchElementException:
-        try:
-            choice = browser.find_element_by_xpath(
-                "//label[@class='_q0nt5']").text
-
-        except Exception:
-            try:
-                choice = browser.find_element_by_xpath(
-                    "//label[@class='_q0nt5 _a7z3k']").text
-
-            except Exception:
-                print("Unable to locate email or phone button, maybe "
-                      "bypass_suspicious_login=True isn't needed anymore.")
-                return False
-
-    if bypass_with_mobile:
-        choice = browser.find_element_by_xpath(
-            "//label[@for='choice_0']").text
-
-        mobile_button = browser.find_element_by_xpath(
-            "//label[@for='choice_0']")
-
-        (ActionChains(browser)
-         .move_to_element(mobile_button)
-         .click()
-         .perform())
-
-        sleep(5)
-
-    send_security_code_button = browser.find_element_by_xpath(
-        "//button[text()='Send Security Code']")
+        print("Unable to locate email or phone button, maybe "
+              "bypass_suspicious_login=True isn't needed anymore.")
+        return False
 
     (ActionChains(browser)
      .move_to_element(send_security_code_button)
@@ -102,7 +73,7 @@ def bypass_suspicious_login(browser, bypass_with_mobile):
     update_activity()
 
     print('Instagram detected an unusual login attempt')
-    print('A security code was sent to your {}'.format(choice))
+    print('A security code was sent to your phone')
     security_code = input('Type the security code here: ')
 
     security_code_field = browser.find_element_by_xpath((
@@ -164,7 +135,7 @@ def login_user(browser,
     # try to load cookie from username
     try:
         for cookie in pickle.load(open('{0}{1}_cookie.pkl'
-                                       .format(logfolder, username), 'rb')):
+                                               .format(logfolder, username), 'rb')):
             browser.add_cookie(cookie)
             cookie_loaded = True
     except (WebDriverException, OSError, IOError):

--- a/instapy/settings.py
+++ b/instapy/settings.py
@@ -1,8 +1,9 @@
 """ Global variables """
 import os
 from sys import platform as p_os
+import sys
 
-BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+BASE_DIR = sys.path[0]
 OS_ENV = "windows" if p_os == "win32" else "osx" if p_os == "darwin" else \
     "linux"
 
@@ -70,13 +71,3 @@ class Selectors:
         "//h1[text()='Likes']/../../following-sibling::div/div")
 
     likes_dialog_close_xpath = "//span[contains(@aria-label, 'Close')]"
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
It appears that when a suspicious login is detected, Instagram no longer displays the page to choose between phone or e-mail. It goes straight to phone, failing the login. 
This would resolve issues like [this](/timgrossmann/InstaPy/issues/3725)