### PR TITLE
Expose `threaded_session`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ The **goal** of this file is explaining to the users of our project the notable 
 _The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)_.
 
 
+## [0.3.0] - ADD DATE HERE
+### Added
+- Allowing `follow_by_tags` to interact with the user
+- Context manager to interaction calls in `like_by_tags` and `follow_likers`
+
+### Changed
+- Expose `threaded_session` of Instapy.end()
+
+### Fixed
+- `follow_likers` always fetches zero likers
+- Prevent division by zero in `validate_username`
+
+
 ## [0.2.2] - 2019-02-21
 ### Fixed
 - Chromedriver requirementnow >= 2.44 instead of == 2.44

--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -4002,11 +4002,11 @@ class InstaPy:
 
         return mutual_following
 
-    def end(self):
+    def end(self, threaded_session=False):
         """Closes the current session"""
 
         Settings.InstaPy_is_running = False
-        close_browser(self.browser, False, self.logger)
+        close_browser(self.browser, threaded_session, self.logger)
 
         with interruption_handler():
             # close virtual display


### PR DESCRIPTION
Expose the `threaded_session` parameter on `close_browser()` when calling  `Instapy.end()` method so that asynchronous tasks (Celery) work fine by setting that parameter to `True`.