### PR TITLE
fix issue when verifying mandatory words (issue #4444)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ The **goal** of this file is explaining to the users of our project the notable 
 _The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)_.
 
 
+## [0.5.0] - ADD DATE HERE
+### Fixed
+- Verifying mandatory words when the script can not get post description
+
+
 ## [0.4.3] - 2019-05-15
 ### Fixed
 - Commenting issue #4409


### PR DESCRIPTION
This change fixes verifying mandatory words when the script can not get post description nor get comments, and also fix commenting when there is zero comments on post.
Fix issue: #4444