### PR TITLE
fix issue with smarthashtag returns no results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ _The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Remove quickstart templates and only reference instapy-quickstart
 - Restructure README and add new DOCUMENTATION file
 
+### Fixed
+- "UnboundLocalError: local variable 'tag' referenced before assignment" when there is no smart-hastag genereated
+
 
 ## [0.3.4] - 2019-03-17
 ### Added

--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -1886,7 +1886,8 @@ class InstaPy:
                 except NoSuchElementException as err:
                     self.logger.error('Invalid Page: {}'.format(err))
 
-        self.logger.info('Tag: {}'.format(tag.encode('utf-8')))
+            self.logger.info('Tag: {}'.format(tag.encode('utf-8')))
+        
         self.logger.info('Liked: {}'.format(liked_img))
         self.logger.info('Already Liked: {}'.format(already_liked))
         self.logger.info('Commented: {}'.format(commented))


### PR DESCRIPTION
### Proposed by @CharlesCCC #4229 

 Fix an issue that if there is no smarthash tag the Instapy will blow up with UnboundLocalError

```
Traceback (most recent call last):
  File "quickstart.py", line 22, in <module>
    session.like_by_tags(amount=10, use_smart_hashtags=True)
  File "/Users/congchencai/Documents/InstaPy/instapy/instapy.py", line 1885, in like_by_tags
    self.logger.info('Tag: {}'.format(tag.encode('utf-8')))
UnboundLocalError: local variable 'tag' referenced before assignment
```

TBH, not sure how it ever worked, as the `tag` wasn't even in the for loop. 