### PR TITLE
Only import instapy-chromedriver when necessary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,12 @@ The **goal** of this file is explaining to the users of our project the notable 
 
 _The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)_.
 
+## [0.1.4] - INSERT MERGING DATE HERE
+### Fixed
+- Only import instapy-chromedriver package when needed
 
-## [0.1.3] - UNKNOWN
+
+## [0.1.3] - 2019-02-05
 ### Fixed
 - Fix "_Failed to load desired amount of users!_" issue.
 

--- a/instapy/file_manager.py
+++ b/instapy/file_manager.py
@@ -8,8 +8,6 @@ from os.path import isfile as file_exists
 from os.path import sep as native_slash
 from platform import python_version
 
-from instapy_chromedriver import binary_path
-
 from .util import highlight_print
 from .settings import Settings
 from .settings import localize_path
@@ -221,6 +219,9 @@ def get_chromedriver_location():
         workspace_path = slashen(WORKSPACE["path"], "native")
         assets_path = "{}{}assets".format(workspace_path, native_slash)
         validate_path(assets_path)
+
+        # only import from this package when necessary
+        from instapy_chromedriver import binary_path
 
         CD = binary_path
         chrome_version = pkg_resources.get_distribution("instapy_chromedriver").version


### PR DESCRIPTION
Accoring to #3920 people have issues when using their own chromedriver, since they fail on importing instapy-chromedriver package.

I don't know why this happens, since when installing instapy on Pi, it should also install the chromedriver package. The chromedriver might be the wrong version but it should still install the package.

Well but it still happens so user have to uncomment the import for instapy-chromedriver when using their own chromedriver.  
I just moved the import down where I use the Path so if you put your own chromedriver in the assets folder, it won't even try to import the one from the package.