### PR TITLE
Proxy port fix

### DIFF
--- a/instapy/browser.py
+++ b/instapy/browser.py
@@ -99,9 +99,9 @@ def set_selenium_local_session(
     if proxy_address and proxy_port:
         firefox_profile.set_preference("network.proxy.type", 1)
         firefox_profile.set_preference("network.proxy.http", proxy_address)
-        firefox_profile.set_preference("network.proxy.http_port", proxy_port)
+        firefox_profile.set_preference("network.proxy.http_port", int(proxy_port))
         firefox_profile.set_preference("network.proxy.ssl", proxy_address)
-        firefox_profile.set_preference("network.proxy.ssl_port", proxy_port)
+        firefox_profile.set_preference("network.proxy.ssl_port", int(proxy_port))
 
     # mute audio while watching stories
     firefox_profile.set_preference("media.volume_scale", "0.0")

--- a/instapy/login_util.py
+++ b/instapy/login_util.py
@@ -164,7 +164,7 @@ def check_browser(browser, logfolder, logger, proxy_address):
     # check connection status
     try:
         logger.info("-- Connection Checklist [1/3] (Internet Connection Status)")
-        browser.get("view-source:https://api.myip.com/")
+        browser.get("view-source:https://ip4.seeip.org/geoip")
         pre = browser.find_element_by_tag_name("pre").text
         current_ip_info = json.loads(pre)
         if (
@@ -186,7 +186,7 @@ def check_browser(browser, logfolder, logger, proxy_address):
                 '- Current IP is "{}" and it\'s from "{}/{}"'.format(
                     current_ip_info["ip"],
                     current_ip_info["country"],
-                    current_ip_info["cc"],
+                    current_ip_info["country_code"],
                 )
             )
             update_activity(


### PR DESCRIPTION
BUG FIXED that prevented the proxy port to be set in firefox + using other API to check for current IP that supports always to return IPv4 

Could be improved further to return IPv6 if the proxy_address given by the user is a IPv6 - but who uses IPv6 ;-)