### PR TITLE
General log rotation, gecko driver log in user directory, comments in 80 chars, 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ _The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Added 
 - Use random tag list for `session.like_by_tags`
 
+### Changed
+- General log rotation, gecko driver log in user directory, comments in 80 chars
+
 ### Fixed
 - Unfollowing of users that haven't posted anything
 - `get_links` xpath for yet another change

--- a/instapy/browser.py
+++ b/instapy/browser.py
@@ -4,6 +4,7 @@ from selenium.common.exceptions import WebDriverException
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.firefox.options import Options as Firefox_Options
 from selenium.webdriver import Remote
+from selenium.common.exceptions import UnexpectedAlertPresentException
 from webdriverdownloader import GeckoDriverDownloader
 
 # general libs
@@ -61,6 +62,7 @@ def set_selenium_local_session(
     page_delay,
     geckodriver_path,
     browser_executable_path,
+    logfolder,
     logger,
 ):
     """Starts local session for a selenium server.
@@ -110,17 +112,21 @@ def set_selenium_local_session(
     # mute audio while watching stories
     firefox_profile.set_preference("media.volume_scale", "0.0")
 
-    # prevent  Hide Selenium Extension: error
+    # prevent Hide Selenium Extension: error
     firefox_profile.set_preference("dom.webdriver.enabled", False)
     firefox_profile.set_preference("useAutomationExtension", False)
     firefox_profile.set_preference("general.platform.override", "iPhone")
     firefox_profile.update_preferences()
+
+    # geckodriver log in specific user logfolder
+    geckodriver_log = "{}geckodriver.log".format(logfolder)
 
     # prefer user path before downloaded one
     driver_path = geckodriver_path or get_geckodriver()
     browser = webdriver.Firefox(
         firefox_profile=firefox_profile,
         executable_path=driver_path,
+        log_path=geckodriver_log,
         options=firefox_options,
     )
 

--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -1,13 +1,21 @@
 """OS Modules environ method to get the setup vars from the Environment"""
 # import built-in & third-party modules
-import time, random, os, csv, json, requests, logging, unicodedata
+import time
+import random
+import os
+import csv
+import json
+import requests
+import unicodedata
+import logging
+
 from datetime import datetime, timedelta
 from math import ceil
 from sys import platform
 from platform import python_version
 from selenium import webdriver
 from selenium.webdriver import DesiredCapabilities
-import logging.handlers
+from logging.handlers import RotatingFileHandler
 from contextlib import contextmanager
 from copy import deepcopy
 
@@ -320,6 +328,7 @@ class InstaPy:
                 page_delay,
                 geckodriver_path,
                 browser_executable_path,
+                self.logfolder,
                 self.logger,
             )
             if len(err_msg) > 0:
@@ -338,7 +347,13 @@ class InstaPy:
             # initialize and setup logging system for the InstaPy object
             logger = logging.getLogger(self.username)
             logger.setLevel(logging.DEBUG)
-            file_handler = logging.FileHandler("{}general.log".format(self.logfolder))
+            # log name and format
+            general_log = "{}general.log".format(self.logfolder)
+            file_handler = logging.FileHandler(general_log)
+            # log rotation, 5 logs with 10MB size each one
+            file_handler = RotatingFileHandler(
+                general_log, maxBytes=10*1024*1024, backupCount=5
+            )
             file_handler.setLevel(logging.DEBUG)
             extra = {"username": self.username}
             logger_formatter = logging.Formatter(
@@ -369,8 +384,8 @@ class InstaPy:
     ):
         """
         Starts remote session for a selenium server.
-        Creates a new selenium driver instance for remote session or uses provided
-        one. Useful for docker setup.
+        Creates a new selenium driver instance for remote session or uses
+        provided one. Useful for docker setup.
 
         :param selenium_url: string
         :param selenium_driver: selenium WebDriver
@@ -396,11 +411,11 @@ class InstaPy:
     def login(self):
         """Used to login the user either with the username and password"""
         # InstaPy uses page_delay speed to implicit wait for elements,
-        # here we're decreasing it to 5 seconds instead of the default 25 seconds
-        # to speed up the login process.
+        # here we're decreasing it to 5 seconds instead of the default 25
+        # seconds to speed up the login process.
         #
-        # In short: default page_delay speed took 25 seconds trying to locate every
-        # element, now it's taking 5 seconds.
+        # In short: default page_delay speed took 25 seconds trying to locate
+        # every element, now it's taking 5 seconds.
         temporary_page_delay = 5
         self.browser.implicitly_wait(temporary_page_delay)
 
@@ -1862,7 +1877,7 @@ class InstaPy:
         tags = tags or []
         self.quotient_breach = False
 
-        # if session includes like_by_tags, then randomize the tag list 
+        # if session includes like_by_tags, then randomize the tag list
         if use_random_tags is True:
             random.shuffle(tags)
             for i, tag in enumerate(tags):

--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -8,6 +8,7 @@ import json
 import requests
 import unicodedata
 import logging
+import logging.handlers
 
 from datetime import datetime, timedelta
 from math import ceil

