### PR TITLE
duplicate view-source: doesn't allow bot proceed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ _The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - A new feature - `target_list()` to parse text files containing target lists of users, hashtags etc.
 
 
+### Changed
+- Remove `view-source` which stops bot from proceeding 
+
 ## [0.6.8] - 2020-01-28
 
 ### Fixed

--- a/instapy/unfollow_util.py
+++ b/instapy/unfollow_util.py
@@ -764,7 +764,7 @@ def get_users_through_dialog_with_graphql(
             "after": end_cursor,
         }
         url = "{}&variables={}".format(graphql_query_URL, str(json.dumps(variables)))
-        browser.get("view-source:{}".format(url))
+        browser.get(url)
         pre = browser.find_element_by_tag_name("pre")
         # response to JSON object
         data = json.loads(pre.text)


### PR DESCRIPTION
removed and replaced with raw url which already has view-source: