### PR TITLE
Allow comments containing @ symbol

### DIFF
--- a/instapy/comment_util.py
+++ b/instapy/comment_util.py
@@ -36,6 +36,13 @@ def get_comment_input(browser):
 
     return comment_input
 
+# get element for post comment button
+def get_comment_post(browser):
+    comment_post = browser.find_elements_by_xpath(
+        read_xpath(get_comment_post.__name__, "comment_post")
+    )
+
+    return comment_post
 
 def open_comment_section(browser, logger):
     missing_comment_elem_warning = (
@@ -72,6 +79,7 @@ def comment_image(browser, username, comments, blacklist, logger, logfolder):
     # wait, to avoid crash
     sleep(3)
     comment_input = get_comment_input(browser)
+    comment_post = get_comment_post(browser)
 
     try:
         if len(comment_input) > 0:
@@ -94,13 +102,22 @@ def comment_image(browser, username, comments, blacklist, logger, logfolder):
             )
             # wait, to avoid crash
             sleep(2)
-            # post comment / <enter>
-            (
-                ActionChains(browser)
-                .move_to_element(comment_input[0])
-                .send_keys(Keys.ENTER)
-                .perform()
-            )
+            # if there is an "@" in the comment, must click the Post button
+            if '@' in comment_to_be_sent:
+                (
+                    ActionChains(browser)
+                    .move_to_element(comment_post[0])
+                    .click()
+                    .perform()
+                )
+            # if there is no "@" in the comment, simply press enter
+            else:  
+                (
+                    ActionChains(browser)
+                    .move_to_element(comment_input[0])
+                    .send_keys(Keys.ENTER)
+                    .perform()
+                )
 
             update_activity(
                 browser,

--- a/instapy/xpath_compile.py
+++ b/instapy/xpath_compile.py
@@ -16,6 +16,11 @@ xpath["dismiss_this_was_me"] = {
     "this_was_me_button": "//button[@name='choice'][text()='This Was Me']"
 }
 
+xpath["get_comment_post"] = {
+    "comment_post": "//button[text()='Post']",
+    
+}
+
 xpath["class_selectors"] = {
     "likes_dialog_body_xpath": "//main",
     "likes_dialog_close_xpath": "//div/button/span",


### PR DESCRIPTION
Fix comment_image to allow comments containing @ symbol

## Description

When a comment contains an @ symbol the Post comment button must be clicked instead of simply pressing Enter on the keyboard. 

Fixes #5947

## How Has This Been Tested?

Ran interact_by_URL with comments containing and not containing @ symbol

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] I have performed a self-review of my own code
- [x] My code follows the style guidelines of this project, `black -t py34`
- [x] My changes generate no new warnings