### PR TITLE
Release 6.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 The **goal** of this file is explaining to the users of our project the notable changes _relevant to them_ that occurred _between_ commits.
 
-_The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)_.
+_The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)_
 
-## Unreleased
+## [0.6.11] - 2020-09-25
 
 ### Added 
 - Use random tag list for `session.like_by_tags`

--- a/instapy/__init__.py
+++ b/instapy/__init__.py
@@ -1,7 +1,7 @@
 # flake8: noqa
 
 # __variables__ with double-quoted values will be available in setup.py
-__version__ = "0.6.10"
+__version__ = "0.6.11"
 
 from .instapy import InstaPy
 from .util import smart_run


### PR DESCRIPTION
### Added 
- Use random tag list for `session.like_by_tags`

### Changed
- General log rotation, gecko driver log in user directory, comments in 80 chars

### Fixed
- Unfollowing of users that haven't posted anything
- `get_links` xpath for yet another change
- Path for Obtaining user id
- `like_util.py` list index out of range error
- `like_by_feed()` method
- `follow_user_following
- processing unexpected alert error on resize