### PR TITLE
Temporarily turn off follow for like_by_tags interaction

### DIFF
--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -1024,9 +1024,10 @@ class InstaPy:
                                       self.user_interact_percentage
                         # Do interactions if any
                         if do_interact and self.user_interact_amount > 0:
-                            original_do_follow = self.do_follow  # store the
+                            original_do_follow = self.do_follow
+                            # store the
                             # original value of `self.do_follow`
-                            self.do_follow = False 
+                            self.do_follow = False
                             # disable following
                             # temporarily cos the user is already followed
                             # above
@@ -1804,9 +1805,10 @@ class InstaPy:
                                     "--> User gonna be interacted: '{}'"
                                     .format(user_name))
 
-                                original_do_follow = self.do_follow  # store the
+                                original_do_follow = self.do_follow
+                                # store the
                                 # original value of `self.do_follow`
-                                self.do_follow = False  
+                                self.do_follow = False
                                 # disable following
                                 # temporarily cos the user is already followed
                                 # above
@@ -1814,7 +1816,7 @@ class InstaPy:
                                                    self.user_interact_amount,
                                                    self.user_interact_random,
                                                    self.user_interact_media)
-                                self.do_follow = original_do_follow  
+                                self.do_follow = original_do_follow
                                 # revert
                                 # back original `self.do_follow` value (either
                                 # it was `False` or `True`)

--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -1034,7 +1034,8 @@ class InstaPy:
                                                    self.user_interact_amount,
                                                    self.user_interact_random,
                                                    self.user_interact_media)
-                            self.do_follow = original_do_follow  # revert
+                            self.do_follow = original_do_follow 
+                            # revert
                             # back original `self.do_follow` value (either
                             # it was `False` or `True`)
 
@@ -1813,7 +1814,8 @@ class InstaPy:
                                                    self.user_interact_amount,
                                                    self.user_interact_random,
                                                    self.user_interact_media)
-                                self.do_follow = original_do_follow  # revert
+                                self.do_follow = original_do_follow  
+                                # revert
                                 # back original `self.do_follow` value (either
                                 # it was `False` or `True`)
 

--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -1802,10 +1802,18 @@ class InstaPy:
                                     "--> User gonna be interacted: '{}'"
                                     .format(user_name))
 
+                                original_do_follow = self.do_follow  # store the
+                                # original value of `self.do_follow`
+                                self.do_follow = False  # disable following
+                                # temporarily cos the user is already followed
+                                # above
                                 self.like_by_users(user_name,
                                                    self.user_interact_amount,
                                                    self.user_interact_random,
                                                    self.user_interact_media)
+                                self.do_follow = original_do_follow  # revert
+                                # back original `self.do_follow` value (either
+                                # it was `False` or `True`)
 
                         elif msg == "already liked":
                             already_liked += 1

--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -1024,21 +1024,19 @@ class InstaPy:
                                       self.user_interact_percentage
                         # Do interactions if any
                         if do_interact and self.user_interact_amount > 0:
+                            # store original value of `self.do_follow`
                             original_do_follow = self.do_follow
-                            # store the
-                            # original value of `self.do_follow`
+                            # disable following temporarily 
+                            # cos user is already followed
                             self.do_follow = False
-                            # disable following
-                            # temporarily cos the user is already followed
-                            # above
+                            
                             self.interact_by_users(acc_to_follow,
                                                    self.user_interact_amount,
                                                    self.user_interact_random,
                                                    self.user_interact_media)
+                            
+                            # back to original `self.do_follow`
                             self.do_follow = original_do_follow 
-                            # revert
-                            # back original `self.do_follow` value (either
-                            # it was `False` or `True`)
 
                 elif msg == "already followed":
                     already_followed += 1
@@ -1804,22 +1802,19 @@ class InstaPy:
                                 self.logger.info(
                                     "--> User gonna be interacted: '{}'"
                                     .format(user_name))
-
+                                # store original value of `self.do_follow`
                                 original_do_follow = self.do_follow
-                                # store the
-                                # original value of `self.do_follow`
+
                                 self.do_follow = False
-                                # disable following
-                                # temporarily cos the user is already followed
-                                # above
+                                # disable following temporarily 
+                                # cos the user is already followed
                                 self.like_by_users(user_name,
                                                    self.user_interact_amount,
                                                    self.user_interact_random,
                                                    self.user_interact_media)
+                                
                                 self.do_follow = original_do_follow
-                                # revert
-                                # back original `self.do_follow` value (either
-                                # it was `False` or `True`)
+                                # revert back original `self.do_follow` value
 
                         elif msg == "already liked":
                             already_liked += 1

--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -1804,17 +1804,17 @@ class InstaPy:
                                     .format(user_name))
                                 # store original value of `self.do_follow`
                                 original_do_follow = self.do_follow
-
-                                self.do_follow = False
                                 # disable following temporarily 
                                 # cos the user is already followed
+                                self.do_follow = False
+                                
                                 self.like_by_users(user_name,
                                                    self.user_interact_amount,
                                                    self.user_interact_random,
                                                    self.user_interact_media)
                                 
+                                # back to original `self.do_follow` value
                                 self.do_follow = original_do_follow
-                                # revert back original `self.do_follow` value
 
                         elif msg == "already liked":
                             already_liked += 1

--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -1026,7 +1026,8 @@ class InstaPy:
                         if do_interact and self.user_interact_amount > 0:
                             original_do_follow = self.do_follow  # store the
                             # original value of `self.do_follow`
-                            self.do_follow = False  # disable following
+                            self.do_follow = False 
+                            # disable following
                             # temporarily cos the user is already followed
                             # above
                             self.interact_by_users(acc_to_follow,
@@ -1804,7 +1805,8 @@ class InstaPy:
 
                                 original_do_follow = self.do_follow  # store the
                                 # original value of `self.do_follow`
-                                self.do_follow = False  # disable following
+                                self.do_follow = False  
+                                # disable following
                                 # temporarily cos the user is already followed
                                 # above
                                 self.like_by_users(user_name,


### PR DESCRIPTION
By submitting this pull request I acknowledge that I have read and agree to the code of conduct for this project.

This Pull Request addresses the following issue:
When `like_by_tags` is used with `set_do_follow` enabled, the user is followed in the `like_by_tags` method as well as in the `like_by_users` method which is called by `like_by_tags` to interact with the user.

This also causes the `set_do_follow` percentage setting to be actually double what is specified since the chance that the user gets followed is calculated twice once in `like_by_tags` and again in `like_by_users`

This PR fixes the issue by implementing a snippet of code already available in `instapy.py` to temporarily turn off the following for the interaction and then reverting the setting after the interaction.