### PR TITLE
Pass arguments by CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Implemented in Python using the Selenium module.
 **Have an issue?**
 If you should encounter any issue, please first [search for similar issues](https://github.com/timgrossmann/InstaPy/issues) and only if you can't find any, create a new issue or use the [discord channel](https://discord.gg/FDETsht) for help.
 
-#### Newsletter: [SignUp for the Newsletter here!](http://eepurl.com/cZbV_v)
+#### Newsletter: [Sign Up for the Newsletter here!](http://eepurl.com/cZbV_v)
 
 
 ## **Installation**
@@ -36,50 +36,67 @@ Now all you need is a **quickstart** script to start _InstaPy_ 🥳
 
 <br /> 
 
-You can also copy and paste this basic quickstart into a new text file and save it as `.py` file.
+You can also copy and paste this basic **quickstart** into a new text file and save it as `.py` file.
 ```python		
 """ Quickstart script for InstaPy usage """		
 # imports		
 from instapy import InstaPy		
 from instapy import smart_run		
 	
-# login credentials		
-insta_username = ''		
-insta_password = ''		
-	
 # get an InstaPy session!		
-# set headless_browser=True to run InstaPy in the background		
-session = InstaPy(username=insta_username,		
-                  password=insta_password,		
-                  headless_browser=False)		
+session = InstaPy()		
 	
 with smart_run(session):		
     """ Activity flow """		
     # general settings		
-    session.set_relationship_bounds(enabled=True,		
-                                    delimit_by_numbers=True,		
-                                    max_followers=4590,		
-                                    min_followers=45,		
-                                    min_following=77)		
-	
     session.set_dont_include(["friend1", "friend2", "friend3"])		
-    session.set_dont_like(["pizza", "#store"])		
 	
     # activity		
     session.like_by_tags(["natgeo"], amount=10)		
- ```
+```
 
 </details>
 
 <br />
 
-After downloading a **quickstart** script to your computer, you can run it in the command prompt as:
+🛰 As you've downloaded a **quickstart** script into your computer, go ahead and run it in the command prompt as:
 ```elm
-python quickstart.py
+python quickstart.py --username abc --password 123
+```
+>**PRO**:  
+Read more about passing arguments from the command line interface in the section - [Pass arguments by CLI](#pass-arguments-by-cli).
+
+<br />
+
+##### 🚁 You can provide _username_ & _password_ inside the **quickstart** script, too!
+```python
+# inside quickstart script
+
+session = InstaPy(username="abc",    
+                  password="123")   
 ```
 
-> If you've used InstaPy before installing it with `pip`, you have to move your old data to the new workspace folder once.
+<br />
+
+🛸 Also, if you like to run _InstaPy_ in **background**, just enable the **headless** mode!
+```erlang
+python quickstart.py -u abc -p 123 --headless-browser
+```
+Or do it right inside the **quickstart** script.
+```python
+# inside quickstart script
+
+session = InstaPy(username="abc",    
+                  password="123",
+                  headless_browser=True)  
+```
+_Until you enable the **headless** mode, InstaPy will run in the **graphical** mode where you can watch the ongoing automation in your web browser_.
+
+
+> If you've used _InstaPy_ before installing it by **pip**, you have to move your _old_ data to the new **workspace** folder for once.
 [Read how to do this here](#migrating-your-data-to-the-workspace-folder).
+
+<br />
 
 #### **Update**
 ```elm
@@ -98,6 +115,8 @@ pip install instapy==0.1.1
 pip uninstall instapy
 ```
 
+<br />
+
 --- 
 
 ### Social
@@ -107,18 +126,18 @@ pip uninstall instapy
 
 ### Do you need help ?
 
-<a href="https://discord.gg/FDETsht"><img alt="Discord channel" src="https://camo.githubusercontent.com/e4a739df27356a78e9cae2e2dda642d118567e7c/68747470733a2f2f737465616d63646e2d612e616b616d616968642e6e65742f737465616d636f6d6d756e6974792f7075626c69632f696d616765732f636c616e732f32373039303534312f386464356339303766326130656563623733646336613437373666633961323538373865626364642e706e67" width=250/></a>
+<a href="https://discord.gg/FDETsht">
+  <img hspace="3" alt="Discord channel" src="https://camo.githubusercontent.com/e4a739df27356a78e9cae2e2dda642d118567e7c/68747470733a2f2f737465616d63646e2d612e616b616d616968642e6e65742f737465616d636f6d6d756e6974792f7075626c69632f696d616765732f636c616e732f32373039303534312f386464356339303766326130656563623733646336613437373666633961323538373865626364642e706e67" width=214/>
+</a>
 
 ### Do you want to support us ?
 
 <a href="https://opencollective.com/instapy/donate" target="_blank">
-  <img src="https://opencollective.com/instapy/contribute/button@2x.png?color=blue" width=300 />
+  <img align="left" hspace="10" src="https://opencollective.com/instapy/contribute/button@2x.png?color=blue" width=300 />
 </a>
 
-<br />
-
 <a href="https://www.paypal.me/supportInstaPy">
-	<img alt="paypalme" src="http://codeinpython.com/tutorials/wp-content/uploads/2017/09/PayPal-ME-300x300.jpg.png" width=100/>
+  <img hspace="14" alt="paypalme" src="http://codeinpython.com/tutorials/wp-content/uploads/2017/09/PayPal-ME-300x300.jpg.png" width=100 />
 </a>
 
 **Help build InstaPy!**      
@@ -222,10 +241,11 @@ Head over to https://github.com/timgrossmann/InstaPy/wiki/How-to-Contribute to f
   * [Changing DB or Chromedriver locations](#changing-db-or-chromedriver-locations)
   * [Custom action delays](#custom-action-delays)
   * [How to avoid _python_ & **pip** confusion](#how-to-avoid-python--pip-confusion)
+  * [Pass arguments by CLI](#pass-arguments-by-cli)
 
 
 ### Advanced Installation
-#### Install or update to the unreleased version  
+#### 🛠 Install or update to the unreleased version  
 For example, there is a **bug** and its **fix** is _merged to the repo_ but a newer version of _InstaPy_ [_containing_ that **fix**] is not yet released to _PyPI_ to be able to be _installed_ or _updated_ by **pip**.  
 
 Then, you can do this to install the **actual state** of the _repo_ 😋
@@ -256,8 +276,10 @@ That's why you will be able to install the actual state of the repo using the `-
 >**PRO** Tip:  
   Read the section - [How to avoid _python_ & **pip** confusion](#how-to-avoid-python--pip-confusion) 😄
 
+<br />
 
-#### Install manually and manage using advanced git commands
+#### ⚗ Install manually and manage using advanced git commands
+###### For those who want to tweak or enhance _InstaPy_.
 
 **1**. Clone _InstaPy_ repository into your computer
 ```erlang
@@ -271,16 +293,32 @@ cd InstaPy
 
 **3**. Install the _local_ **instapy** package
 ```erlang
-pip install .
+pip install -e .
 ```
+<details>
+  <summary>
+    <b>
+      Learn why <code>-e</code> flag is required 🔎
+    </b>
+  </summary>
+
+Since you're gonna install the local version of _InstaPy_ you'll probably change its code per your need which is the reason you do an advanced installation from a _Git_ source, then if you don't use the `-e` flag, you'll have to install that local package by **pip** every time after making a change.  
+
+But fortunately, `-e` flag comes to help;  
+`-e` means _editable_ install, so that after editing files you don't need to re-install the package again since it will always refer to the edited files cos with the _editable_ install, it just **links** the project's location to **pip**'s install location _rather than_ adding them to **pip** location separately..
+<br />
+</details>
 or
+
 ```erlang
 python setup.py install
 ```
 
-#### Install into a Virtual Environment
+<br />
 
-###### The best way to install _InstaPy_ is to create a virtual environment and install _InstaPy_ there, then, run it from a separate file
+#### ⛑ Install into a Virtual Environment
+
+###### The best way to install _InstaPy_ is to create a virtual environment and install _InstaPy_ there, then, run it from a separate file.
 
 <details>
   <summary>
@@ -313,7 +351,7 @@ source venv/bin/activate
 
 **5**. Install the _local_ **instapy** package
 ```erlang
-pip install .
+pip install -e .
 ```
 
 
@@ -342,7 +380,7 @@ venv\Scripts\activate.bat
 
 **5**. Install the _local_ **instapy** package
 ```erlang
-pip install .
+pip install -e .
 ```
 
 
@@ -393,7 +431,7 @@ In essence,
 
 </details>
 
-
+<br />
 
 ## InstaPy Available Features
 
@@ -2503,7 +2541,7 @@ To do this simply pass the `disable_image_load=True` parameter in the InstaPy co
 session = InstaPy(username=insta_username,
                   password=insta_password,
                   headless_browser=False,
-		  disable_image_load=True,
+		              disable_image_load=True,
                   multi_logs=True)
 ```
 
@@ -2620,6 +2658,140 @@ python -m pip show instapy
 
 Using this style, you will never have to worry about what is the correct alias of the **pip** for you specific _python_ installation and all you have to know is just the _python_'s alias you use.  
 
+
+
+### Pass arguments by CLI
+###### It is recommended to pass your credentials from command line interface rather than storing them inside quickstart scripts.  
+
+Note that, arguments passed from the CLI has higher priorities than the arguments inside a **quickstart** script.  
+E.g., let's assume you have,
+```python
+# inside quickstart script
+
+session = InstaPy(username="abc")
+```
+and you start that **quickstart** script as,
+```erlang
+python quickstart.py -u abcdef -p 12345678
+```
+Then, your _username_ will be set as `abcdef` rather than `abc`.  
+_And obviously, if you don't pass the flag, it'll try to get that argument from the **quickstart** script [if any]_.
+
+#### Currently these _flags_ are supported:
+  🚩 `-u` abc, `--username` abc
+   - Sets your username.
+
+  🚩 `-p` 123, `--password` 123
+   - Sets your password.
+
+  🚩 `-pd` 25, `--page-delay` 25
+   - Sets the implicit wait.
+
+  🚩 `-pa` 192.168.1.1, `--proxy-address` 192.168.1.1
+   - Sets the proxy address.
+
+  🚩 `-pp` 8080, `--proxy-port` 8080
+   - Sets the proxy port.
+
+  🚩 `-uf`, `--use-firefox`
+   - Enables Firefox.
+
+  🚩 `-hb`, `--headless-browser`
+   - Enables headless mode.
+
+  🚩 `-dil`, `--disable-image-load`
+   - Disables image load.
+
+  🚩 `-bsa`, `--bypass-suspicious-attempt`
+   - Bypasses suspicious attempt.
+
+  🚩 `-bwm`, `--bypass-with-mobile`
+   - Bypasses with mobile phone.
+
+To get the list of available commands, you can type,
+```erlang
+python quickstart.py -h
+# or
+python quickstart.py --help
+```
+
+#### Examples
+⚽ Let's quickly set your username and password right by CLI,   
+```erlang
+python quickstart.py -u Toto.Lin8  -p 4X27_Tibor
+# or
+python quickstart.py --username Toto.Lin8  --password 4X27_Tibor
+# or
+python quickstart.py -u "Toto.Lin8"  -p "4X27_Tibor"
+```
+
+⚽ Enable Firefox,
+```erlang
+python quickstart.py -uf
+# or
+python quickstart.py --use-firefox
+```
+
+<details>
+<summary>
+  <h4>
+    Advanced 🔎
+  </h4>
+</summary> 
+
+You can **pass** and then **parse** the **_custom_** CLI arguments you like right inside the **quickstart** script.  
+To do it, open up your **quickstart** script and add these lines,
+```python
+# inside quickstart script
+
+import argparse
+
+my_parser = argparse.ArgumentParser()
+# add the arguments as you like WHICH you will pass
+# e.g., here is the simplest example you can see,
+my_parser.add_argument("--my-data-files-name")
+args, args_unknown = my_parser.parse_known_args()
+
+filename = args.my_data_files_name
+
+# now you can print it
+print(filename)
+
+# or open that file
+with open(filename, 'r') as f:
+    my_data = f.read()
+```
+After adding your custom arguments to the **quickstart** script, you can now **pass** them by CLI, comfortably,
+```erlang
+python quickstart.py --my-data-files-name "C:\\Users\\Anita\\Desktop\\data_file.txt"
+```
+>**NOTE**:  
+Use **dash** in flag and parse them with **underscores**;  
+E.g., we have used the flag as **`--my-data-files-name`** and parsed it as `args.`**`my_data_files_name`** ...
+
+>**PRO**:
+See `parse_cli_args()` function [used internally] inside the **util.py** file to write & parse more advanced flags.  
+You can also import that function into your **quickstart** script and parse the **formal** flags into there to be used, as well.
+
+```python
+# inside quickstart script
+
+from instapy.util import parse_cli_args
+
+
+cli_args = parse_cli_args()
+username = cli_args.username
+
+print(username)
+```
+👆🏼👉🏼 as you will pass the _username_ like,
+```erlang
+python quickstart.py -u abc
+```
+
+</details>
+
+<br />
 
 
 ---

--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -46,6 +46,7 @@ from .util import highlight_print
 from .util import dump_record_activity
 from .util import truncate_float
 from .util import save_account_progress
+from .util import parse_cli_args
 from .unfollow_util import get_given_user_followers
 from .unfollow_util import get_given_user_following
 from .unfollow_util import unfollow
@@ -97,6 +98,19 @@ class InstaPy:
                  bypass_suspicious_attempt=False,
                  bypass_with_mobile=False,
                  multi_logs=True):
+
+        cli_args = parse_cli_args()
+        username = cli_args.username or username
+        password = cli_args.password or password
+        use_firefox = cli_args.use_firefox or use_firefox
+        page_delay = cli_args.page_delay or page_delay
+        headless_browser = cli_args.headless_browser or headless_browser
+        proxy_address = cli_args.proxy_address or proxy_address
+        proxy_port = cli_args.proxy_port or proxy_port
+        disable_image_load = cli_args.disable_image_load or disable_image_load
+        bypass_suspicious_attempt = (
+            cli_args.bypass_suspicious_attempt or bypass_suspicious_attempt)
+        bypass_with_mobile = cli_args.bypass_with_mobile or bypass_with_mobile
 
         Settings.InstaPy_is_running = True
         # workspace must be ready before anything

--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -204,13 +204,13 @@ class InstaPy:
         self.clarifai_check_video = False
         self.clarifai_proxy = None
 
-        self.potency_ratio = 1.3466
-        self.delimit_by_numbers = True
+        self.potency_ratio = None   # 1.3466
+        self.delimit_by_numbers = None
 
-        self.max_followers = 90000
-        self.max_following = 66834
-        self.min_followers = 35
-        self.min_following = 27
+        self.max_followers = None   # 90000
+        self.max_following = None   # 66834
+        self.min_followers = None   # 35
+        self.min_following = None   # 27
 
         self.delimit_liking = False
         self.liking_approved = True
@@ -1087,6 +1087,7 @@ class InstaPy:
                                 min_following=None):
         """Sets the potency ratio and limits to the provide an efficient
         activity between the targeted masses"""
