### PR TITLE
Add additional exception cath

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,7 +98,7 @@ ENV/
 .DS_Store
 
 # Storage
-instapy.db
+*.db
 logs/
 
 # Editors

--- a/instapy/login_util.py
+++ b/instapy/login_util.py
@@ -205,8 +205,11 @@ def login_user(browser,
             "//a[text()='Log in']")
     except NoSuchElementException:
         print("Login A/B test detected! Trying another string...")
-        login_elem = browser.find_element_by_xpath(
-            "//a[text()='Log In']")
+        try:
+            login_elem = browser.find_element_by_xpath(
+                "//a[text()='Log In']")
+        except NoSuchElementException:
+            return False
 
     if login_elem is not None:
         try:


### PR DESCRIPTION
Currently the Instagram is having issue, my account is keep trying to login and can't find the "Login" element, instead of blow up with NoSuchElementException, add additional try catch along with return False to exit it gracefully. 

Also add gitignore to ignore all the *.db SQLite files. 