--- a/instapy/login_util.py
+++ b/instapy/login_util.py
@@ -234,7 +234,8 @@ def login_user(
     assert username, "Username not provided"
     assert password, "Password not provided"
 
-    # Hotfix - this check crashes more often than not -- plus in not necessary, I can verify my own connection
+    # Hotfix - this check crashes more often than not -- plus in not necessary,
+    # I can verify my own connection
     if want_check_browser:
         if not check_browser(browser, logfolder, logger, proxy_address):
             return False

--- a/instapy/unfollow_util.py
+++ b/instapy/unfollow_util.py
@@ -761,9 +761,7 @@ def get_users_through_dialog_with_graphql(
         # get follower name
         followers_list.append(follower["node"]["username"])
 
-    has_next_page = data["data"]["user"][str(edge_type)]["page_info"][
-        "has_next_page"
-    ]
+    has_next_page = data["data"]["user"][str(edge_type)]["page_info"]["has_next_page"]
 
     while has_next_page and len(followers_list) <= amount:
         # server call interval
@@ -797,9 +795,7 @@ def get_users_through_dialog_with_graphql(
             followers_list.append(follower["node"]["username"])
 
         # check if there is next page
-        has_next_page = data["data"]["user"][str(edge_type)]["page_info"][
-            "has_next_page"
-        ]
+        has_next_page = data["data"]["user"][str(edge_type)]["page_info"]["has_next_page"]
 
         # simulation
         # TODO: this needs to be rewrited

--- a/instapy/unfollow_util.py
+++ b/instapy/unfollow_util.py
@@ -192,7 +192,7 @@ def get_following_status(
             follow_button_XP = read_xpath(
                 get_following_status.__name__, "follow_button_XP"
             )
-        except:
+        except Exception:
             return "UNAVAILABLE", None
     follow_button = explicit_wait(
         browser, "VOEL", [follow_button_XP, "XPath"], logger, 7, False
@@ -753,7 +753,7 @@ def get_users_through_dialog_with_graphql(
     # get all followers or following of current page
     # edge_type: used to check followers or following in JSON
     #            "edge_followed_by" or "edge_follow"
-    followers_page = data["data"]["user"]["" + edge_type+ ""]["edges"]
+    followers_page = data["data"]["user"][str(edge_type)]["edges"]
     followers_list = []
 
     # iterate over page size and add users to the list
@@ -761,7 +761,7 @@ def get_users_through_dialog_with_graphql(
         # get follower name
         followers_list.append(follower["node"]["username"])
 
-    has_next_page = data["data"]["user"]["" + edge_type+ ""]["page_info"][
+    has_next_page = data["data"]["user"][str(edge_type)]["page_info"][
         "has_next_page"
     ]
 
@@ -770,7 +770,7 @@ def get_users_through_dialog_with_graphql(
         sleep(random.randint(2, 6))
 
         # get next page reference
-        end_cursor = data["data"]["user"]["" + edge_type+ ""]["page_info"]["end_cursor"]
+        end_cursor = data["data"]["user"][str(edge_type)]["page_info"]["end_cursor"]
 
         # url variables
         variables = {
@@ -789,7 +789,7 @@ def get_users_through_dialog_with_graphql(
         data = json.loads(pre.text)
 
         # get all followers of current page
-        followers_page = data["data"]["user"]["" + edge_type+ ""]["edges"]
+        followers_page = data["data"]["user"][str(edge_type)]["edges"]
 
         # iterate over page size and add users to the list
         for follower in followers_page:
@@ -797,7 +797,7 @@ def get_users_through_dialog_with_graphql(
             followers_list.append(follower["node"]["username"])
 
         # check if there is next page
-        has_next_page = data["data"]["user"]["" + edge_type+ ""]["page_info"][
+        has_next_page = data["data"]["user"][str(edge_type)]["page_info"][
             "has_next_page"
         ]
 

--- a/instapy/util.py
+++ b/instapy/util.py
@@ -2441,9 +2441,11 @@ def get_query_hash(browser, logger, edge_followed_by):
     # There are two query hash, one for followers and following, ie:
     # t="c76146de99bb02f6415203be841dd25a",n="d04b0a864b4b54837c0d870b0e77e076"
     if edge_followed_by:
-        pattern_hash = '[a-z0-9]{32}(?=",n=")' # Used to query: edge_followed_by
+        # Used to query: edge_followed_by
+        pattern_hash = '[a-z0-9]{32}(?=",n=")'
     else:
-        pattern_hash = '[a-z0-9]{32}(?=",u=1)' # Used to query: edge_follow
+        # Used to query: edge_follow
+        pattern_hash = '[a-z0-9]{32}(?=",u=1)'
     # locate pattern value from JS file
     # sequence of 32 words and/or numbers just before ,n=" value
     hash = re.findall(pattern_hash, page_source)


### PR DESCRIPTION
Hello

Here the summary for changes implemented, updated branch to fix/blackify before merge request.
No functionality has been compromised.

1. `login_util.py`
   Fixed 80 length for comments; pycodestyle
   Comments can be easily adjusted to 80 characters 

2. `unfollow_util.py`
   Fixed `except Exception` in line 195
   Fixed `edge_type` variable to behave like str(), now it is readable 

3. `util.py`
   Fixed 80 length for comments; pycodestyle
   Comments can be easily adjusted to 80 characters

4. `browser.py`
   Added "from selenium.common.exceptions import UnexpectedAlertPresentException"
   due to `except UnexpectedAlertPresentException as exc:` in
   `set_selenium_local_session()`
   Added `logfolder` parameter in `set_selenium_local_session()` then
   geckodriver.log is saved in user/logs instead of src directory

5. `instapy.py`
   Ordered imports, one by line
   Added "from logging.handlers import RotatingFileHandler" to control the
   general.log size. The general.log file grows up, cause issues if env is
   running lack of space; 5 logs with 10MB size each one.

```bash
(venv) ➜  InstaPy git:(log_rotation)  pycodestyle --max-line-lengt=200 instapy
instapy/util.py:1730:9: E731 do not assign a lambda expression, use a def
instapy/util.py:2214:50: E203 whitespace before ':'
```