### PR TITLE
Fixed .lower() error on list in validate_username

### DIFF
--- a/instapy/util.py
+++ b/instapy/util.py
@@ -416,7 +416,7 @@ def validate_username(
             logger.error("~cannot get user bio")
             return False, "---> Sorry, couldn't get get user bio " "account active\n"
         for bio_keyword in skip_bio_keyword:
-            if map(lambda x:x.lower(),bio_keyword) in map(lambda x:x.lower(),profile_bio):
+            if map(lambda x: x.lower(), bio_keyword) in map(lambda x: x.lower(), profile_bio):
                 return (
                     False,
                     "{} has a bio keyword of {}, by default skip\n".format(

--- a/instapy/util.py
+++ b/instapy/util.py
@@ -416,7 +416,7 @@ def validate_username(
             logger.error("~cannot get user bio")
             return False, "---> Sorry, couldn't get get user bio " "account active\n"
         for bio_keyword in skip_bio_keyword:
-            if bio_keyword.lower() in profile_bio.lower():
+            if map(lambda x:x.lower(),bio_keyword) in map(lambda x:x.lower(),profile_bio):
                 return (
                     False,
                     "{} has a bio keyword of {}, by default skip\n".format(


### PR DESCRIPTION
The previous code produced the following error due to calling .lower() on a list:
`
  File "/usr/local/lib/python2.7/dist-packages/instapy/util.py", line 382, in validate_username
    if bio_keyword.lower() in profile_bio.lower():
AttributeError: 'list' object has no attribute 'lower"
`
The updated function uses map() to produce these same lists to avoid the error.