### PR TITLE
avoid user errors providing user names with caps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ The **goal** of this file is explaining to the users of our project the notable 
 _The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)_.
 
 
+## [0.1.4] - INSERT MERGING DATE HERE
+### Fixed
+- avoid user errors providing user names with caps
+
+
 ## [0.1.3] - UNKNOWN
 ### Fixed
 - Fix "_Failed to load desired amount of users!_" issue.

--- a/instapy/unfollow_util.py
+++ b/instapy/unfollow_util.py
@@ -963,7 +963,7 @@ def get_given_user_followers(browser,
     :param logfolder: the logger folder
     :return: list of user's followers also followed
     """
-    user_name = user_name.strip()
+    user_name = user_name.strip().lower()
 
     user_link = "https://www.instagram.com/{}/".format(user_name)
     web_address_navigator(browser, user_link)

--- a/instapy/unfollow_util.py
+++ b/instapy/unfollow_util.py
@@ -1029,7 +1029,7 @@ def get_given_user_following(browser,
                              jumps,
                              logger,
                              logfolder):
-    user_name = user_name.strip()
+    user_name = user_name.strip().lower()
 
     user_link = "https://www.instagram.com/{}/".format(user_name)
     web_address_navigator(browser, user_link)


### PR DESCRIPTION
as all user names in instagram are always lower case, to avoid user errors providing uppercase letters adding  .lower() 