### PR TITLE
Fix for Issue #5890 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,6 @@ Pipfile
 
 # Instances
 z_*
+
+# config for testing
+local_templates/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ _The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 - Fixed typo in message when a video is tried to like.
 - Fixed the problem where `followers_list` could be used without being initialized.
+- Fixed follow element not found on comment page
 
 ## [0.6.12] - 2020-10-26
 

--- a/instapy/comment_util.py
+++ b/instapy/comment_util.py
@@ -57,6 +57,26 @@ def open_comment_section(browser, logger):
     else:
         logger.warning(missing_comment_elem_warning)
 
+def open_target_profile(browser, logger):
+    missing_target_profile_elem_warning = (
+        "--> Target Profile Button Not Found!"
+        "\t~may cause issues with browser windows of smaller widths"
+    )
+
+    target_profile_elem = browser.find_elements_by_xpath(
+        read_xpath(open_target_profile.__name__, "target_profile")
+    )
+
+    if len(target_profile_elem) > 0:
+        try:
+            click_element(browser, target_profile_elem[0])
+
+        except WebDriverException:
+            logger.warning(missing_target_profile_elem_warning)
+
+    else:
+        logger.warning(missing_target_profile_elem_warning)
+
 
 def comment_image(browser, username, comments, blacklist, logger, logfolder):
     """Checks if it should comment on the image"""
@@ -132,6 +152,9 @@ def comment_image(browser, username, comments, blacklist, logger, logfolder):
 
     logger.info("--> Commented: {}".format(rand_comment.encode("utf-8")))
     Event().commented(username)
+
+    # Going back to the profile page of the user we commented before
+    open_target_profile(browser, logger)
 
     # get the post-comment delay time to sleep
     naply = get_action_delay("comment")

--- a/instapy/comment_util.py
+++ b/instapy/comment_util.py
@@ -57,6 +57,7 @@ def open_comment_section(browser, logger):
     else:
         logger.warning(missing_comment_elem_warning)
 
+
 def open_target_profile(browser, logger):
     missing_target_profile_elem_warning = (
         "--> Target Profile Button Not Found!"

--- a/instapy/xpath_compile.py
+++ b/instapy/xpath_compile.py
@@ -124,6 +124,10 @@ xpath["get_number_of_posts"] = {
     "num_of_posts_txt_no_such_element": "//section/div[3]/div/header/section/ul/li[1]/span/span",
 }
 
+xpath["open_target_profile"] = {
+    "target_profile": "//section/main/div/ul/div/li/div/div/div[2]/h2/div[1]/a"
+}
+
 xpath["get_relationship_counts"] = {
     "following_count": "//a[contains(@href,'following') and not(contains(@href,'mutual'))]/span",
     "followers_count": "//a[contains(@href,'followers') and not(contains(@href,'mutual'))]/span",


### PR DESCRIPTION
Problem: Couldn't follow 'Username'! ~user is inaccessible 
Solution: introduced new method that clicks on the user profile button in the comment page