### PR TITLE
Processing unexpected alert error on resize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ _The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Path for Obtaining user id
 - `like_util.py` list index out of range error
 - `like_by_feed()` method
+- processing unexpected alert error on resize
 
 ## [0.6.10] - 2020-07-30
 

--- a/instapy/browser.py
+++ b/instapy/browser.py
@@ -137,7 +137,15 @@ def set_selenium_local_session(
     browser.implicitly_wait(page_delay)
 
     # set mobile viewport (iPhone X)
-    browser.set_window_size(375, 812)
+    try:
+        browser.set_window_size(375, 812)
+    except UnexpectedAlertPresentException as exc:
+        logger.exception(
+            "Unexpected alert on resizing web browser!\n\t"
+            "{}".format(str(exc).encode("utf-8"))
+        )
+        close_browser(browser, False, logger)
+        return browser, 'Unexpected alert on browser resize'
 
     message = "Session started!"
     highlight_print("browser", message, "initialization", "info", logger)


### PR DESCRIPTION
Check if resize failed with proxy authentication alert or any other unexpected firefox alert. Now if proxy require login and password UnexpectedAlertPresentException raised and firefox stays open.