### PR TITLE
Fix text file handling for comments

### DIFF
--- a/instapy/util.py
+++ b/instapy/util.py
@@ -2408,9 +2408,8 @@ def file_handling(file):
             # extract file's lines in list
             for line in f.readlines():
                 if line != "\n":
-                    element = line.strip("\n").lower()
-                    # remove spaces
-                    element = "".join(e for e in element if e != " ")
+                    # remove leading whitespaces, newline and tab characters
+                    element = line.lstrip().strip("\n")
                     elements.append(element)
     except FileNotFoundError:
         return ["FileNotFoundError"]

--- a/tests/resources/invalid_target_list.txt
+++ b/tests/resources/invalid_target_list.txt
@@ -1,5 +1,5 @@
-photo  grAphy
+This is a comment...
 
-portrait
+photography
 
-    miNimaListic
+    portrait

--- a/tests/resources/valid_target_list.txt
+++ b/tests/resources/valid_target_list.txt
@@ -1,3 +1,3 @@
+This is a comment...
 photography
 portrait
-minimalistic

--- a/tests/test_file_handling.py
+++ b/tests/test_file_handling.py
@@ -8,7 +8,7 @@ class TestFileHandling(unittest.TestCase):
 
     # list of expected entries
     global expected_entries
-    expected_entries = ["photography", "portrait", "minimalistic"]
+    expected_entries = ["This is a comment...", "photography", "portrait"]
 
     def test_valid_entries(self):
         """Check file_handling with valid entries"""


### PR DESCRIPTION
Hello, I found out a mistake I made while implementing the `file_handling` function mentioned on issue #5396 and submitted on pull request #5443. 

I was removing all spaces found before, after and in-between target words and also transforming all letters to lowercase, which would transform a possible comment from `This is a comment` to `thisisacomment`.

I fixed that and updated the unit tests included.