+
         self.potency_ratio = potency_ratio if enabled is True else None
         self.delimit_by_numbers = delimit_by_numbers if enabled is True else \
             None

--- a/instapy/util.py
+++ b/instapy/util.py
@@ -18,6 +18,7 @@ from contextlib import contextmanager
 from tempfile import gettempdir
 import emoji
 from emoji.unicode_codes import UNICODE_EMOJI
+import argparse
 
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as ec
@@ -1997,3 +1998,69 @@ def close_dialog_box(browser):
 
     except NoSuchElementException as exc:
         pass
+
+
+def parse_cli_args():
+    """ Parse arguments passed by command line interface """
+
+    parser = argparse.ArgumentParser(
+        prog="InstaPy",
+        description="Parse InstaPy constructor's arguments",
+        epilog="And that's how you'd pass arguments by CLI..",
+        conflict_handler='resolve')
+
+    """ Flags that REQUIRE a value once added
+    ```python quickstart.py --username abc```
+    """
+    parser.add_argument(
+        "-u", "--username", help="Username", type=str, metavar="abc")
+    parser.add_argument(
+        "-p", "--password", help="Password", type=str, metavar="123")
+    parser.add_argument(
+        "-pd", "--page-delay", help="Implicit wait", type=int, metavar="25")
+    parser.add_argument(
+        "-pa", "--proxy-address", help="Proxy address",
+        type=str, metavar="192.168.1.1")
+    parser.add_argument(
+        "-pp", "--proxy-port", help="Proxy port", type=str, metavar="8080")
+
+    """ Auto-booleans: adding these flags ENABLE themselves automatically
+    ```python quickstart.py --use-firefox```
+    """
+    parser.add_argument(
+        "-uf", "--use-firefox", help="Use Firefox",
+        action="store_true", default=None)
+    parser.add_argument(
+        "-hb", "--headless-browser", help="Headless browser",
+        action="store_true", default=None)
+    parser.add_argument(
+        "-dil", "--disable-image-load", help="Disable image load",
+        action="store_true", default=None)
+    parser.add_argument(
+        "-bsa", "--bypass-suspicious-attempt",
+        help="Bypass suspicious attempt", action="store_true", default=None)
+    parser.add_argument(
+        "-bwm", "--bypass-with-mobile", help="Bypass with mobile phone",
+        action="store_true", default=None)
+
+    """ Style below can convert strings into booleans:
+    ```parser.add_argument("--is-debug",
+                           default=False,
+                           type=lambda x: (str(x).capitalize() == "True"))```
+
+    So that, you can pass bool values explicitly from CLI,
+    ```python quickstart.py --is-debug True```
+
+    NOTE: This style is the easiest of it and currently not being used.
+    """
+
+    args, args_unknown = parser.parse_known_args()
+    """ Once added custom arguments if you use a reserved name of core flags
+    and don't parse it, e.g.,
+    `-ufa` will misbehave cos it has `-uf` reserved flag in it.
+
+    But if you parse it, it's okay.
+    """
+
+    return args
+

