### PR TITLE
Subject: fix_5863 followers_list unassigned variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,20 @@ _The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 
 ## [0.6.13] - UNRELEASED
+
 ### Added
+
 - Handle situation if stale elements detected when cookie cannot be loaded
 
+### Fixed
+
+- Fixed typo in message when a video is tried to like.
+- Fixed the problem where `followers_list` could be used without being initialized.
 
 ## [0.6.12] - 2020-10-26
+
 ### Added
+
 - Defined local variables ( ie: 'unfollow_state') to fix message for referenced before assignment
 - *.code-workspace in .gitignore for vscode project (macOS)
 - `like_by_locations()` with randomize flag
@@ -21,6 +29,7 @@ _The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - information for geckodriver_log_level, development only
 
 ### Changed
+
 - check if liking activity was blocked after every like
 - Call scroll_down() after follower accepted, with this new def the window is scrolled down after accepting a follower.
 - Sorted imports, to make code readable
@@ -30,6 +39,7 @@ _The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - `like_by_feed` limits from 100 to 50
 
 ### Fixed
+
 - fixed some comments were double quotes were not necessary
 - issue where `getTitle` was timing out
 - `get_users_through_dialog_with_graphql` with a new try/except
@@ -37,7 +47,7 @@ _The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [0.6.11] - 2020-09-25
 
-### Added 
+### Added
 - Use random tag list for `session.like_by_tags`
 
 ### Changed
@@ -55,18 +65,21 @@ _The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [0.6.10] - 2020-07-30
 
 ### Added
+
 - Generallize mandatory words and add mandatory_bio_keywords
 
-### Changed 
+### Changed
+
 - Update xpath for like/unlike and comment
 - Fix `like_by_feed()` xpath
 - `get_like_on_feed()` improve function readability
 
 ### Fixed
+
 - "UnboundLocalError: local variable 'commenting_approved' referenced before assignment" error when bot tries to comment
 - Typo updating configuration object. Changed nofity into notify
 - Add specific firefox preference agent data to prevent error
-- Smart location url 
+- Smart location url
 - Error "Hide Selenium Extension: Error" mentioned in #5304
 - XPATH for like svg
 
@@ -77,11 +90,10 @@ _The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Additional parameter `browser_executable_path` now available when initializing InstaPy. Use it to run a specific installation of Firefox.
 - A new feature - `target_list()` to parse text files containing target lists of users, hashtags etc.
 
-
 ### Changed
-- Remove `view-source` which stops bot from proceeding 
-- Remove instagram status check
 
+- Remove `view-source` which stops bot from proceeding
+- Remove instagram status check
 
 ## [0.6.8] - 2020-01-28
 
@@ -89,20 +101,17 @@ _The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 - xPath for breaking LIKE and COMMENT
 
-
 ## [0.6.7] - 2020-01-05
 
 ### Fixed
 
 - Adjusted follow xPath
 
-
 ## [0.6.6] - 2019-11-11
 
 ### Changed
 
 - Additional web checks default `False` to avoid erros on runtime
-
 
 ## [0.6.5] - 2019-10-20
 

--- a/instapy/unfollow_util.py
+++ b/instapy/unfollow_util.py
@@ -719,6 +719,8 @@ def get_users_through_dialog_with_graphql(
     # TODO: simulation implmentation
 
     real_amount = amount
+    followers_list = []
+
     if randomize and amount >= 3:
         # expanding the population for better sampling distribution
         amount = amount * 1.9
@@ -772,7 +774,6 @@ def get_users_through_dialog_with_graphql(
         # edge_type: used to check followers or following in JSON
         #            "edge_followed_by" or "edge_follow"
         followers_page = data["data"]["user"][str(edge_type)]["edges"]
-        followers_list = []
     except:
         # sometimes IG page displays a message that "Failed to Load. Retry"
         # so, instead of terminatig the App we will move to next step.
@@ -817,7 +818,6 @@ def get_users_through_dialog_with_graphql(
         try:
             # get all followers of current page
             followers_page = data["data"]["user"][str(edge_type)]["edges"]
-            followers_list = []
         except:
             logger.error("JSON (2) cannot be loaded, moving on...")
             return [], []


### PR DESCRIPTION
Problem: followers_list cleared due to double declaration.
Solution: followers_list is now defined once in `get_users_through_dialog_with_graphql`

ie:
`1605144344786 is 19:25:44.786 GMT-06:00`
```
1605144344786	Marionette	DEBUG	0 <- [1,649,null,{"value":"{\"data\":{\"user\":{\"edge_followed_by\":{\"count\":364124,\"page_info\":{\"has_next_page\":true,\"en ... kS&_nc_tp=25&oh=e5318dac5748263890cb65&oe=5FD5B830\",\"username\":\"dirscejeff\"}}}}]}}},\"status\":\"ok\"}"}]
1605144344787	webdriver::server	DEBUG	<- 200 OK {"value":"{\"data\":{\"user\":{\"edge_followed_by\":{\"count\":364124,\"page_info\":{\"has_next_page\":true,\"end_cursor\":\"QVFEeVM5bWE0dFJ5Nmlqa0taYmFVQU05N21LQVpDRVE1NVkzbDVpTG5hN0R3N1pKNWNPd24TcmNYeg==\"},\"edges\":[{\"node\":{\"id\":\"1999851\",\"username\":
```
```
INFO [2020-11-11 19:25:34] [internet]  User 'internet' [2/6]
INFO [2020-11-11 19:25:41] [internet]  GraphQL query hash: [c76146de903be841dd25a]
INFO [2020-11-11 19:25:44] [internet]  To be followed: [1/5/internet]
INFO [2020-11-11 19:25:44] [internet]  To be followed: [2/5/internet]
INFO [2020-11-11 19:25:44] [internet]  To be followed: [3/5/internet]
INFO [2020-11-11 19:25:44] [internet]  To be followed: [4/5/internet]
INFO [2020-11-11 19:25:44] [internet]  To be followed: [5/5/internet]
INFO [2020-11-11 19:25:44] [internet]  Grabbed 5 usernames from 'internet `Followers` to do following
```