### PR TITLE
Fix for session.get_relationship_counts() broken behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ The **goal** of this file is explaining to the users of our project the notable 
 _The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)_.
 
 
+## [0.5.2] - 2019-06-28
+### Fixed
+- `session.get_relationship_counts()` broken behavior 
+
+
 ## [0.5.1] - 2019-06-18
 ### Added
 - Documentation for basic Selenium Errors

--- a/instapy/__init__.py
+++ b/instapy/__init__.py
@@ -8,5 +8,5 @@ from .file_manager import get_workspace
 
 
 # __variables__ with double-quoted values will be available in setup.py
-__version__ = "0.5.1"
+__version__ = "0.5.2"
 

--- a/instapy/util.py
+++ b/instapy/util.py
@@ -942,7 +942,7 @@ def get_relationship_counts(browser, username, logger):
     except WebDriverException:
         try:
             followers_count = format_number(
-                browser.find_element_by_xpath(read_xpath(get_relationship_counts.__name__,"followers_count")).text)
+                browser.find_element_by_xpath(str(read_xpath(get_relationship_counts.__name__,"followers_count"))))
         except NoSuchElementException:
             try:
                 browser.execute_script("location.reload()")
@@ -983,7 +983,7 @@ def get_relationship_counts(browser, username, logger):
     except WebDriverException:
         try:
             following_count = format_number(
-                browser.find_element_by_xpath(read_xpath(get_relationship_counts.__name__,"following_count")).text)
+                browser.find_element_by_xpath(str(read_xpath(get_relationship_counts.__name__,"following_count"))))
 
         except NoSuchElementException:
             try:


### PR DESCRIPTION
There is a fix for two more use cases related to #4518  PR and fixes #4517  issue. Also referencing #4520 because that PR tries to fix this same issue.

At the moment the script has been runing with a cron for 4 days without any errors.

Before the fix the script was breaking after the emulate follows session with the basic_follow_unfollow_activity.py quickstart template.