--- a/instapy/util.py
+++ b/instapy/util.py
@@ -10,6 +10,7 @@ import os
 import sys
 from sys import exit as clean_exit
 from platform import system
+from platform import python_version
 from subprocess import call
 import csv
 import sqlite3
@@ -18,7 +19,7 @@ from contextlib import contextmanager
 from tempfile import gettempdir
 import emoji
 from emoji.unicode_codes import UNICODE_EMOJI
-import argparse
+from argparse import ArgumentParser
 
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as ec
@@ -2003,11 +2004,15 @@ def close_dialog_box(browser):
 def parse_cli_args():
     """ Parse arguments passed by command line interface """
 
-    parser = argparse.ArgumentParser(
-        prog="InstaPy",
-        description="Parse InstaPy constructor's arguments",
-        epilog="And that's how you'd pass arguments by CLI..",
-        conflict_handler='resolve')
+    AP_kwargs = dict(prog="InstaPy",
+                     description="Parse InstaPy constructor's arguments",
+                     epilog="And that's how you'd pass arguments by CLI..",
+                     conflict_handler="resolve")
+    if python_version() < "3.5":
+        parser = CustomizedArgumentParser(**AP_kwargs)
+    else:
+        AP_kwargs.update(allow_abbrev=False)
+        parser = ArgumentParser(**AP_kwargs)
 
     """ Flags that REQUIRE a value once added
     ```python quickstart.py --username abc```
@@ -2063,4 +2068,28 @@ def parse_cli_args():
     """
 
     return args
