### PR TITLE
Solution for the 'Log in' text error due an A/B test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,14 @@ The **goal** of this file is explaining to the users of our project the notable 
 _The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)_.
 
 
+## [0.2.3] - 2019-03-01
+### Changed
+- Made Log in text checking more resilient 
+
+
 ## [0.2.2] - 2019-02-21
 ### Fixed
-- Chromedriver requirementnow >= 2.44 instead of == 2.44
+- Chromedriver requirement now >= 2.44 instead of == 2.44
 
 
 ## [0.2.1] - 2019-02-21

--- a/instapy/__init__.py
+++ b/instapy/__init__.py
@@ -8,5 +8,5 @@ from .file_manager import get_workspace
 
 
 # __variables__ with double-quoted values will be available in setup.py
-__version__ = "0.2.2"
+__version__ = "0.2.3"
 

--- a/instapy/login_util.py
+++ b/instapy/login_util.py
@@ -202,11 +202,11 @@ def login_user(browser,
     # Check if the first div is 'Create an Account' or 'Log In'
     try:
         login_elem = browser.find_element_by_xpath(
-            "//article//a[text()='Log in']")
+            "//a[text()='Log in']")
     except NoSuchElementException:
         print("Login A/B test detected! Trying another string...")
         login_elem = browser.find_element_by_xpath(
-            "//article//a[text()='Log In']")
+            "//a[text()='Log In']")
 
     if login_elem is not None:
         try:
@@ -265,11 +265,11 @@ def login_user(browser,
 
     try:
         login_button = browser.find_element_by_xpath(
-            "//button//div[text()='Log in']")
+            "//div[text()='Log in']")
     except NoSuchElementException:
         print("Login A/B test detected! Trying another string...")
-        login_elem = browser.find_element_by_xpath(
-            "//article//a[text()='Log In']")
+        login_button = browser.find_element_by_xpath(
+            "//div[text()='Log In']")
 
     (ActionChains(browser)
      .move_to_element(login_button)

--- a/instapy/login_util.py
+++ b/instapy/login_util.py
@@ -203,7 +203,7 @@ def login_user(browser,
     try:
         login_elem = browser.find_element_by_xpath(
             "//article//a[text()='Log in']")
-    except:
+    except NoSuchElementException:
         print("Login A/B test detected! Trying another string...")
         login_elem = browser.find_element_by_xpath(
             "//article//a[text()='Log In']")
@@ -266,7 +266,7 @@ def login_user(browser,
     try:
         login_button = browser.find_element_by_xpath(
             "//button//div[text()='Log in']")
-    except:
+    except NoSuchElementException:
         print("Login A/B test detected! Trying another string...")
         login_elem = browser.find_element_by_xpath(
             "//article//a[text()='Log In']")

--- a/instapy/login_util.py
+++ b/instapy/login_util.py
@@ -200,10 +200,11 @@ def login_user(browser,
               "new cookie...".format(username))
 
     # Check if the first div is 'Create an Account' or 'Log In'
-    login_elem = browser.find_element_by_xpath(
-        "//article//a[text()='Log in']")
-
-    if login_elem is None:
+    try:
+        login_elem = browser.find_element_by_xpath(
+            "//article//a[text()='Log in']")
+    except:
+        print("Login A/B test detected! Trying another string...")
         login_elem = browser.find_element_by_xpath(
             "//article//a[text()='Log In']")
 
@@ -262,10 +263,11 @@ def login_user(browser,
     for i in range(2):
         update_activity()
 
-    login_button = browser.find_element_by_xpath(
-        "//button//div[text()='Log in']")
-
-    if login_button is None:
+    try:
+        login_button = browser.find_element_by_xpath(
+            "//button//div[text()='Log in']")
+    except:
+        print("Login A/B test detected! Trying another string...")
         login_elem = browser.find_element_by_xpath(
             "//article//a[text()='Log In']")
 

--- a/instapy/login_util.py
+++ b/instapy/login_util.py
@@ -203,6 +203,10 @@ def login_user(browser,
     login_elem = browser.find_element_by_xpath(
         "//article//a[text()='Log in']")
 
+    if login_elem is None:
+        login_elem = browser.find_element_by_xpath(
+            "//article//a[text()='Log In']")
+
     if login_elem is not None:
         try:
             (ActionChains(browser)
@@ -260,6 +264,10 @@ def login_user(browser,
 
     login_button = browser.find_element_by_xpath(
         "//button//div[text()='Log in']")
+
+    if login_button is None:
+        login_elem = browser.find_element_by_xpath(
+            "//article//a[text()='Log In']")
 
     (ActionChains(browser)
      .move_to_element(login_button)


### PR DESCRIPTION
I've seen the login button text different in some occasions during past hour, so Instagram is probably doing an A/B test that can affect new logins without a previous cookie. The solution shall be as follow:
- Detect an alternative 'Log In' button if the regular 'Log in' is not found.

Needs to be tested and probably needs to be in a try catch statement, I currently cannot run my own code due my folder structure explained here https://github.com/timgrossmann/InstaPy/issues/4065