### PR TITLE
Fix get_links_from_feed xpath expression.

### DIFF
--- a/instapy/util.py
+++ b/instapy/util.py
@@ -984,11 +984,16 @@ def click_element(browser, element, tryNum=0):
 
         if tryNum == 0:
             # try scrolling the element into view
-            browser.execute_script(
-                "document.getElementsByClassName('"
-                + element.get_attribute("class")
-                + "')[0].scrollIntoView({ inline: 'center' });"
-            )
+            try:
+                # This tends to fail because the script fails to get the element class
+                if element.get_attribute("class") != '':
+                    browser.execute_script(
+                        "document.getElementsByClassName('"
+                        + element.get_attribute("class")
+                        + "')[0].scrollIntoView({ inline: 'center' });"
+                    )
+            except Exception:
+                pass
 
         elif tryNum == 1:
             # well, that didn't work, try scrolling to the top and then
@@ -1003,13 +1008,18 @@ def click_element(browser, element, tryNum=0):
         else:
             # try `execute_script` as a last resort
             # print("attempting last ditch effort for click, `execute_script`")
-            browser.execute_script(
-                "document.getElementsByClassName('"
-                + element.get_attribute("class")
-                + "')[0].click()"
-            )
-            # update server calls after last click attempt by JS
-            update_activity(browser, state=None)
+            try:
+                if element.get_attribute("class") != '':
+                    browser.execute_script(
+                        "document.getElementsByClassName('"
+                        + element.get_attribute("class")
+                        + "')[0].click()"
+                    )
+                    # update server calls after last click attempt by JS
+                    update_activity(browser, state=None)
+            except Exception:
+                print("Failed to click an element, giving up now")
+
             # end condition for the recursive function
             return
 

--- a/instapy/xpath_compile.py
+++ b/instapy/xpath_compile.py
@@ -106,7 +106,7 @@ xpath["get_links_for_location"] = {
     "main_elem": "//main/article/div[2]",
 }
 
-xpath["get_links_from_feed"] = {"get_links": "//article/div/div[3]/div[2]/a"}
+xpath["get_links_from_feed"] = {"get_links": "//article/div[3]/div[2]/a"}
 
 xpath["get_links_for_tag"] = {
     "top_elements": "//main/article/div[1]",


### PR DESCRIPTION
Improve exception handling in click_element(). This doesn't actually fix the root problem of not being able to click the element but at least it prevents the crash that follows an unhandled exception there.