### PR TITLE
Correct Hide Selenium Extension: Error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ _The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Typo updating configuration object. Changed nofity into notify
 - Add specific firefox preference agent data to prevent error
 - Smart location url 
-
+- Error "Hide Selenium Extension: Error" mentioned in #5304
 
 ## [0.6.9] - 2020-06-12
 

--- a/instapy/browser.py
+++ b/instapy/browser.py
@@ -109,7 +109,13 @@ def set_selenium_local_session(
 
     # mute audio while watching stories
     firefox_profile.set_preference("media.volume_scale", "0.0")
-
+    
+    # correct hide selenium extension: error
+    firefox_profile.set_preference('dom.webdriver.enabled', False)
+    firefox_profile.set_preference('useAutomationExtension', False)
+    firefox_profile.set_preference('general.platform.override', 'iPhone')
+    firefox_profile.update_preferences()
+    
     # prefer user path before downloaded one
     driver_path = geckodriver_path or get_geckodriver()
     browser = webdriver.Firefox(


### PR DESCRIPTION
This PR corrects the error "Hide Selenium Extension: Error" mentioned in https://github.com/timgrossmann/InstaPy/issues/5304