### PR TITLE
Python3.7 + remove chromedriver package

### DIFF
--- a/docker_conf/python/Dockerfile
+++ b/docker_conf/python/Dockerfile
@@ -1,8 +1,7 @@
-FROM python:3.6-slim-stretch
+FROM python:3.7-slim-stretch
 COPY ./requirements.txt /tmp
 RUN apt-get update \
     && apt-get install -y --no-install-recommends --no-install-suggests \
-      chromedriver \
       wget \
       gcc \
       g++ \


### PR DESCRIPTION
Hello guys,

This PR is about two things:

- Using `Python3.7` for Docker image to be consistent with classic code.
- Removing `chromedriver` package installation by `apt` , because it is install by `pip` : the image size down to 241MB instead of 515MB.

Regards,
Herrox