### PR TITLE
remove backer from sponsors

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,6 @@ Thank you to all our backers! 🙏 [[Become a backer](https://opencollective.com
 
 Support this project by becoming a sponsor. Your logo will show up here with a link to your website. [[Become a sponsor](https://opencollective.com/instapy#sponsor)]
 
-<a href="https://opencollective.com/instapy/sponsor/0/website" target="_blank"><img src="https://opencollective.com/instapy/sponsor/0/avatar.svg"></a>
 <a href="https://www.chancetheapp.com" target="_blank">
 	<img src="https://user-images.githubusercontent.com/16529337/52699787-dbb17f80-2f76-11e9-9657-c103d4e89d88.png" height=75 />
 </a>


### PR DESCRIPTION
Opencollective should not display regular backers as Sponsors. 
Only monthly donators should be displayed as Sponsors, the rest as backers.

Removed the link for automatic retrieval of the Sponsors, they will be added manually. 