### PR TITLE
InstapyFollowed and nonFollowers parameters, and issue 4784

### DIFF
--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -1318,8 +1318,8 @@ class InstaPy:
             self.skip_non_business,
             self.skip_business_percentage,
             self.skip_business_categories,
-            self.skip_bio_keyword,
             self.dont_skip_business_categories,
+            self.skip_bio_keyword,
             self.logger,
             self.logfolder,
         )

--- a/instapy/unfollow_util.py
+++ b/instapy/unfollow_util.py
@@ -292,6 +292,8 @@ def unfollow(
 
     if customList is True or InstapyFollowed is True or nonFollowers is True:
 
+        if nonFollowers is True: InstapyFollowed = False  # nonFollowers is already based on InstapyFollowed minus Followers
+
         if customList is True:
             logger.info("Unfollowing from the list of pre-defined usernames\n")
             unfollow_list = customList_data


### PR DESCRIPTION
Managing InstapyFollowed and nonFollowers parameters = True in unfollow()

When passing both parameters InstapyFollowed and nonFollowers as True to unfollow(), the second is ignored as the condition InstapyFollowed comes first. The suggestion below would ignore InstapyFollowed and base the following actions on nonFollowers (which is itself based on the InstapyFollowed list minus users that followed back at any time).

Add in unfollow_util.py, line 295:

if nonFollowers is True: InstapyFollowed = False # nonFollowers is already based on InstapyFollowed minus Followers

The second one is to swap the order of **self.skip_bio_keyword** and  **self.dont_skip_business_categories** on validate_user_call() as pointed out by @uluQulu here: https://github.com/timgrossmann/InstaPy/issues/4784