### PR TITLE
Fix issue #5002 with new feature

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -67,6 +67,7 @@
 - **[Instance Settings](#instance-settings)**
   - [Running on a Headless Browser](#running-on-a-headless-browser)
   - [Bypass Suspicious Login Attempt](#bypass-suspicious-login-attempt)
+  - [Running internet connection checks](#running-internet-connection-checks)
   - [Use a proxy](#use-a-proxy)
   - [Running in threads](#running-in-threads)
   
@@ -1764,6 +1765,18 @@ session = InstaPy(username=insta_username,
                   proxy_port=4444)
 ```
 
+### Running internet connection checks
+InstaPy performs a few checks online, including you connection and the availability of Instagram servers. These checks sometimes fail because Instapy uses third party services to perform these checks. Nevertheless, you can override these checks with this variable: `want_check_browser`.
+
+`want_check_browser` default is True, you can set it to false at session start. Recommend to do this if experiencing connection errors.
+
+example:
+```python
+session = InstaPy(username=insta_username,
+                  password=insta_password,
+                  want_check_browser=False)
+```
+
 ### Running in threads
 If you're running InstaPy in threads and get exception `ValueError: signal only works in main thread` , you have to properly close the session.
 There is two ways to do it:
@@ -1784,6 +1797,8 @@ session.login()
 # some activity here ...
 session.end(threaded_session=True)
 ```
+
+
 
 ---
 

--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -164,7 +164,7 @@ class InstaPy:
             Settings.database_location = localize_path(
                 "db", "instapy_{}.db".format(self.username)
             )
-            
+
         self.want_check_browser = want_check_browser
 
         self.do_comment = False
@@ -414,7 +414,7 @@ class InstaPy:
             self.logfolder,
             self.proxy_address,
             self.bypass_security_challenge_using,
-            self.want_check_browser
+            self.want_check_browser,
         ):
             message = (
                 "Unable to login to Instagram! "

--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -120,6 +120,7 @@ class InstaPy:
         geckodriver_path: str = None,
         split_db: bool = False,
         bypass_security_challenge_using: str = "email",
+        want_check_browser: bool = True,
     ):
         print("InstaPy Version: {}".format(__version__))
         cli_args = parse_cli_args()
@@ -131,6 +132,7 @@ class InstaPy:
         proxy_port = cli_args.proxy_port or proxy_port
         disable_image_load = cli_args.disable_image_load or disable_image_load
         split_db = cli_args.split_db or split_db
+        want_check_browser = cli_args.want_check_browser or want_check_browser
 
         Settings.InstaPy_is_running = True
         # workspace must be ready before anything
@@ -162,6 +164,8 @@ class InstaPy:
             Settings.database_location = localize_path(
                 "db", "instapy_{}.db".format(self.username)
             )
+            
+        self.want_check_browser = want_check_browser
 
         self.do_comment = False
         self.comment_percentage = 0
@@ -410,6 +414,7 @@ class InstaPy:
             self.logfolder,
             self.proxy_address,
             self.bypass_security_challenge_using,
+            self.want_check_browser
         ):
             message = (
                 "Unable to login to Instagram! "

--- a/instapy/login_util.py
+++ b/instapy/login_util.py
@@ -266,7 +266,7 @@ def login_user(
     logfolder,
     proxy_address,
     security_code_to_phone,
-    want_check_browser
+    want_check_browser,
 ):
     """Logins the user with the given username and password"""
     assert username, "Username not provided"

--- a/instapy/login_util.py
+++ b/instapy/login_util.py
@@ -266,13 +266,16 @@ def login_user(
     logfolder,
     proxy_address,
     security_code_to_phone,
+    want_check_browser
 ):
     """Logins the user with the given username and password"""
     assert username, "Username not provided"
     assert password, "Password not provided"
 
-    if not check_browser(browser, logfolder, logger, proxy_address):
-        return False
+    # Hotfix - this check crashes more often than not -- plus in not necessary, I can verify my own connection
+    if want_check_browser:
+        if not check_browser(browser, logfolder, logger, proxy_address):
+            return False
 
     ig_homepage = "https://www.instagram.com"
     web_address_navigator(browser, ig_homepage)


### PR DESCRIPTION
Issue #5002 : internet connection status = error, when it should not be error
check_browser() function in login_util.py does some checks online that depend on some third party webpages to be available, which does not guarantee the integrity of the results of this check. To my experience this crashes more often than not.
 
New feature : want_check_browser boolean option at session start, prompts the user a possibility to decide if they want to perform this online check.