### PR TITLE
fix issue with smarthashtag returns no results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ The **goal** of this file is explaining to the users of our project the notable 
 
 _The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)_.
 
+## [0.3.6] - 2019-03-30
+### Fixed
+- "UnboundLocalError: local variable 'tag' referenced before assignment" when there is no smart-hastag genereated
 
 ## [0.3.4] - 2019-03-17
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,10 @@ The **goal** of this file is explaining to the users of our project the notable 
 
 _The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)_.
 
-## [0.3.5] - 2019-03-30
+## [0.4.0] - 2019-03-30
 ### Fixed
 - "UnboundLocalError: local variable 'tag' referenced before assignment" when there is no smart-hastag genereated
+
 
 ## [0.3.4] - 2019-03-17
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ The **goal** of this file is explaining to the users of our project the notable 
 
 _The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)_.
 
-## [0.4.0] - 2019-03-30
+## [0.4.0] - ADD DATE HERE
 ### Fixed
 - "UnboundLocalError: local variable 'tag' referenced before assignment" when there is no smart-hastag genereated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ The **goal** of this file is explaining to the users of our project the notable 
 
 _The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)_.
 
-## [0.3.6] - 2019-03-30
+## [0.3.5] - 2019-03-30
 ### Fixed
 - "UnboundLocalError: local variable 'tag' referenced before assignment" when there is no smart-hastag genereated
 

--- a/instapy/__init__.py
+++ b/instapy/__init__.py
@@ -8,5 +8,5 @@ from .file_manager import get_workspace
 
 
 # __variables__ with double-quoted values will be available in setup.py
-__version__ = "0.3.4"
+__version__ = "0.3.5"
 

--- a/instapy/__init__.py
+++ b/instapy/__init__.py
@@ -8,5 +8,5 @@ from .file_manager import get_workspace
 
 
 # __variables__ with double-quoted values will be available in setup.py
-__version__ = "0.3.5"
+__version__ = "0.4.0"
 

--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -1882,7 +1882,8 @@ class InstaPy:
                 except NoSuchElementException as err:
                     self.logger.error('Invalid Page: {}'.format(err))
 
-        self.logger.info('Tag: {}'.format(tag.encode('utf-8')))
+            self.logger.info('Tag: {}'.format(tag.encode('utf-8')))
+
         self.logger.info('Liked: {}'.format(liked_img))
         self.logger.info('Already Liked: {}'.format(already_liked))
         self.logger.info('Commented: {}'.format(commented))


### PR DESCRIPTION
 Fix an issue that if there is no smarthash tag the Instapy will blow up with UnboundLocalError

```
Traceback (most recent call last):
  File "quickstart.py", line 22, in <module>
    session.like_by_tags(amount=10, use_smart_hashtags=True)
  File "/Users/congchencai/Documents/InstaPy/instapy/instapy.py", line 1885, in like_by_tags
    self.logger.info('Tag: {}'.format(tag.encode('utf-8')))
UnboundLocalError: local variable 'tag' referenced before assignment
```

TBH, not sure how it ever worked, as the `tag` wasn't even in the for loop. 