### PR TITLE
Remove redundant assignment by correting logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ The **goal** of this file is explaining to the users of our project the notable 
 _The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)_.
 
 
+## [0.5.0] - ADD DATE HERE
+### Changed
+- Remove redundant assignment of pod_post_ids
+
+
 ## [0.4.2] - 2019-04-15
 ### Fixed
 - Fail of whole pod run on exception

--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -5269,9 +5269,7 @@ class InstaPy:
                 self.logger.info("I don't have any recent post, so I will just help a few pod posts and move on.")
                 nposts = 40
 
-            if len(pod_post_ids) <= nposts:
-                pod_post_ids = pod_post_ids
-            else:
+            if len(pod_post_ids) > nposts:
                 pod_post_ids = random.sample(pod_post_ids, nposts)
 
             for pod_post_id in pod_post_ids:


### PR DESCRIPTION
Assigning a variable to itself is useless and very likely indicates an error in the code.

Assigning a variable to itself is redundant and often an indication of a mistake in the code.