### PR TITLE
Add specific agent data to prevent error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ _The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - "UnboundLocalError: local variable 'commenting_approved' referenced before assignment" error when bot tries to comment
 - Typo updating configuration object. Changed nofity into notify
+- Add specific firefox preference agent data to prevent error
 
 
 ## [0.6.9] - 2020-06-12

--- a/instapy/browser.py
+++ b/instapy/browser.py
@@ -109,6 +109,11 @@ def set_selenium_local_session(
 
     # mute audio while watching stories
     firefox_profile.set_preference("media.volume_scale", "0.0")
+    # prevent  Hide Selenium Extension: error
+    firefox_profile.set_preference('dom.webdriver.enabled', False)
+    firefox_profile.set_preference('useAutomationExtension', False)
+    firefox_profile.set_preference('general.platform.override', 'iPhone')
+    firefox_profile.update_preferences()
 
     # prefer user path before downloaded one
     driver_path = geckodriver_path or get_geckodriver()


### PR DESCRIPTION
This fixes the selenium extension: error problem, for now
Before:  Hide Selenium Extension: error
After: Hide Selenium Extension: ok