### PR TITLE
docs: fix simple typo, reqeust -> request

### DIFF
--- a/instapy/util.py
+++ b/instapy/util.py
@@ -1519,7 +1519,7 @@ def emergency_exit(browser, username, logger):
 
 
 def load_user_id(username, person, logger, logfolder):
-    """ Load the user ID at reqeust from local records """
+    """ Load the user ID at request from local records """
     pool_name = "{0}{1}_followedPool.csv".format(logfolder, username)
     user_id = "undefined"
 


### PR DESCRIPTION
There is a small typo in instapy/util.py.

Should read `request` rather than `reqeust`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md