### PR TITLE
quickfix To Actually Ignore Top Posts when requested

### DIFF
--- a/instapy/like_util.py
+++ b/instapy/like_util.py
@@ -302,7 +302,7 @@ def get_links_for_tag(browser, tag, amount, skip_top_posts, randomize, media, lo
             )
             possible_posts = None
 
-    if skip_top_posts: 
+    if skip_top_posts:
         amount = amount + 9
 
     logger.info(
@@ -399,7 +399,7 @@ def get_links_for_tag(browser, tag, amount, skip_top_posts, randomize, media, lo
 
     sleep(4)
 
-    if skip_top_posts: 
+    if skip_top_posts:
         del links[0:9]
 
     if randomize is True:

--- a/instapy/like_util.py
+++ b/instapy/like_util.py
@@ -316,9 +316,6 @@ def get_links_for_tag(browser, tag, amount, skip_top_posts, randomize, media, lo
     )
 
     if possible_posts is not None:
-        possible_posts = (
-            possible_posts if not skip_top_posts else possible_posts - len(top_posts)
-        )
         amount = possible_posts if amount > possible_posts else amount
     # sometimes pages do not have the correct amount of posts as it is
     # written there, it may be cos of some posts is deleted but still keeps

--- a/instapy/like_util.py
+++ b/instapy/like_util.py
@@ -302,6 +302,9 @@ def get_links_for_tag(browser, tag, amount, skip_top_posts, randomize, media, lo
             )
             possible_posts = None
 
+    if skip_top_posts: 
+        amount = amount + 9
+
     logger.info(
         "desired amount: {}  |  top posts [{}]: {}  |  possible posts: "
         "{}".format(
@@ -395,6 +398,9 @@ def get_links_for_tag(browser, tag, amount, skip_top_posts, randomize, media, lo
         raise
 
     sleep(4)
+
+    if skip_top_posts: 
+        del links[0:9]
 
     if randomize is True:
         random.shuffle(links)


### PR DESCRIPTION
Due to a design change at Instagram relating to their structure when searching for pictures by tags the "top_posts" arrays are not being filled anymore (in the whole program probably). Since they are simply returning 0 elements and the top post elements are now being automatically found through the normal image search there wasn't a big error crisis for the users but the like ratio should have gone down drastically for some people since the top post are now being counted as if they were actual posts which could potentially be liked. This would lead to people starting to raise their base values because there are 9 pictures per tag which are definitely not going to get liked.

The quick fix currently works like this: I'm raising the inserted base Amount by 9 to delete the first nine objects in the Array at the end of the function if skip_top_posts is set to true.