### PR TITLE
added an additional check for blocking likes

### DIFF
--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -1365,7 +1365,8 @@ class InstaPy:
                                                      user_name,
                                                      self.blacklist,
                                                      self.logger,
-                                                     self.logfolder)
+                                                     self.logfolder,
+                                                     liked_img)
 
                         if like_state is True:
                             liked_img += 1
@@ -1453,6 +1454,9 @@ class InstaPy:
 
                         elif msg == "already liked":
                             already_liked += 1
+
+                        elif msg == "block on likes":
+                            break
 
                         elif msg == "jumped":
                             # will break the loop after certain consecutive
@@ -1778,7 +1782,8 @@ class InstaPy:
                                                      user_name,
                                                      self.blacklist,
                                                      self.logger,
-                                                     self.logfolder)
+                                                     self.logfolder,
+                                                     liked_img)
 
                         if like_state is True:
                             liked_img += 1
@@ -1878,6 +1883,9 @@ class InstaPy:
 
                         elif msg == "already liked":
                             already_liked += 1
+
+                        elif msg == "block on likes":
+                            break
 
                         elif msg == "jumped":
                             # will break the loop after certain consecutive
@@ -2042,7 +2050,8 @@ class InstaPy:
                                                      user_name,
                                                      self.blacklist,
                                                      self.logger,
-                                                     self.logfolder)
+                                                     self.logfolder,
+                                                     total_liked_img)
                         if like_state is True:
                             total_liked_img += 1
                             liked_img += 1
@@ -2103,6 +2112,9 @@ class InstaPy:
 
                         elif msg == "already liked":
                             already_liked += 1
+
+                        elif msg == "block on likes":
+                            break
 
                         elif msg == "jumped":
                             # will break the loop after certain consecutive
@@ -2309,7 +2321,8 @@ class InstaPy:
                                                          user_name,
                                                          self.blacklist,
                                                          self.logger,
-                                                         self.logfolder)
+                                                         self.logfolder,
+                                                         total_liked_img)
                             if like_state is True:
                                 total_liked_img += 1
                                 liked_img += 1
@@ -2367,6 +2380,9 @@ class InstaPy:
 
                             elif msg == "already liked":
                                 already_liked += 1
+
+                            elif msg == "block on likes":
+                                break
 
                             elif msg == "jumped":
                                 # will break the loop after certain
@@ -2603,7 +2619,8 @@ class InstaPy:
                                                          user_name,
                                                          self.blacklist,
                                                          self.logger,
-                                                         self.logfolder)
+                                                         self.logfolder,
+                                                         total_liked_img)
                             if like_state is True:
                                 total_liked_img += 1
                                 liked_img += 1
@@ -2668,6 +2685,9 @@ class InstaPy:
 
                             elif msg == "already liked":
                                 already_liked += 1
+
+                            elif msg == "block on likes":
+                                break
 
                             elif msg == "jumped":
                                 # will break the loop after certain
@@ -3676,7 +3696,8 @@ class InstaPy:
                                                              user_name,
                                                              self.blacklist,
                                                              self.logger,
-                                                             self.logfolder)
+                                                             self.logfolder,
+                                                             liked_img)
 
                                 if like_state is True:
                                     liked_img += 1
@@ -3788,6 +3809,9 @@ class InstaPy:
 
                                 elif msg == "already liked":
                                     already_liked += 1
+
+                                elif msg == "block on likes":
+                                    break
 
                                 elif msg == "jumped":
                                     # will break the loop after
@@ -4423,7 +4447,8 @@ class InstaPy:
                                                  user_name,
                                                  self.blacklist,
                                                  self.logger,
-                                                 self.logfolder)
+                                                 self.logfolder,
+                                                 liked_img)
 
                     if like_state is True:
                         liked_img += 1
@@ -4520,6 +4545,9 @@ class InstaPy:
 
                     elif msg == "already liked":
                         already_liked += 1
+
+                    elif msg == "block on likes":
+                        break
 
                     elif msg == "jumped":
                         # will break the loop after certain consecutive jumps
@@ -4980,13 +5008,17 @@ class InstaPy:
                                                    user_name,
                                                    self.blacklist,
                                                    self.logger,
-                                                   self.logfolder)
+                                                   self.logfolder,
+                                                   self.liked_img)
                 if image_like_state is True:
                     like_failures_tracker["consequent"]["post_likes"] = 0
                     self.liked_img += 1
 
                 elif msg == "already liked":
                     self.already_liked += 1
