### PR TITLE
Add sleep to wait for follower list to load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ The **goal** of this file is explaining to the users of our project the notable 
 _The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)_.
 
 
+## [0.3.4] - 2019-03-17
+### Fixed
+- "Failed to load desired amount of users" when trying to read long follower lists
+
+
 ## [0.3.3] - 2019-03-14
 ### Added
 - Add additional exception catch to Login check

--- a/instapy/unfollow_util.py
+++ b/instapy/unfollow_util.py
@@ -771,6 +771,7 @@ def follow_user(browser, track, login, user_name, button, blacklist, logger,
 
 
 def scroll_to_bottom_of_followers_list(browser, element):
+    sleep(5)
     browser.execute_script(
         "arguments[0].children[1].scrollIntoView()", element)
     sleep(1)


### PR DESCRIPTION
Fixed "Failed to load desired amount of users" when trying to read long follower lists (users with hunders of thousands followers) that takes too long to load