### PR TITLE
Fixing XPATH for like svg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ _The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Add specific firefox preference agent data to prevent error
 - Smart location url 
 - Error "Hide Selenium Extension: Error" mentioned in #5304
+- XPATH for like svg
 
 ## [0.6.9] - 2020-06-12
 

--- a/instapy/xpath_compile.py
+++ b/instapy/xpath_compile.py
@@ -142,8 +142,8 @@ xpath["like_comment"] = {
 }
 
 xpath["like_image"] = {
-    "like": "//section/span/button/div[*[local-name()='svg']/@aria-label='Like']",
-    "unlike": "//section/span/button/div[*[local-name()='svg']/@aria-label='Unlike']",
+    "like": "//section/span/button/div/span[*[local-name()='svg']/@aria-label='Like']",
+    "unlike": "//section/span/button/div/span[*[local-name()='svg']/@aria-label='Unlike']",
 }
 
 xpath["like_from_image"] = {


### PR DESCRIPTION
Updating XPATH to the like button svg. There's an additional _span_ that's causing the XPATH look up to fail.