### PR TITLE
Fix get_action_delay method always returning default values #4540

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ The **goal** of this file is explaining to the users of our project the notable 
 _The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)_.
 
 
+## [0.5.4] - 2019-07-03
+### Fixed
+- `get_action_delay` method always returning default values #4540
+
+
 ## [0.5.3] - 2019-07-02
 ### Fixed
 - Argument Being Interpreted as Sequence in `bypass_suspicious_login`

--- a/instapy/__init__.py
+++ b/instapy/__init__.py
@@ -8,5 +8,5 @@ from .file_manager import get_workspace
 
 
 # __variables__ with double-quoted values will be available in setup.py
-__version__ = "0.5.3"
+__version__ = "0.5.4"
 

--- a/instapy/util.py
+++ b/instapy/util.py
@@ -1764,7 +1764,7 @@ def get_action_delay(action):
     if (not config or
             config["enabled"] is not True or
             config[action] is None or
-            isinstance(config[action], (int, float))):
+            isinstance(config[action], (int, float))) is not True:
         return defaults[action]
 
     else:


### PR DESCRIPTION
Hey, this should fix `get_action_delay` bug #4540, returning default values even after updating values with `set_action_delays`.

Not sure whether to set merge into master or dev.

EDIT:

Hey this was just a one-liner change.

On master there is a bug (#4540) in `get_action_delay` method. It checks if `config[action]` is `int,float` and if yes it returns default value - so even if we change action delays with `set_action_delays` default value is always returned. I reversed the logic to `is not True` which fixes the bug.