+
+                elif msg == "block on likes":
+                    break
 
                 else:
                     self.logger.info(
@@ -5306,10 +5338,17 @@ class InstaPy:
 
                     if liking:
                         like_state, msg = like_image(self.browser,
-                                                        user_name,
-                                                        self.blacklist,
-                                                        self.logger,
-                                                        self.logfolder)
+                                                     user_name,
+                                                     self.blacklist,
+                                                     self.logger,
+                                                     self.logfolder,
+                                                     self.liked_img)
+
+                        if like_state is True:
+                            self.liked_img += 1
+
+                        elif msg == "block on likes":
+                            break
 
                     if commenting:
                         comments = self.fetch_smart_comments(

--- a/instapy/like_util.py
+++ b/instapy/like_util.py
@@ -666,7 +666,7 @@ def check_link(browser, post_link, dont_like, mandatory_words,
     return False, user_name, is_video, 'None', "Success"
 
 
-def like_image(browser, username, blacklist, logger, logfolder):
+def like_image(browser, username, blacklist, logger, logfolder, total_liked_img):
     """Likes the browser opened image"""
     # check action availability
     if quota_supervisor("likes") == "jump":
@@ -697,6 +697,11 @@ def like_image(browser, username, blacklist, logger, logfolder):
             # get the post-like delay time to sleep
             naply = get_action_delay("like")
             sleep(naply)
+
+            # after every 10 liked image do checking on the block
+            if total_liked_img % 10 == 0 and not verify_blocked_like(browser, logger):
+                return False, "block on likes"
+
             return True, "success"
 
         else:
@@ -713,6 +718,20 @@ def like_image(browser, username, blacklist, logger, logfolder):
     logger.info('--> Invalid Like Element!')
 
     return False, "invalid element"
+
+
+def verify_blocked_like(browser, logger):
+    """Check for a ban on likes using the last liked image"""
+
+    browser.refresh()
+    unlike_xpath = "//section/span/button/span[@aria-label='Unlike']"
+    like_elem = browser.find_elements_by_xpath(unlike_xpath)
+
+    if len(like_elem) == 1:
+        return True
+    else:
+        logger.info('-------- WARNING! Image was NOT liked! You are have a BLOCK on likes!')
+        return False
 
 
 def get_tags(browser, url):

--- a/instapy/like_util.py
+++ b/instapy/like_util.py
@@ -674,8 +674,8 @@ def like_image(browser, username, blacklist, logger, logfolder, total_liked_img)
     if quota_supervisor("likes") == "jump":
         return False, "jumped"
 
-    like_xpath = read_xpath(like_image.__name__,"like")
-    unlike_xpath = read_xpath(like_image.__name__,"unlike")
+    like_xpath = read_xpath(like_image.__name__, "like")
+    unlike_xpath = read_xpath(like_image.__name__, "unlike")
 
     # find first for like element
     like_elem = browser.find_elements_by_xpath(like_xpath)
@@ -726,7 +726,7 @@ def verify_liked_image(browser, logger):
     """Check for a ban on likes using the last liked image"""
 
     browser.refresh()
-    unlike_xpath = "//section/span/button/span[@aria-label='Unlike']"
+    unlike_xpath = read_xpath(like_image.__name__, "unlike")
     like_elem = browser.find_elements_by_xpath(unlike_xpath)
 
     if len(like_elem) == 1:

--- a/instapy/like_util.py
+++ b/instapy/like_util.py
@@ -699,7 +699,7 @@ def like_image(browser, username, blacklist, logger, logfolder, total_liked_img)
             sleep(naply)
 
             # after every 10 liked image do checking on the block
-            if total_liked_img % 10 == 0 and not verify_blocked_like(browser, logger):
+            if total_liked_img % 10 == 0 and not verify_liked_image(browser, logger):
                 return False, "block on likes"
 
             return True, "success"
@@ -720,7 +720,7 @@ def like_image(browser, username, blacklist, logger, logfolder, total_liked_img)
     return False, "invalid element"
 
 
-def verify_blocked_like(browser, logger):
+def verify_liked_image(browser, logger):
     """Check for a ban on likes using the last liked image"""
 
     browser.refresh()


### PR DESCRIPTION
This PR adds an additional check for blocking likes.

When receiving a ban on likes, the script continues to put likes. But if you refresh the page you can see that it is missing. If you liked the post in the application, you can see the blocking alert.

My suggestion is to check for a ban after every 10 liked image. That is, after putting a like, refresh the page and check if it is.

Sorry for my bad english. =)

![Screenshot_2019-04-09-17-51-34-060_com instagram android](https://user-images.githubusercontent.com/40631869/55819017-99349b00-5b00-11e9-8b50-5640e63611dd.png)