+
+
+class CustomizedArgumentParser(ArgumentParser):
+    """
+     Subclass ArgumentParser in order to turn off
+    the abbreviation matching on older pythons.
+
+    `allow_abbrev` parameter was added by Python 3.5 to do it.
+    Thanks to @paul.j3 - https://bugs.python.org/msg204678 for this solution.
+    """
+
+    def _get_option_tuples(self, option_string):
+        """
+         Default of this method searches through all possible prefixes
+        of the option string and all actions in the parser for possible
+        interpretations.
+
+        To view the original source of this method, running,
+        ```
+        import inspect; import argparse; inspect.getsourcefile(argparse)
+        ```
+        will give the location of the 'argparse.py' file that have this method.
+        """
+        return []
 

--- a/quickstart.py
+++ b/quickstart.py
@@ -1,33 +1,21 @@
 """ Quickstart script for InstaPy usage """
+
 # imports
 from instapy import InstaPy
 from instapy import smart_run
 from instapy import set_workspace
 
-# login credentials
-insta_username = ''
-insta_password = ''
 
 # set workspace folder at desired location (default is at your home folder)
 set_workspace(path=None)
 
 # get an InstaPy session!
-# set headless_browser=True to run InstaPy in the background
-session = InstaPy(username=insta_username,
-                  password=insta_password,
-                  headless_browser=False)
+session = InstaPy()
 
 with smart_run(session):
     """ Activity flow """
     # general settings
