### PR TITLE
Fix error `TypeError: '<' not supported between instances of 'int' and 'NoneType'

### DIFF
--- a/instapy/like_util.py
+++ b/instapy/like_util.py
@@ -921,7 +921,7 @@ def verify_liking(browser, maximum, minimum, logger):
             "{}".format(likes_count)
         )
         return False
-    elif min is not None and likes_count < minimum:
+    elif minimum is not None and likes_count < minimum:
         logger.info(
             "Not liked this post! ~less likes exist off minumum limit "
             "at {}".format(likes_count)


### PR DESCRIPTION
Error 
TypeError: '<' not supported between instances of 'int' and 'NoneType'

is raised if set     
min_likes=None in set_delimit_liking