### PR TITLE
Fixed typo in `dissmiss_save_information`  to `dismiss_save_information`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ _The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 - Handle situation if stale elements detected when cookie cannot be loaded
 - Convert Documentation to Docusaurus
+- Fixed typo in `dismiss_save_information`
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,13 @@ _The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 - Handle situation if stale elements detected when cookie cannot be loaded
 - Convert Documentation to Docusaurus
-- Fixed typo in `dismiss_save_information`
 
 ### Fixed
 
 - Fixed typo in message when a video is tried to like.
 - Fixed the problem where `followers_list` could be used without being initialized.
+- Fixed incorrect xpath used by `interact_by_comments`
+- Fixed typo in `dissmiss_save_information` to `dismiss_save_information`
 
 ## [0.6.12] - 2020-10-26
 

--- a/instapy/login_util.py
+++ b/instapy/login_util.py
@@ -261,7 +261,7 @@ def login_user(
     )
     if login_state is True:
         dismiss_notification_offer(browser, logger)
-        dissmiss_save_information(browser, logger)
+        dismiss_save_information(browser, logger)
         return True
 
     # if user is still not logged in, then there is an issue with the cookie
@@ -390,7 +390,7 @@ def login_user(
 
     dismiss_get_app_offer(browser, logger)
     dismiss_notification_offer(browser, logger)
-    dissmiss_save_information(browser, logger)
+    dismiss_save_information(browser, logger)
 
     # check for login error messages and display it in the logs
     if "instagram.com/challenge" in browser.current_url:
@@ -518,13 +518,11 @@ def dismiss_notification_offer(browser, logger):
         click_element(browser, dismiss_elem)
 
 
-def dissmiss_save_information(browser, logger):
+def dismiss_save_information(browser, logger):
     """ Dismiss 'Save Your Login Info?' offer on session start """
     # This question occurs when pkl doesn't exist
-    offer_elem_loc = read_xpath(dissmiss_save_information.__name__, "offer_elem_loc")
-    dismiss_elem_loc = read_xpath(
-        dissmiss_save_information.__name__, "dismiss_elem_loc"
-    )
+    offer_elem_loc = read_xpath(dismiss_save_information.__name__, "offer_elem_loc")
+    dismiss_elem_loc = read_xpath(dismiss_save_information.__name__, "dismiss_elem_loc")
 
     offer_loaded = explicit_wait(
         browser, "VOEL", [offer_elem_loc, "XPath"], logger, 4, False

--- a/instapy/xpath_compile.py
+++ b/instapy/xpath_compile.py
@@ -35,7 +35,7 @@ xpath["dismiss_notification_offer"] = {
     "dismiss_elem_loc": "//button[text()='Not Now']",
 }
 
-xpath["dissmiss_save_information"] = {
+xpath["dismiss_save_information"] = {
     "offer_elem_loc": "//*[contains(text(), 'Save Info')]",
     "dismiss_elem_loc": "//*[contains(text(), 'Not Now')]",
 }


### PR DESCRIPTION
Noticed a typo, it was an extra `s` character. So
changed from `dissmiss_save_information` to `dismiss_save_information`
Nothing else was modified.

CHANGELOG update from #5895