-    session.set_relationship_bounds(enabled=True,
-                                    delimit_by_numbers=True,
-                                    max_followers=4590,
-                                    min_followers=45,
-                                    min_following=77)
-
     session.set_dont_include(["friend1", "friend2", "friend3"])
-    session.set_dont_like(["pizza", "#store"])
 
     # activity
     session.like_by_tags(["natgeo"], amount=10)


### PR DESCRIPTION
<p align="center">
  <img src="https://user-images.githubusercontent.com/33269249/52164128-05141500-2706-11e9-8319-8a33b19ba959.gif">
  <img src="https://user-images.githubusercontent.com/33269249/52164210-2e817080-2707-11e9-9630-a89a810284eb.gif">
<p>

Thanks to @RuiFerreira#9357 from our _Discord_ server for the idea of parsing CLI args after what I've decided to share the solution with the community 🎊
And special thanks to @timgrossmann for design decisions.

I encourage you to view the changes at Readme - [Pass arguments by CLI](https://github.com/uluQulu/InstaPy/tree/dev#pass-arguments-by-cli) which explains _almost_ everything I can say.
One of the good news is it is implemented to be **fully flexible** for several use cases user can produce.

<br />

By default, it can parse 10 formal arguments of the _InstaPy_ constructor - [Currently these flags are supported](https://github.com/uluQulu/InstaPy/tree/dev#currently-these-flags-are-supported).

To get the list of available commands, you can type,
```erlang
python quickstart.py -h
# or
python quickstart.py --help
```

<h3>
  <a href="https://github.com/uluQulu/InstaPy/tree/dev#examples-2">
    Examples
  </a>
</h3>

⚽ Let's quickly set your username and password right by CLI,   
```erlang
python quickstart.py -u Toto.Lin8  -p 4X27_Tibor
# or
python quickstart.py --username Toto.Lin8  --password 4X27_Tibor
# or
python quickstart.py -u "Toto.Lin8"  -p "4X27_Tibor"
```

⚽ Enable Firefox,
```erlang
python quickstart.py -uf
# or
python quickstart.py --use-firefox
```

<br />

<h3>
  <a href="https://github.com/uluQulu/InstaPy/tree/dev#----advanced---">
    Advanced
  </a>
</h3>

You can extend it per your use case like this,
```python
# inside quickstart script

import argparse


my_parser = argparse.ArgumentParser()
my_parser.add_argument("--my-data-files-name")
args, args_unknown = my_parser.parse_known_args()

filename = args.my_data_files_name
with open(filename, 'r') as f:
    my_data = f.read()
```
```erlang
python quickstart.py --my-data-files-name "C:\\Users\\Anita\\Desktop\\data_file.txt"
```

<br />

🌌 You can also import that function into your **quickstart** script and parse the **formal** flags into there to be used, as well.
```python
# inside quickstart script

from instapy.util import parse_cli_args


cli_args = parse_cli_args()
username = cli_args.username

print(username)
```
👆🏼👉🏼 as you will pass the _username_ like,
```erlang
python quickstart.py -u abc
```

>**NOTE**:
Arguments passed from CLI has higher priorities than the arguments inside a **quickstart** script (_read more [here](https://github.com/uluQulu/InstaPy/tree/dev#pass-arguments-by-cli)_).

>**TIP**: 
**quickstart.py** is just a name of the sample _**quickstart** script_.
Your _**quickstart** script_ might be called anything else, e.g. **simple_but_effective.py** and then you'll pass arguments normally,
```erlang
python simple_but_effective.py -u abc -p 123
```

### Details
I have used **argparse**.
E.g. I've noticed **pip** itself uses **optparse** (_see `pip -h`_). 
Or my fav python package- **youtube-dl** also uses **optparse** in most portions but also has a minimal **argparse** usage.

So why I chose **argparse** over others?
As of today, it is the best option.
Why?
- Is part of the standard library.
- Supported by Python >= 2.7.
- Is better than **optparse** (_which is an older lib_) in almost all ways and can produce better help screens than it.
Also, **optparse** has been deprecated with these official statements;
"_[Deprecated since version 2.7](https://docs.python.org/2/library/optparse.html): The **optparse** module is deprecated and will not be developed further; development will continue with the **argparse** module._"
"_[Deprecated since version 3.2](https://docs.python.org/3/library/optparse.html): The **optparse** module is deprecated and will not be developed further; development will continue with the **argparse** module._"

#### What about other alternatives?
There are several built-in and also external packages that are really good and some of them are more high-level increasing ease of use.
But for our case **argparse** is sufficient enough and of course, if there could be a case where **argparse** couldn't handle, then other alternatives would be considered in the future since it will be not any difficult having that kind of libs working analogically.

### Final

What does this style **bring**?
 - It opens new possibilities to users to extend their usage 🎂
 - It adds another layer of security for users who has mistakenly shared their login credentials in several places while providing their setup for debugging issues 🔐
 - It'll help ppl who vastly schedule jobs and now with CLI args, it will devastatingly ease their usage 🏍
 - Help contributors, collaborators & Tim to push files without worrying if they have removed the login credentials from the _**quickstart** script_ 😂
 - Quickly set/test different arguments without opening a text editor 👈🏼 debuggers friend 🥰
 - Etc.

## Other changes
+ Turn **off** verification based on _relationship bounds_ **by default**, completely - https://github.com/timgrossmann/InstaPy/commit/757815f73ed1246c5340dc487a8b1c556b4f20db.

_Before_ I **extended** the verification based on _relationship bounds_, it was _already_ enabled **by default** with pre-defined values, so after that I _preserved_ it.  
And I _initially_ supported that idea - being enabled **by default** until user _explicitly disables_..  
Cos I thought it'd kind of 'force' ppl to target the correct audience of their choice.  

But, during that time, I have seen **lots of** newbies who really complain that _`'it does not like anything'`_ [or so] and then they realize that it's cos of not configuring the relationship bounds well.  
Although, **logger messages** regarding _relationship bounds_ are very **clear**, it's just some of the very new users who _couldn't_ understand it..  
Also, right now, that config is **quite famous** amongst usage, so that is _fine_ to turn it off **by default**.  

  
###### _Please, read the **commit descriptions** for the **other** _little_ changes that occurred_.
---

<p> 
<img align="left" src="https://user-images.githubusercontent.com/33269249/52164593-3b08c780-270d-11e9-9359-9c94c6078f6a.gif"> 
<img align="left" width="85" src="https://i.imgur.com/NaQecF6.gif">
</p>

<sub>Please, feel free to ask any question you've got.</sub>
