### PR TITLE
Fixed relationship data username variable in Instapy constructor

### DIFF
--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -275,7 +275,9 @@ class InstaPy:
         self.skip_business_percentage = 100
         self.skip_no_profile_pic_percentage = 100
         self.skip_private_percentage = 100
-        self.relationship_data = {self.username: {"all_following": [], "all_followers": []}}
+        self.relationship_data = {
+            self.username: {"all_following": [], "all_followers": []}
+        }
 
         self.simulation = {"enabled": True, "percentage": 100}
 

--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -275,7 +275,7 @@ class InstaPy:
         self.skip_business_percentage = 100
         self.skip_no_profile_pic_percentage = 100
         self.skip_private_percentage = 100
-        self.relationship_data = {username: {"all_following": [], "all_followers": []}}
+        self.relationship_data = {self.username: {"all_following": [], "all_followers": []}}
 
         self.simulation = {"enabled": True, "percentage": 100}
 


### PR DESCRIPTION
# Pull Request

## Description

This fixes a KeyError exception while unfollowing caused by relationship_data not having the correct value when credentials are configured by enviroment variable. The dictionary of relationship_data is getting set with a 'None' key because it uses the username argument instead of the instance variable.

## How Has This Been Tested?

- [x] Test

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have checked my code and corrected any misspellings
- [x] I have performed a self-review of my own code
- [x] My code follows the style guidelines of this project, `black -t py34`
- [x] My changes generate no new warnings
