### PR TITLE
fixes issue #5991 about smart_hashtags and the new api token required…

### DIFF
--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -726,9 +726,8 @@ class InstaPy:
             return
 
         for tag in tags:
-            user_agent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0.2 Safari/605.1.15"
-            myToken = displaypurposes.generate_api_token(tag, user_agent)
-            head = {"User-Agent": user_agent, "api-token": myToken}
+            myToken = displaypurposes.generate_api_token(tag, Settings.user_agent)
+            head = {"User-Agent": Settings.user_agent, "api-token": myToken}
             req = requests.get(
                 "https://apidisplaypurposes.com/tag/{}".format(tag), headers=head
             )

--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -20,7 +20,7 @@ from selenium.webdriver import DesiredCapabilities
 from logging.handlers import RotatingFileHandler
 from contextlib import contextmanager
 from copy import deepcopy
-from displaypurposes import displaypurposes
+from apidisplaypurposes import displaypurposes
 
 try:
     from pyvirtualdisplay import Display
@@ -726,10 +726,12 @@ class InstaPy:
             return
 
         for tag in tags:
-            user_agent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0.2 Safari/605.1.15'
+            user_agent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0.2 Safari/605.1.15"
             myToken = displaypurposes.generate_api_token(tag, user_agent)
-            head = {'User-Agent':user_agent, 'api-token':myToken}
-            req = requests.get("https://apidisplaypurposes.com/tag/{}".format(tag), headers=head)
+            head = {"User-Agent": user_agent, "api-token": myToken}
+            req = requests.get(
+                "https://apidisplaypurposes.com/tag/{}".format(tag), headers=head
+            )
             data = json.loads(req.text)
 
             if data["tagExists"] is True:
@@ -1909,10 +1911,10 @@ class InstaPy:
             self.logger.info("Using smart location hashtags")
             tags = self.smart_location_hashtags
         else:
-           # deletes white spaces in tags
-           tags = [tag.strip() for tag in tags]
-           tags = tags or []
-           self.quotient_breach = False
+            # deletes white spaces in tags
+            tags = [tag.strip() for tag in tags]
+            tags = tags or []
+            self.quotient_breach = False
 
         # if session includes like_by_tags, then randomize the tag list
         if use_random_tags is True:

--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -20,7 +20,6 @@ from selenium.webdriver import DesiredCapabilities
 from logging.handlers import RotatingFileHandler
 from contextlib import contextmanager
 from copy import deepcopy
-from apidisplaypurposes import displaypurposes
 
 try:
     from pyvirtualdisplay import Display
@@ -725,12 +724,21 @@ class InstaPy:
             print("set_smart_hashtags is misconfigured")
             return
 
+        if python_version() > "3.5":
+            # CI Travis alert for Python3.5 and apidisplaypurposes
+            from apidisplaypurposes import displaypurposes
+
         for tag in tags:
-            myToken = displaypurposes.generate_api_token(tag, Settings.user_agent)
-            head = {"User-Agent": Settings.user_agent, "api-token": myToken}
-            req = requests.get(
-                "https://apidisplaypurposes.com/tag/{}".format(tag), headers=head
-            )
+            if python_version() > "3.5":
+                myToken = displaypurposes.generate_api_token(tag, Settings.user_agent)
+                head = {"User-Agent": Settings.user_agent, "api-token": myToken}
+                req = requests.get(
+                    "https://apidisplaypurposes.com/tag/{}".format(tag), headers=head
+                )
+             else:
+                # Old fashion request, must fail in Python <= 3.5
+                req = requests.get("https://apidisplaypurposes.com/tag/{}".format(tag))
+
             data = json.loads(req.text)
 
             if data["tagExists"] is True:

--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -20,6 +20,7 @@ from selenium.webdriver import DesiredCapabilities
 from logging.handlers import RotatingFileHandler
 from contextlib import contextmanager
 from copy import deepcopy
+from displaypurposes import displaypurposes
 
 try:
     from pyvirtualdisplay import Display
@@ -725,7 +726,10 @@ class InstaPy:
             return
 
         for tag in tags:
-            req = requests.get("https://apidisplaypurposes.com/tag/{}".format(tag))
+            user_agent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0.2 Safari/605.1.15'
+            myToken = displaypurposes.generate_api_token(tag, user_agent)
+            head = {'User-Agent':user_agent, 'api-token':myToken}
+            req = requests.get("https://apidisplaypurposes.com/tag/{}".format(tag), headers=head)
             data = json.loads(req.text)
 
             if data["tagExists"] is True:
@@ -1904,11 +1908,11 @@ class InstaPy:
         elif use_smart_location_hashtags is True and self.smart_location_hashtags != []:
             self.logger.info("Using smart location hashtags")
             tags = self.smart_location_hashtags
-
-        # deletes white spaces in tags
-        tags = [tag.strip() for tag in tags]
-        tags = tags or []
-        self.quotient_breach = False
+        else:
+           # deletes white spaces in tags
+           tags = [tag.strip() for tag in tags]
+           tags = tags or []
+           self.quotient_breach = False
 
         # if session includes like_by_tags, then randomize the tag list
         if use_random_tags is True:

--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -724,18 +724,17 @@ class InstaPy:
             print("set_smart_hashtags is misconfigured")
             return
 
-        if python_version() > "3.5":
-            # CI Travis alert for Python3.5 and apidisplaypurposes
-            from apidisplaypurposes import displaypurposes
-
         for tag in tags:
             if python_version() > "3.5":
+                # CI Travis alert for Python3.5 and apidisplaypurposes
+                from apidisplaypurposes import displaypurposes
+
                 myToken = displaypurposes.generate_api_token(tag, Settings.user_agent)
                 head = {"User-Agent": Settings.user_agent, "api-token": myToken}
                 req = requests.get(
                     "https://apidisplaypurposes.com/tag/{}".format(tag), headers=head
                 )
-             else:
+            else:
                 # Old fashion request, must fail in Python <= 3.5
                 req = requests.get("https://apidisplaypurposes.com/tag/{}".format(tag))
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,4 +20,4 @@ MeaningCloud-python>=1.1.1
 PyYAML>=3.13
 webdriverdownloader
 python-telegram-bot>=12.0.0
-api-display-purposes>=0.0.3
+api-display-purposes>=0.0.3; python_version > '3.5'

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ MeaningCloud-python>=1.1.1
 PyYAML>=3.13
 webdriverdownloader
 python-telegram-bot>=12.0.0
+api-display-purposes>=0.0.3


### PR DESCRIPTION
## Description
display purposes API used to retrieve the most popular hashtags changed its API and didn't allow InstaPy to use it anymore. The changes are just a few lines on the instapy.py file.  Now, it requests the token directly through the display-purposes python API before doing the URL request. To do this, it is mandatory to have installed display-purposes (not really sure how to add this to the installation requirements of InstaPy as I am not a python expert)

Fixes #5991 

## How Has This Been Tested?
To test it, I run my own quickstart.py where I request some smart hastags to like. I saw the list of new hastags and it was working with like_by_tags

- [X] Test

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have checked my code and corrected any misspellings
- [X] I have performed a self-review of my own code
- [x] My code follows the style guidelines of this project, `black -t py34`
- [ ] My changes generate no new warnings
