### PR TITLE
Add the possibility to specify the browser executable path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ The **goal** of this file is explaining to the users of our project the notable 
 _The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)_.
 
 
+## [Unreleased]
+
+### Added
+
+- Additional parameter `browser_executable_path` now available when initializing InstaPy. Use it to run a specific installation of Firefox.
+
+
 ## [0.6.8] - 2020-01-28
 
 ### Fixed

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -70,6 +70,7 @@
   - [Running internet connection checks](#running-internet-connection-checks)
   - [Use a proxy](#use-a-proxy)
   - [Running in threads](#running-in-threads)
+  - [Choose the browser version](#choose-the-browser-version)
   
  <br />
 
@@ -1799,7 +1800,19 @@ session.login()
 session.end(threaded_session=True)
 ```
 
+### Choose the browser version
+If you have more than one Firefox version on your system or if you are using a portable version you can instruct InstaPy to use that version using the `browser_executable_path` argument in the class initializer.
 
+Specifying the Firefox executable path can also help you if you are getting the following error message:
+
+`selenium.common.exceptions.SessionNotCreatedException: Message: Unable to find a matching set of capabilities`
+
+example on a Windows machine (with the right path also works on Linux and MAC)
+```python
+session = InstaPy(username=insta_username,
+                  password=insta_password,
+                  browser_executable_path=r"D:\Program Files\Mozilla Firefox\firefox.exe")
+```
 
 ---
 

--- a/instapy/browser.py
+++ b/instapy/browser.py
@@ -60,6 +60,7 @@ def set_selenium_local_session(
     disable_image_load,
     page_delay,
     geckodriver_path,
+    browser_executable_path,
     logger,
 ):
     """Starts local session for a selenium server.
@@ -86,6 +87,9 @@ def set_selenium_local_session(
         firefox_profile = webdriver.FirefoxProfile(browser_profile_path)
     else:
         firefox_profile = webdriver.FirefoxProfile()
+
+    if browser_executable_path is not None:
+        firefox_options.binary = browser_executable_path
 
     # set English language
     firefox_profile.set_preference("intl.accept_languages", "en-US")

--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -115,6 +115,7 @@ class InstaPy:
         split_db: bool = False,
         bypass_security_challenge_using: str = "email",
         want_check_browser: bool = True,
+        browser_executable_path: str = None,
     ):
         print("InstaPy Version: {}".format(__version__))
         cli_args = parse_cli_args()
@@ -316,6 +317,7 @@ class InstaPy:
                 disable_image_load,
                 page_delay,
                 geckodriver_path,
+                browser_executable_path,
                 self.logger,
             )
             if len(err_msg) > 0:


### PR DESCRIPTION
After a fresh install, when I run the standard `quickstart.py` file, I kept getting the exception reported below.

`selenium.common.exceptions.SessionNotCreatedException: Message: Unable to find a matching set of capabilities`

After some debugging/troubleshooting I found this was due on how the web drivers is initialized and on the fact that the binary path was not part of the specified options so I came up with this fix.

This can also be useful if anyone wants to run InstaPy with a portable version of Firefox.