### PR TITLE
Fix for get_relationship_counts broken behavior

### DIFF
--- a/instapy/util.py
+++ b/instapy/util.py
@@ -942,7 +942,7 @@ def get_relationship_counts(browser, username, logger):
     except WebDriverException:
         try:
             followers_count = format_number(
-                browser.find_element_by_xpath(read_xpath(get_relationship_counts.__name__,"followers_count")).text)
+                browser.find_element_by_xpath(read_xpath(get_relationship_counts.__name__,"followers_count")))
         except NoSuchElementException:
             try:
                 browser.execute_script("location.reload()")


### PR DESCRIPTION
This error is thrown when `get_relationship_counts` is called. Removing the `.text` fixes the error.