### PR TITLE
Update set_mandatory_language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ The **goal** of this file is explaining to the users of our project the notable 
 _The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)_.
 
 
+## [0.5.0] - ADD DATE HERE
+### Changed
+- `set_mandatory_language` can maintain multiple character sets
+
+
 ## [0.4.2] - 2019-04-15
 ### Fixed
 - Fail of whole pod run on exception

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -334,10 +334,11 @@ will like the image if **any** of those words are in there
 ### Mandatory Language
 
 ```python
-session.set_mandatory_language(enabled=True, character_set='LATIN')
+session.set_mandatory_language(enabled=True, character_set=['LATIN'])
+session.set_mandatory_language(enabled=True, character_set=['LATIN', 'CYRILLIC'])
 ```
 
-`.set_mandatory_language` restrict the interactions, liking and following if any character of the description is outside of the character set selected (the location is not included and non-alphabetic characters are ignored). For example if you choose `LATIN`, any character in Cyrillic will flag the post as inappropriate.
+`.set_mandatory_language` restrict the interactions, liking and following if any character of the description is outside of the character sets you selected (the location is not included and non-alphabetic characters are ignored). For example if you choose `LATIN`, any character in Cyrillic will flag the post as inappropriate. If you choose 'LATIN' and 'CYRILLIC', any other character sets will flag the post as inappropriate as well.
 
 * Available character sets: `LATIN`,  `GREEK`, `CYRILLIC`, `ARABIC`, `HEBREW`, `CJK`, `HANGUL`, `HIRAGANA`, `KATAKANA` and `THAI`
 

--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -701,19 +701,30 @@ class InstaPy:
 
         return self
 
-    def set_mandatory_language(self, enabled=False, character_set='LATIN'):
+    def set_mandatory_language(self, enabled=False, character_set=['LATIN']):
         """Restrict the description of the image to a character set"""
         if self.aborting:
             return self
 
-        if (character_set not in ['LATIN', 'GREEK', 'CYRILLIC', 'ARABIC',
-                                  'HEBREW', 'CJK', 'HANGUL', 'HIRAGANA',
-                                  'KATAKANA', 'THAI']):
-            self.logger.warning('Unkown character set! Treating as "LATIN".')
-            character_set = 'LATIN'
+        char_set = []
 
+        if not isinstance(character_set, list):
+            character_set = [character_set]
+        
+        for chr_set in character_set:
+            if (chr_set not in ['LATIN', 'GREEK', 'CYRILLIC', 'ARABIC',
+                                      'HEBREW', 'CJK', 'HANGUL', 'HIRAGANA',
+                                      'KATAKANA', 'THAI', 'MATHEMATICAL']):
+                self.logger.warning('Unkown character set! Treating as "LATIN".')
+                ch_set_name = 'LATIN'
+            else:
+                ch_set_name = chr_set
+                
+            if ch_set_name not in char_set:
+                char_set.append(ch_set_name)
+                
         self.mandatory_language = enabled
-        self.mandatory_character = character_set
+        self.mandatory_character = char_set
 
         return self
 
@@ -5155,8 +5166,8 @@ class InstaPy:
             return self.check_letters[uchr]
         except KeyError:
             return self.check_letters.setdefault(uchr,
-                                                 self.mandatory_character in
-                                                 unicodedata.name(uchr))
+                                                any(mandatory_char in unicodedata.name(
+                                                uchr) for mandatory_char in self.mandatory_character))
 
     def run_time(self):
         """ Get the time session lasted in seconds """


### PR DESCRIPTION
Now set_mandatory_language can maintain multiple character sets, not only one.

This is useful if you want to interact with multiple languages, but don't want include others.

Usage:
session.set_mandatory_language(enabled=True, character_set=['LATIN', 'CYRILLIC'])