### PR TITLE
Fix set_smart_location_hashtags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,9 @@ _The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added second `accept_igcookie_dialogue` to handled the second "cookie accept screen" that is not automatically accepted
 
 ### Fixed
+
 - Move call to `get_following_status` above `web_address_navigator` inside `get_links_for_username` function
+- Fixed the correct URL `displaypurposes.com`, the old `displaypurposes.com` API is deprecated
 
 ## [0.6.13] - 2020-12-30
 

--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -774,7 +774,7 @@ class InstaPy:
     def set_smart_location_hashtags(
         self, locations: list, radius: int = 10, limit: int = 3, log_tags: bool = True
     ):
-        """Generate smart hashtags based on https://displaypurposes.com/map"""
+        """Generate smart hashtags based on https://apidisplaypurposes.com/map"""
         if locations is None:
             self.logger.error("set_smart_location_hashtags is misconfigured")
             return self
@@ -792,7 +792,7 @@ class InstaPy:
                 bbox["lat_max"],
                 radius,
             )
-            url = "https://displaypurposes.com/local/?bbox={}".format(bbox_url)
+            url = "https://apidisplaypurposes.com/local/?bbox={}".format(bbox_url)
 
             req = requests.get(url)
             data = json.loads(req.text)


### PR DESCRIPTION
Fixed set_smart_location_hashtags
The old URL of the displaypurposes.com API was obsolete and made the program crash on run
Fixed to the correct URL
Tested and it now works fine

This fix resolves #6094 