### PR TITLE
Add verified_only flag to get_followers()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The **goal** of this file is explaining to the users of our project the notable 
 _The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)_
 
 
+## [0.6.15] - UNRELEASED
+
+### Added
+
+- Added `verified_only` argument to `get_followers` to return only verified users
+
 ## [0.6.14] - UNRELEASED
 
 ### Added

--- a/docs/relationship-tools.md
+++ b/docs/relationship-tools.md
@@ -45,6 +45,13 @@ _If the data is requested at the range **else than** `"full"`, it will write **t
 + `6874` means the **count** of the usernames retrieved.
 + `json` is the **filetype** and the data is stored as a `list` in it.
 
+`verified_only`:
+Gives the _option_ to only return followers with a Verified status.
+* `verified_only=True`:
+    + Only returns followers that contain `is_verified` key
+* `verified_only=False`:
+    + Default option, Returns all followers for user
+
 
 There are **several** `use cases` of this tool for **various purposes**.
 _E.g._, inside your **quickstart** script, you can **do** _something like this_:

--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -4495,7 +4495,7 @@ class InstaPy:
         amount: int = None,
         live_match: bool = False,
         store_locally: bool = True,
-        verified_only: bool = False
+        verified_only: bool = False,
     ):
         """
          Gets and returns `followers` information of given user
@@ -4536,7 +4536,7 @@ class InstaPy:
             store_locally,
             self.logger,
             self.logfolder,
-            verified_only
+            verified_only,
         )
         return grabbed_followers
 

--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -4495,6 +4495,7 @@ class InstaPy:
         amount: int = None,
         live_match: bool = False,
         store_locally: bool = True,
+        verified_only: bool = False
     ):
         """
          Gets and returns `followers` information of given user
@@ -4535,6 +4536,7 @@ class InstaPy:
             store_locally,
             self.logger,
             self.logfolder,
+            verified_only
         )
         return grabbed_followers
 

--- a/instapy/relationship_tools.py
+++ b/instapy/relationship_tools.py
@@ -186,7 +186,6 @@ def get_followers(
             # get followers
             page_info = data["user"]["edge_followed_by"]["page_info"]
             edges = data["user"]["edge_followed_by"]["edges"]
-
             for user in edges:
                 if verified_only:
                     if user["node"]["is_verified"]:

--- a/instapy/relationship_tools.py
+++ b/instapy/relationship_tools.py
@@ -30,7 +30,7 @@ def get_followers(
     store_locally,
     logger,
     logfolder,
-    verified_only=False
+    verified_only=False,
 ):
     """ Get entire list of followers using graphql queries. """
 
@@ -318,6 +318,7 @@ def get_followers(
         return verified_followers
     else:
         return all_followers
+
 
 def get_following(
     browser,

--- a/instapy/relationship_tools.py
+++ b/instapy/relationship_tools.py
@@ -38,7 +38,6 @@ def get_followers(
     user_data = {}
     variables = {}
     all_followers = []
-    verified_followers = []
     sc_rolled = 0
     grab_notifier = False
     local_read_failure = False
@@ -187,11 +186,12 @@ def get_followers(
             page_info = data["user"]["edge_followed_by"]["page_info"]
             edges = data["user"]["edge_followed_by"]["edges"]
             for user in edges:
-                # If verified_only is True, determine if following user is verified and append to verified_followers
-                if verified_only and user["node"]["is_verified"]:
-                    verified_followers.append(user["node"]["username"])
-
-                all_followers.append(user["node"]["username"])
+                # If verified_only is True, determine if user is verified before adding to all_followers
+                if verified_only:
+                    if user["node"]["is_verified"]:
+                        all_followers.append(user["node"]["username"])
+                else:
+                    all_followers.append(user["node"]["username"])
 
             grabbed = len(set(all_followers))
 
@@ -313,10 +313,7 @@ def get_followers(
     sleep(sleep_t)
     logger.info("Yawn :] let's go!\n")
 
-    if verified_only:
-        return verified_followers
-    else:
-        return all_followers
+    return all_followers
 
 
 def get_following(

--- a/instapy/relationship_tools.py
+++ b/instapy/relationship_tools.py
@@ -30,6 +30,7 @@ def get_followers(
     store_locally,
     logger,
     logfolder,
+    verified_only=False
 ):
     """ Get entire list of followers using graphql queries. """
 
@@ -37,6 +38,7 @@ def get_followers(
     user_data = {}
     variables = {}
     all_followers = []
+    verified_followers = []
     sc_rolled = 0
     grab_notifier = False
     local_read_failure = False
@@ -184,7 +186,12 @@ def get_followers(
             # get followers
             page_info = data["user"]["edge_followed_by"]["page_info"]
             edges = data["user"]["edge_followed_by"]["edges"]
+
             for user in edges:
+                if verified_only:
+                    if user["node"]["is_verified"]:
+                        verified_followers.append(user["node"]["username"])
+
                 all_followers.append(user["node"]["username"])
 
             grabbed = len(set(all_followers))
@@ -307,8 +314,10 @@ def get_followers(
     sleep(sleep_t)
     logger.info("Yawn :] let's go!\n")
 
-    return all_followers
-
+    if verified_only:
+        return verified_followers
+    else:
+        return all_followers
 
 def get_following(
     browser,

--- a/instapy/relationship_tools.py
+++ b/instapy/relationship_tools.py
@@ -188,9 +188,8 @@ def get_followers(
             edges = data["user"]["edge_followed_by"]["edges"]
             for user in edges:
                 # If verified_only is True, determine if following user is verified and append to verified_followers
-                if verified_only:
-                    if user["node"]["is_verified"]:
-                        verified_followers.append(user["node"]["username"])
+                if verified_only and user["node"]["is_verified"]:
+                    verified_followers.append(user["node"]["username"])
 
                 all_followers.append(user["node"]["username"])
 

--- a/instapy/relationship_tools.py
+++ b/instapy/relationship_tools.py
@@ -187,6 +187,7 @@ def get_followers(
             page_info = data["user"]["edge_followed_by"]["page_info"]
             edges = data["user"]["edge_followed_by"]["edges"]
             for user in edges:
+                # If verified_only is True, determine if following user is verified and append to verified_followers
                 if verified_only:
                     if user["node"]["is_verified"]:
                         verified_followers.append(user["node"]["username"])


### PR DESCRIPTION
## Description

I use this package to pull verified users for my business accounts' followers. This seems to be a common use case, so I figured I'd add these changes to the main repo.

## How Has This Been Tested?

The following command now returns only verified users for username:
```
followers_list = session.grab_followers(username=targetAccount, amount=amount, live_match=True, store_locally=False, verified_only=True)
```

Checked for 5 different accounts, all worked.

## Checklist:

- [X ] I have commented my code, particularly in hard-to-understand areas
- [X ] I have made corresponding changes to the documentation
- [X ] I have checked my code and corrected any misspellings
- [X ] I have performed a self-review of my own code
- [X ] My code follows the style guidelines of this project, `black -t py34`
- [X ] My changes generate no new warnings
