### PR TITLE
Fixes issue #6085

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ _The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 - Added delays after load cookie in login.util.py
 - Added `apidisplaypurposes about` in `smart_hashtags` and new api token; Python3.5
+- Added interact_user_likers interacting with the likers from a given user's posts.
+
+### Fixed
+- Move call to `get_following_status` above `web_address_navigator` inside `get_links_for_username` function
 
 ## [0.6.13] - 2020-12-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ _The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 - Added delays after load cookie in login.util.py
 - Added `apidisplaypurposes about` in `smart_hashtags` and new api token; Python3.5
-- Added interact_user_likers interacting with the likers from a given user's posts.
+- Added `interact_user_likers` interacting with the likers from a given user's posts
 
 ### Fixed
 - Move call to `get_following_status` above `web_address_navigator` inside `get_links_for_username` function

--- a/instapy/like_util.py
+++ b/instapy/like_util.py
@@ -448,6 +448,11 @@ def get_links_for_username(
     if taggedImages:
         user_link = user_link + "tagged/"
 
+    # if private user, we can get links only if we following
+    following_status, _ = get_following_status(
+        browser, "profile", username, person, None, logger, logfolder
+    )
+
     # Check URL of the webpage, if it already is user's profile page,
     # then do not navigate to it again
     web_address_navigator(browser, user_link)
@@ -458,11 +463,6 @@ def get_links_for_username(
             "page may have been removed..."
         )
         return False
-
-    # if private user, we can get links only if we following
-    following_status, _ = get_following_status(
-        browser, "profile", username, person, None, logger, logfolder
-    )
 
     # if following_status is None:
     #    browser.wait_for_valid_connection(browser, username, logger)


### PR DESCRIPTION
Move call to `get_following_status` above `web_address_navigator` inside
`get_links_for_username` function

<!-- Did you know that we have a Discord channel ? Join us: https://discord.gg/FDETsht -->
<!-- Is this a Feature Request ? Please, check out our Wiki first https://github.com/timgrossmann/InstaPy/wiki -->

## Description
This PR fixes the issue #6085, where InstaPy starts interacting with user's posts instead of interacting with tagged posts of the user when using interact_by_users_tagged_posts function.

Fixes #6085

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [x ] Test

## Checklist:

- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation
- [ x] I have checked my code and corrected any misspellings
- [ x] I have performed a self-review of my own code
- [ x] My code follows the style guidelines of this project, `black -t py34`
- [ x] My changes generate no new warnings
