### PR TITLE
fix set_smart_hashtags with sort='random'

### DIFF
--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -700,8 +700,10 @@ class InstaPy:
                         self.smart_hashtags.append(item["tag"])
 
                 elif sort == "random":
-                    if len(data['results']) < limit:
-                        random_tags = random.sample(data['results'], len(data['results']))
+                    if len(data["results"]) < limit:
+                        random_tags = random.sample(
+                            data["results"], len(data["results"])
+                        )
                     else:
                         random_tags = random.sample(data["results"], limit)
                     for item in random_tags:

--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -700,7 +700,10 @@ class InstaPy:
                         self.smart_hashtags.append(item["tag"])
 
                 elif sort == "random":
-                    random_tags = random.sample(data["results"], limit)
+                    if len(data['results']) < limit:
+                        random_tags = random.sample(data['results'], len(data['results']))
+                    else:
+                        random_tags = random.sample(data["results"], limit)
                     for item in random_tags:
                         self.smart_hashtags.append(item["tag"])
 


### PR DESCRIPTION
When using the functionality set_smart_hashtags with words which are not in English or do not generate more than 9 results for that one hashtag the program will crash with this error:

`Traceback (most recent call last):
  File "playing_around_with_quota_supervisor.py", line 58, in <module>
    limit=10, sort='random', log_tags=True)
  File "/home/pi/.local/lib/python3.7/site-packages/instapy/instapy.py", line 703, in set_smart_hashtags
    random_tags = random.sample(data['results'], limit)
  File "/usr/lib/python3.7/random.py", line 321, in sample
    raise ValueError("Sample larger than population or is negative")
ValueError: Sample larger than population or is negative
`

The newly added secure handling will fix this issue for everyone who wants to use the set_smart_hashtags function with sort set to random and doesn't or can't work with the sort function set to 'top' which was suggested as a workaround in this issue: #1577