### PR TITLE
Fix missing check for action and uninitialized action_delays in settings

### DIFF
--- a/instapy/util.py
+++ b/instapy/util.py
@@ -1765,7 +1765,7 @@ def get_action_delay(action):
             action not in config or
             config["enabled"] is not True or
             config[action] is None or
-            isinstance(config[action], (int, float))) is not True:
+            isinstance(config[action], (int, float)) is not True):
         return defaults[action]
 
     else:

--- a/instapy/util.py
+++ b/instapy/util.py
@@ -1762,6 +1762,7 @@ def get_action_delay(action):
     config = Settings.action_delays
 
     if (not config or
+            action not in config or
             config["enabled"] is not True or
             config[action] is None or
             isinstance(config[action], (int, float))) is not True:

--- a/tests/test_action_delays.py
+++ b/tests/test_action_delays.py
@@ -1,0 +1,8 @@
+from instapy import util
+
+
+def test_default_values_returned():
+    assert util.get_action_delay("like") == 2
+    assert util.get_action_delay("comment") == 2
+    assert util.get_action_delay("follow") == 3
+    assert util.get_action_delay("unfollow") == 10

--- a/tests/test_action_delays.py
+++ b/tests/test_action_delays.py
@@ -2,7 +2,7 @@ from instapy import util
 
 
 def test_default_values_returned():
-    assert util.get_action_delay("like") == 2
-    assert util.get_action_delay("comment") == 2
-    assert util.get_action_delay("follow") == 3
-    assert util.get_action_delay("unfollow") == 10
+    assert util.get_action_delay('like') == 2
+    assert util.get_action_delay('comment') == 2
+    assert util.get_action_delay('follow') == 3
+    assert util.get_action_delay('unfollow') == 10


### PR DESCRIPTION
Hey,

yesterday's fix of `get_action_delays` method https://github.com/timgrossmann/InstaPy/pull/4606/commits/b71563f7381e48c2bd8cccac1a861f720ddbb452 caused another bug along the line #4610 #4619 #4622 #4610 #4615

`Settings.action_delays` is not initialized properly. As suggested by @lvkins I'm adding another check to see if we have any actions set in `Settings.action_delays`.

Maybe we should initialize `Settings.action_delays` in `__init__` so we have some sensible defaults ?