### PR TITLE
Added second `accept_igcookie_dialogue` for new IG cookie page

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,17 +8,17 @@ branches:
     - legacy
     - experimental
 
-install: pip install tox
+install: pip install -U pip tox
 
 script: tox
 
 stages:
-    - name: static analysis
-    - name: test
-    - name: docs
-      if: type = push AND branch = master AND fork = false
-    - name: pypi-prod
-      if: type = push AND fork = false AND tag =~ ^\d+\.\d+\.\d+
+  - name: static analysis
+  - name: test
+  - name: docs
+    if: type = push AND branch = master AND fork = false
+  - name: pypi-prod
+    if: type = push AND fork = false AND tag =~ ^\d+\.\d+\.\d+
 
 jobs:
   fast_finish: true
@@ -70,7 +70,7 @@ jobs:
     - stage: docs
       language: node_js
       node_js:
-        - '10'
+        - "10"
       cache:
         yarn: true
       script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ _The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 - Added delays after load cookie in login.util.py
 - Added `apidisplaypurposes about` in `smart_hashtags` and new api token; Python3.5
+- Added second `accept_igcookie_dialogue` to handled the second "cookie accept screen" that is not automatically accepted
+
+### Changed
+
+- Changed `python-telegram-bot` in requirements to be installed in Pyhton veriosns greater than 3.6, Travis CI error fixed
 
 ## [0.6.13] - 2020-12-30
 

--- a/instapy/login_util.py
+++ b/instapy/login_util.py
@@ -283,6 +283,9 @@ def login_user(
         accept_igcookie_dialogue(browser, logger)
         return True
 
+    # This fix comes from comment in #6060 If not necessary we can remove it
+    accept_igcookie_dialogue(browser, logger)
+
     # if user is still not logged in, then there is an issue with the cookie
     # so go create a new cookie.
     if cookie_loaded:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,23 +1,24 @@
+api-display-purposes>=0.0.3; python_version > '3.5'
 certifi>=2018.10.15
-chardet>=3.0.4
+chardet>=3.0.4,<4
 clarifai>=2.4.1
-configparser>=3.5.0
+configparser>=3.5.0,<4
 EasyProcess>=0.2.3
 emoji>=0.5.1
 future>=0.17.1
 grpcio>=1.16.1
-idna>=2.7
+idna>=2.7,<3
 jsonschema>=2.6.0,<3
+MeaningCloud-python>=1.1.1
 plyer>=1.3.1
-protobuf>=3.6.1
+protobuf>=3.6.1,<4
+python-telegram-bot>=12.0.0; python_version > '3.6'
 PyVirtualDisplay>=0.2.1; sys_platform != 'win32'
+PyYAML>=3.13
+regex>=2018.11.22
 requests>=2.20.1
 selenium>=3.141.0
+setuptools_rust>=0.11.6
 six>=1.11.0
 urllib3>=1.24.1
-regex>=2018.11.22
-MeaningCloud-python>=1.1.1
-PyYAML>=3.13
-webdriverdownloader
-python-telegram-bot>=12.0.0
-api-display-purposes>=0.0.3; python_version > '3.5'
+webdriverdownloader>=1.1.0.3


### PR DESCRIPTION
Updated `travis.tml` (format), sorted requirements and versions limits, added `accept_igcookie_dialogue` 

Problem: New IG cookie window in some regions is not handled, that could
induce a crash

Solution: Added second `accept_igcookie_dialogue` to catch the new ID
cookie window

Signed-off-by: elulcao <elulcao@icloud.com>

<!-- Did you know that we have a Discord channel ? Join us: https://discord.gg/FDETsht -->
<!-- Is this a Feature Request ? Please, check out our Wiki first https://github.com/timgrossmann/InstaPy/wiki -->
# Pull Request Template

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Do not include any personal data.

Fixes # (issue)

#6060 

## How Has This Been Tested?

Manually, real IG account 

- [ x ] Test

## Checklist:

- [ x ] I have commented my code, particularly in hard-to-understand areas
- [ NA ] I have made corresponding changes to the documentation
- [ x ] I have checked my code and corrected any misspellings
- [ x ] I have performed a self-review of my own code
- [ x ] My code follows the style guidelines of this project, `black -t py34`
- [ x ] My changes generate no new warnings
