### PR TITLE
Docker fix workspace issue + delete command parameters

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,6 @@
-version: '3' 
+version: '3'
 services:
   web:
-    #command: ["./code/wait-for-selenium.sh", "http://selenium:4444/wd/hub", "--", "python", "code/docker_quickstart.py"]
     environment:
       - PYTHONUNBUFFERED=0
       - INSTAPY_WORKSPACE=/code

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,10 @@
-version: '3'
+version: '3' 
 services:
   web:
-    command: ["./code/wait-for-selenium.sh", "http://selenium:4444/wd/hub", "--", "python", "code/docker_quickstart.py"]
+    #command: ["./code/wait-for-selenium.sh", "http://selenium:4444/wd/hub", "--", "python", "code/docker_quickstart.py"]
     environment:
       - PYTHONUNBUFFERED=0
+      - INSTAPY_WORKSPACE=/code
     build:
       context: .
       dockerfile: ./docker_conf/python/Dockerfile


### PR DESCRIPTION
Fix workspace variable as `/code` instead of `/root` in `docker-compose.yml` file: it was causing an issue (#4096) where files generated by `InstaPy` where written in a non-permanent storage on `/root` and erased each times the container was started again. Including `cookie`, `blacklist`, `general.log` and all the others files in `InstaPy/logs/_username_/`

Delete the `command` parameter in `docker-compose.yml` because this paramter is already specified directly in `Dockerfile`