### PR TITLE
 split sq lite db by username

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ The **goal** of this file is explaining to the users of our project the notable 
 
 _The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)_.
 
+## [0.4.1] - 2019-04-03
+### Added
+- Added support for split database with -sdb flag to avoid SQLite lock up
 
 ## [0.4.0] - 2019-04-03
 ### Added

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -2653,7 +2653,7 @@ To do this simply pass the `disable_image_load=True` parameter in the InstaPy co
 session = InstaPy(username=insta_username,
                   password=insta_password,
                   headless_browser=False,
-		              disable_image_load=True,
+		  disable_image_load=True,
                   multi_logs=True)
 ```
 
@@ -2688,7 +2688,7 @@ To do this simply pass the `split_db=True` parameter in the InstaPy constructor 
 session = InstaPy(username=insta_username,
                   password=insta_password,
                   headless_browser=False,
-		              split_db=True,
+		  split_db=True,
                   multi_logs=True)
 ```
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -100,6 +100,7 @@
   - [Disable Image Loading](#disable-image-loading)
   - [Using Multiple Chromedrivers](#using-multiple-chromedrivers)
   - [Changing DB or Chromedriver locations](#changing-db-or-chromedriver-locations)
+  - [Split SQLite DB by Username](#split-sqlite-by-username)
   - [How to avoid _python_ & pip confusion](#how-to-avoid-python--pip-confusion)
 
 ---
@@ -2673,6 +2674,24 @@ Set these in instapy/settings.py if you're locating the library in the /usr/lib/
 Settings.database_location = '/path/to/instapy.db'
 Settings.chromedriver_location = '/path/to/chromedriver'
 ```
+
+### Split SQLite by Username 
+If you experience issue with multiple accounts Instapy.db lockup. You can add the following flag
+
+`-sdb` when running in Command line
+
+or 
+
+To do this simply pass the `split_db=True` parameter in the InstaPy constructor like so:
+
+```python
+session = InstaPy(username=insta_username,
+                  password=insta_password,
+                  headless_browser=False,
+		              split_db=True,
+                  multi_logs=True)
+```
+
 
 
 ### How to avoid _python_ & **pip** confusion

--- a/instapy/__init__.py
+++ b/instapy/__init__.py
@@ -8,5 +8,5 @@ from .file_manager import get_workspace
 
 
 # __variables__ with double-quoted values will be available in setup.py
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 

--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -34,6 +34,7 @@ from .like_util import get_links_for_username
 from .like_util import like_comment
 from .login_util import login_user
 from .settings import Settings
+from .settings import localize_path
 from .print_log_writer import log_follower_num
 from .print_log_writer import log_following_num
 
@@ -105,7 +106,8 @@ class InstaPy:
                  disable_image_load=False,
                  bypass_suspicious_attempt=False,
                  bypass_with_mobile=False,
-                 multi_logs=True):
+                 multi_logs=True,
+                 split_db=False):
 
         cli_args = parse_cli_args()
         username = cli_args.username or username
@@ -119,6 +121,7 @@ class InstaPy:
         bypass_suspicious_attempt = (
             cli_args.bypass_suspicious_attempt or bypass_suspicious_attempt)
         bypass_with_mobile = cli_args.bypass_with_mobile or bypass_with_mobile
+        split_db = cli_args.split_db or split_db
 
         Settings.InstaPy_is_running = True
         # workspace must be ready before anything
@@ -146,6 +149,10 @@ class InstaPy:
         self.username = username or os.environ.get('INSTA_USER')
         self.password = password or os.environ.get('INSTA_PW')
         Settings.profile["name"] = self.username
+
+        self.split_db = split_db
+        if self.split_db:
+            Settings.database_location = localize_path("db", "instapy_{}.db".format(self.username))
 
         self.page_delay = page_delay
         self.use_firefox = use_firefox

--- a/instapy/util.py
+++ b/instapy/util.py
@@ -2092,6 +2092,9 @@ def parse_cli_args():
     parser.add_argument(
         "-bwm", "--bypass-with-mobile", help="Bypass with mobile phone",
         action="store_true", default=None)
+    parser.add_argument(
+        "-sdb", "--split-db", help="Split sqlite-db as instapy_{username}.db",
+        action="store_true", default=None)
 
     """ Style below can convert strings into booleans:
     ```parser.add_argument("--is-debug",


### PR DESCRIPTION
### Split SQLite by Username 
If you experience issue with multiple accounts Instapy.db lockup. You can add the following flag

`-sdb` when running in Command line

or 

To do this simply pass the `split_db=True` parameter in the InstaPy constructor like so:

```python
session = InstaPy(username=insta_username,
                  password=insta_password,
                  headless_browser=False,
		  split_db=True,
                  multi_logs=True)
```