### PR TITLE
Fix unfollowing of users that haven't posted anything

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ The **goal** of this file is explaining to the users of our project the notable 
 
 _The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)_.
 
+## Unreleased
+### Fixed
+- Unfollowing of users that haven't posted anything
 
 ## [0.6.10] - 2020-07-30
 

--- a/instapy/unfollow_util.py
+++ b/instapy/unfollow_util.py
@@ -180,16 +180,16 @@ def get_following_status(
             return "UNAVAILABLE", None
     # wait until the follow button is located and visible, then get it
     try:
-        browser.find_element_by_xpath(
-            read_xpath(get_following_status.__name__, "follow_button_XP")
+        follow_button = browser.find_element_by_xpath(
+            read_xpath(get_following_status.__name__, "follow_span_XP_following")
         )
-        follow_button_XP = read_xpath(get_following_status.__name__, "follow_button_XP")
+        return "Following", follow_button
     except NoSuchElementException:
         try:
-            follow_button = browser.find_element_by_xpath(
-                read_xpath(get_following_status.__name__, "follow_span_XP_following")
+            browser.find_element_by_xpath(
+                read_xpath(get_following_status.__name__, "follow_button_XP")
             )
-            return "Following", follow_button
+            follow_button_XP = read_xpath(get_following_status.__name__, "follow_button_XP")
         except:
             return "UNAVAILABLE", None
     follow_button = explicit_wait(


### PR DESCRIPTION
**THE PROBLEM**
In `unfollow_util.py` a function called `get_following_status` is defined.
In that function the following status is checked with the following code:
```
try:
  browser.find_element_by_xpath(
    read_xpath(get_following_status.__name__, "follow_button_XP")
  )
  follow_button_XP = read_xpath(get_following_status.__name__, "follow_button_XP")
except NoSuchElementException:
  try:
    follow_button = browser.find_element_by_xpath(
      read_xpath(get_following_status.__name__, "follow_span_XP_following")
    )
    return "Following", follow_button
  except:
    return "UNAVAILABLE", None
```
So if the first `try` block didn't raise exceptions, the status is read from the element and returned at the end of the function:
```
following_status = follow_button.text
return following_status, follow_button
```
The `read_xpath` function is defined in the file named `xpath.py`: 
```
from .xpath_compile import xpath

def read_xpath(function_name, xpath_name):
    return xpath[function_name][xpath_name]
```
and gets the xpath from `xpath_compile.py` file:
```
xpath = {}
```
```
xpath["get_following_status"] = {
    "follow_button_XP": "//button[text()='Following' or \
                                  text()='Requested' or \
                                  text()='Follow' or \
                                  text()='Follow Back' or \
                                  text()='Unblock']",
    "follow_span_XP_following": "//button/div/span[contains(@aria-label, 'Following')]",
}
```

So first the `get_following_status` function tries to find a element from this xpath `//button[text()='Following' or text()='Requested' or text()='Follow' or text()='Follow Back' or text()='Unblock']` and if it doesn't find an element, it tries to find an element from this xpath `//button/div/span[contains(@aria-label, 'Following')]`

**This is at least the case in Firefox Browser 77.0.1 on my mac ->**
I have done some testing in the Firefox developer's tools, and it seems that profile pages of users I don't follow contain the element found from the first xpath and the profiles of users I follow that HAVE uploaded photos don't, in their profile pages an element is found from the second xpath. 
But here's the catch: as weird as it seems, for some reason the profile pages of users I follow that HAVE NOT uploaded any photos contain an hidden element found from the first xpath with the text 'Follow'. However, because their profile pages also contain the element found from the second xpath, **my suggestion for a fix is to first check the second xpath (**`//button/div/span[contains(@aria-label, 'Following')]`**) and only then the other one.**

If you want to test if this is the case in your browser too, you can use the search function (COMMAND+F or CTRL+F probably) in the developer tools and type in the xpath to check if it matches an element.

I hope my explanation was understandable...

This fixed my InstaPy bot, but I haven't done any more extensive testing...and I don't know if there was a reason for checking the other xpath first.