### PR TITLE
grab_posts_likers

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Table of Contents
   * [Unfollowing](#unfollowing)
   * [Remove outgoing follow requests](#remove-outgoing-follow-requests)
   * [Don't unfollow active users](#dont-unfollow-active-users)
+  * [Retrieve last posts likers](#retrieve-last-posts-likers)
   * [Interactions based on the number of followers and/or following a user has](#interactions-based-on-the-number-of-followers-andor-following-a-user-has)
   * [Interactions based on the number of posts a user has](#interactions-based-on-the-number-of-posts-a-user-has)
   * [Skipping user for private account, no profile picture, business account](#skipping-user-for-private-account-no-profile-picture-business-account)
@@ -703,6 +704,39 @@ session.remove_follow_requests(amount=200, sleep_delay=600)
 
 session.set_dont_unfollow_active_users(enabled=True, posts=5)
 ```
+
+
+### Retrieve last posts likers
+
+You can retrieve the most active users or ghost followers by analysing who liked your last posts.
+
+```python
+# this retrieves the last 5 posts likers
+session.grab_posts_likers(posts=5)
+```
+
+A simple list of tuples is returned:
+
+```python
+[
+('http://instagram.com/last_post_url', ['user1', 'user2', ...]),
+('http://instagram.com/second_to_last_post_url', ['user3', 'user4', ...])
+]
+```
+
+By using this list you can rank the most active users, determine ghost followers and much more.
+The URL helps identifying which post the likers list is referred to (for example to save the list of likers to retrieve later on).
+
+`skip_posts` argument can be used to specify which post you want to start analysing. For example
+
+```python
+likers_posts_1_and_2 = session.grab_posts_likers(posts=2)
+likers_posts_3_and_4_and_5 = session.grab_posts_likers(posts=3, skip_posts=2)
+likers_post_6 = session.grab_posts_likers(posts=1, skip_posts=5)
+```
+
+This parameter allows you to do this long analysis even in different days. Or retrieve and merge data again to update  information from recent posts.
+
 
 ### Interactions based on the number of followers and/or following a user has
 

--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -39,6 +39,7 @@ from .print_log_writer import log_following_num
 from .time_util import sleep
 from .time_util import set_sleep_percentage
 from .util import get_active_users
+from .util import get_posts_likers
 from .util import validate_username
 from .util import web_address_navigator
 from .util import interruption_handler
@@ -3788,6 +3789,23 @@ class InstaPy:
         # except:
         except Exception:
             self.logger.info('Campaign {} first run'.format(campaign))
+
+    def grab_posts_likers(self,
+                    posts=3,
+                    skip_posts=0,
+                    boundary=None,
+                    username=None):
+
+        if username is None:
+            username = self.username
+        
+        # return list of users who liked posts
+        return get_posts_likers(self.browser,
+                                username,
+                                posts,
+                                skip_posts,
+                                boundary,
+                                self.logger)
 
     def grab_followers(self,
                        username=None,


### PR DESCRIPTION
Refactoring of code to retrieve likers from the last posts. This functionality was already there, but hidden and called only from `set_dont_unfollow_active_users`, these likers were merged together creating a single list of active users, which makes that retrieval only useful only for that functionality.

Now instead `get_active_users` calls the new function `get_posts_likers(browser, username, posts, skip_posts, boundary, logger)`. This function is basically the same as `get_active_users` but it retrieves the likers from the last `posts` posts as a list of tuples:

[(post1_url, likers_nicknames_list), (post2_url, likers_nicknames_list), ...]

In this way this list can be saved, or it can be utilized for further analyses (e.g. most loyal users, etc.)

`get_active_users` now has the same behaviour as before, but it uses `get_posts_likers` to avoid duplicated code.

I believe this functionality is very important to determine the quality of following people, without limiting the behaviour to a simple "unfollow if is not active in the last 7 photos".
