### PR TITLE
Prevent division by zero in validate_username

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ The **goal** of this file is explaining to the users of our project the notable 
 _The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)_.
 
 
+## [0.3.0] - ADD DATE HERE
+### Added
+- Allowing `follow_by_tags` to interact with the user
+- Context manager to interaction calls in `like_by_tags` and `follow_likers`
+
+### Fixed
+- `follow_likers` always fetches zero likers
+- Prevent division by zero in `validate_username`
+
+
 ## [0.2.2] - 2019-02-21
 ### Fixed
 - Chromedriver requirementnow >= 2.44 instead of == 2.44

--- a/instapy/util.py
+++ b/instapy/util.py
@@ -185,6 +185,10 @@ def validate_username(browser,
             potency_ratio *= -1
             reverse_relationship = True
 
+        # division by zero is bad
+        followers_count = 1 if followers_count == 0 else followers_count
+        following_count = 1 if following_count == 0 else following_count
+
         if followers_count and following_count:
             relationship_ratio = (
                 float(followers_count) / float(following_count)
@@ -567,11 +571,11 @@ def get_active_users(browser, username, posts, boundary, logger):
                     sleep_actual(3)
                 else:
                     raise NoSuchElementException
-                    
+
             except (IndexError, NoSuchElementException):
                 # Video have no likes button / no posts in page
                 logger.info("video found, try next post until we run out of posts")
-                
+
                 # edge case of account having only videos,  or last post is a video.
                 if checked_posts >= total_posts:
                     break
@@ -580,7 +584,7 @@ def get_active_users(browser, username, posts, boundary, logger):
                     try:
                         # click close button
                         close_dialog_box(browser)
-        
+
                         # click next button
                         next_button = browser.find_element_by_xpath(
                             "//a[contains(@class, 'HBoOv')]"
@@ -610,7 +614,7 @@ def get_active_users(browser, username, posts, boundary, logger):
                 )
             else:
                 amount = None
-                
+
             while scroll_it is not False and boundary != 0:
                 scroll_it = browser.execute_script('''
                     var div = arguments[0];


### PR DESCRIPTION
TBH I'm not sure that this have ever caused issues, but I think it might be related to the bot sometimes following users that do not match `relationship_ratio`. At most (or all) such cases the bot followed accounts with zero followers/following numbers.

Anyway, I think it is better to defend against division by zero.

Oh, and I also removed some trailing white space.